### PR TITLE
Revert back from `examples` to `snippets`

### DIFF
--- a/demo-node/package.yaml
+++ b/demo-node/package.yaml
@@ -35,7 +35,7 @@ pipelines:
       read_zeek_tsv
       import
 
-examples:
+snippets:
   - name: Show all Suricata alerts
     description: |
       Use the `where` operator to zero in on one particular schema.

--- a/feodo/package.yaml
+++ b/feodo/package.yaml
@@ -26,7 +26,7 @@ pipelines:
         | context update feodo --key=dst_ip --clear
     restart-on-error: 1 hour
 
-examples:
+snippets:
   - name: Lookup Feodo
     description: Evaluate all stored data with a `src_ip` field against the Feodo IP Blocklist.
     definition: |

--- a/slack/package.yaml
+++ b/slack/package.yaml
@@ -34,7 +34,7 @@ pipelines:
       | batch 1
       | to http POST "{{ inputs.webhook-url }}" write json
 
-examples:
+snippets:
   - name: Say Hello in Slack
     description: |
       Sends the message "Hello, world! 👋" to Slack.

--- a/suricata/package.yaml
+++ b/suricata/package.yaml
@@ -1364,7 +1364,7 @@ pipelines:
       )
       @name = "ocsf.network_activity"
       publish "ocsf.network_activity"
-examples:
+snippets:
   - name: Todays Alerts
     description: Display all Suricata alerts from the last 24 hours.
     definition: |

--- a/zeek/package.yaml
+++ b/zeek/package.yaml
@@ -551,7 +551,7 @@ pipelines:
       @name = "ocsf.dhcp_activity"
       publish "ocsf.dhcp_activity"
 
-examples:
+snippets:
   - name: Zeek log volume from the last 3 hours
     description: |
       A line chart displaying how many Zeek events arrived in the last 3 hours.


### PR DESCRIPTION
I thought that PR was merged already, but apparently it wasn't quite yet.