### PR TITLE
Fix ThreatFox examples

### DIFF
--- a/threatfox/package.yaml
+++ b/threatfox/package.yaml
@@ -137,7 +137,7 @@ snippets:
       from https://threatfox-api.abuse.ch/api/v1/
         query=get_iocs
         days:=7
-      | yield value
+      | yield data[]
       | summarize count(.) by confidence_level
       | sort confidence_level desc
       | chart bar
@@ -158,4 +158,4 @@ snippets:
       Shows a table of all ThreatFox IOCs of type `domain`.
     definition: |
       context inspect threatfox-domains
-      | yield value
+      | yield data[]


### PR DESCRIPTION
This PR fixes invalid field references in the ThreatFox package examples.
