### PR TITLE
Drop implicitly map flow age

### DIFF
--- a/suricata-ocsf/package.yaml
+++ b/suricata-ocsf/package.yaml
@@ -106,6 +106,7 @@ pipelines:
         unmapped.flow.state,
         unmapped.flow.start,
         unmapped.flow.end,
+        unmapped.flow.age,
       )
       @name = "ocsf.network_activity"
       publish "ocsf"


### PR DESCRIPTION
This PR removes an already mapped field from the Suricata flow event.
