### PR TITLE
Improve pipeline name in ThreatFox package

### DIFF
--- a/threatfox/package.yaml
+++ b/threatfox/package.yaml
@@ -59,7 +59,7 @@ contexts:
 
 pipelines:
   fetch-threatfox-ioc-database:
-    name: Update ThreatFox context
+    name: Download ThreatFox IOC database
     description: |
       A pipeline that periodically fetches the ThreatFox IOC database and
       publishes the feed to the `threatfox` topic.


### PR DESCRIPTION
This PR uses a more telling name in the ThreatFox pipeline that downloads the IOC database.
