### PR TITLE
Drop event type from unmapped OCSF fields

### DIFF
--- a/suricata-ocsf/package.yaml
+++ b/suricata-ocsf/package.yaml
@@ -85,6 +85,7 @@ pipelines:
         status: event.flow.state,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -278,6 +279,7 @@ pipelines:
         answers: answers,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -389,6 +391,7 @@ pipelines:
         tree_uid: tree_uid,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -458,6 +461,7 @@ pipelines:
         },
       }
       drop(
+        unmapped.event_type,
         unmapped.flow_id,
         unmapped.timestamp,
         unmapped.dest_ip,
@@ -583,6 +587,7 @@ pipelines:
         status_id: status_id,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -713,6 +718,7 @@ pipelines:
         status_id: status_id,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -778,6 +784,7 @@ pipelines:
         status_id: 0,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -870,6 +877,7 @@ pipelines:
         port: event.ftp.dynamic_port,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -935,6 +943,7 @@ pipelines:
         smtp_hello: event.smtp.helo
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -1030,6 +1039,7 @@ pipelines:
         status: status,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -1111,6 +1121,7 @@ pipelines:
         status: status,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -1183,6 +1194,7 @@ pipelines:
         status: status,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -1255,6 +1267,7 @@ pipelines:
         status: status,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -1327,6 +1340,7 @@ pipelines:
         status: status,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -1401,6 +1415,7 @@ pipelines:
         status: status,
       }
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dest_ip,
         unmapped.dest_port,
@@ -1506,6 +1521,7 @@ pipelines:
       }
       // Drop all the mapped fields.
       drop(
+        unmapped.event_type,
         unmapped.timestamp,
         unmapped.dhcp.assigned_ip,
         unmapped.dhcp.client_mac,

--- a/zeek-ocsf/package.yaml
+++ b/zeek-ocsf/package.yaml
@@ -138,6 +138,7 @@ pipelines:
       }
       // Drop all the mapped fields.
       drop(
+        unmapped._path,
         unmapped._write_ts,
         unmapped.community_id,
         unmapped.conn_state,
@@ -257,6 +258,7 @@ pipelines:
       //"
       // Drop all the mapped fields.
       drop(
+        unmapped._path,
         unmapped._write_ts,
         unmapped.answers,
         unmapped.id,
@@ -378,10 +380,11 @@ pipelines:
       }
       // Drop all the mapped fields.
       drop(
+        unmapped._path,
+        unmapped._write_ts,
         unmapped.method,
         unmapped.id,
         unmapped.ts,
-        unmapped._write_ts,
         unmapped.uid,
         unmapped.referrer,
         unmapped.host,
@@ -500,6 +503,8 @@ pipelines:
       }
       // Drop all the mapped fields.
       drop(
+        unmapped._path,
+        unmapped._write_ts,
         // TODO: find a better way to map the *set* of UIDs. Since there are
         // multiple per DORA session, we can't just map them to the singleton
         // `metadata.uid`.
@@ -513,7 +518,6 @@ pipelines:
         unmapped.client_addr,
         unmapped.mac,
         unmapped.host_name,
-        unmapped._write_ts,
         unmapped.domain,
         unmapped.client_fqdn,
         // TODO: we could map client and server message to the single primary


### PR DESCRIPTION
This PR removes the log-specific event type from the unmapped data, as it's implicit in the OCSF event class.
