### PR TITLE
Fix the `foxio` package

### DIFF
--- a/foxio/package.yaml
+++ b/foxio/package.yaml
@@ -77,7 +77,7 @@ pipelines:
       @name = "foxio.ja4+"
       publish "foxio"
 
-  populate-ja4-contexts:
+  populate-ja4-context:
     name: Update the JA4 context
     description: |
       A pipeline that extracts JA4 fingerprints and updates the corresponding
@@ -86,28 +86,80 @@ pipelines:
       // tql2
       subscribe "foxio"
       where @name == "foxio.ja4+"
-      if (ja4_fingerprint != null) {
-        legacy "context update ja4 --key=ja4_fingerprint"
-      }
-      if (ja4s_fingerprint != null) {
-        legacy "context update ja4s --key=ja4s_fingerprint"
-      }
-      if (ja4h_fingerprint != null) {
-        legacy "context update ja4h --key=ja4h_fingerprint"
-      }
-      if (ja4x_fingerprint != null) {
-        legacy "context update ja4x --key=ja4x_fingerprint"
-      }
-      if (ja4t_fingerprint != null) {
-        legacy "context update ja4t --key=ja4t_fingerprint"
-      }
-      if (ja4ts_fingerprint != null) {
-        legacy "context update ja4ts --key=ja4ts_fingerprint"
-      }
-      if (ja4tscan_fingerprint != null) {
-        legacy "context update ja4tscan --key=ja4tscan_fingerprint"
-      }
-      discard
+      where ja4_fingerprint != null
+      legacy "context update ja4 --key=ja4_fingerprint"
+
+  populate-ja4s-context:
+    name: Update the JA4S context
+    description: |
+      A pipeline that extracts JA4S fingerprints and updates the corresponding
+      context.
+    definition: |
+      // tql2
+      subscribe "foxio"
+      where @name == "foxio.ja4s+"
+      where ja4s_fingerprint != null
+      legacy "context update ja4s --key=ja4s_fingerprint"
+
+  populate-ja4h-context:
+    name: Update the JA4H context
+    description: |
+      A pipeline that extracts JA4H fingerprints and updates the corresponding
+      context.
+    definition: |
+      // tql2
+      subscribe "foxio"
+      where @name == "foxio.ja4h+"
+      where ja4h_fingerprint != null
+      legacy "context update ja4h --key=ja4h_fingerprint"
+
+  populate-ja4x-context:
+    name: Update the JA4X context
+    description: |
+      A pipeline that extracts JA4X fingerprints and updates the corresponding
+      context.
+    definition: |
+      // tql2
+      subscribe "foxio"
+      where @name == "foxio.ja4x+"
+      where ja4x_fingerprint != null
+      legacy "context update ja4x --key=ja4x_fingerprint"
+
+  populate-ja4t-context:
+    name: Update the JA4T context
+    description: |
+      A pipeline that extracts JA4T fingerprints and updates the corresponding
+      context.
+    definition: |
+      // tql2
+      subscribe "foxio"
+      where @name == "foxio.ja4t+"
+      where ja4t_fingerprint != null
+      legacy "context update ja4t --key=ja4t_fingerprint"
+
+  populate-ja4ts-context:
+    name: Update the JA4TS context
+    description: |
+      A pipeline that extracts JA4TS fingerprints and updates the corresponding
+      context.
+    definition: |
+      // tql2
+      subscribe "foxio"
+      where @name == "foxio.ja4ts+"
+      where ja4ts_fingerprint != null
+      legacy "context update ja4ts --key=ja4ts_fingerprint"
+
+  populate-ja4tscan-context:
+    name: Update the JA4TScan context
+    description: |
+      A pipeline that extracts JA4TScan fingerprints and updates the
+      corresponding context.
+    definition: |
+      // tql2
+      subscribe "foxio"
+      where @name == "foxio.ja4tscan+"
+      where ja4tscan_fingerprint != null
+      legacy "context update ja4tscan --key=ja4tscan_fingerprint"
 
 examples:
   - name: Enrich Zeek conn logs with JA4 fingerpints


### PR DESCRIPTION
`if` does not yet support nested pipelines that call `ctrl.set_waiting(false)`, which (sometimes) led to a crash. So this works around the issue by simply using separate pipelines for updating the contexts.