### PR TITLE
Fix another OCSF schema bug

### DIFF
--- a/zeek-ocsf/package.yaml
+++ b/zeek-ocsf/package.yaml
@@ -506,7 +506,7 @@ pipelines:
         domain: zeek.domain,
       }
       drop zeek.server_addr, zeek.domain
-      ocsf.lease_duration = zeek.lease_time
+      ocsf.lease_dur = zeek.lease_time
       drop zeek.lease_time
       ocsf.transaction_uid = zeek.trans_id
       drop zeek.trans_id


### PR DESCRIPTION
@JW-Corelight found another typo in the mapping. Thanks for reporting!

(We need the native `ocsf::validate` operator soon.)
