### PR TITLE
Improve Suricata flow state mapping

### DIFF
--- a/suricata-ocsf/package.yaml
+++ b/suricata-ocsf/package.yaml
@@ -87,7 +87,7 @@ pipelines:
           packets: event.flow.pkts_toclient + event.flow.pkts_toserver,
         },
         status_id: 99,
-        status: event.flow.state,
+        status: "Other",
       }
       drop(
         unmapped.timestamp,
@@ -103,7 +103,6 @@ pipelines:
         unmapped.flow.bytes_toserver,
         unmapped.flow.pkts_toclient,
         unmapped.flow.pkts_toserver,
-        unmapped.flow.state,
         unmapped.flow.start,
         unmapped.flow.end,
         unmapped.flow.age,


### PR DESCRIPTION
We shouldn't map this to the OCSF status.
