### PR TITLE
Fix typo in Zeek OCSF mapping

### DIFF
--- a/zeek-ocsf/package.yaml
+++ b/zeek-ocsf/package.yaml
@@ -469,7 +469,7 @@ pipelines:
       ocsf.duration = zeek.duration
       drop zeek.duration
       ocsf.start_time = ocsf.time
-      ocsf.end_type = ocsf.time + ocsf.duration
+      ocsf.end_time = ocsf.time + ocsf.duration
       // === Context ===
       ocsf.metadata = {
         log_name: "dhcp.log",


### PR DESCRIPTION
This PR fixes a typo in the Zeek OCSF mappings.

Reported by @JW-Corelight.
