### PR TITLE
Remove TQL2 comments

### DIFF
--- a/alphamountain/package.yaml
+++ b/alphamountain/package.yaml
@@ -68,7 +68,6 @@ pipelines:
       A pipeline that periodically fetches the alphaMountain Threats Feed and
       publishes it to the `alphamountain` topic.
     definition: |
-      // tql2
       every {{ inputs.refresh-interval }} {
         load_http "https://batch.alphamountain.ai/threat/feed/csv", data = {
           version: 1,
@@ -87,7 +86,6 @@ pipelines:
     description: |
       A pipeline that updates the `alphamountain-threats` context.
     definition: |
-      // tql2
       subscribe "alphamountain"
       where @name == "alphamountain.threat"
       context::update "alphamountain-threats", key=hostname, create_timeout={{ inputs.threat-expiry }}
@@ -98,7 +96,6 @@ pipelines:
       A pipeline that periodically fetches the alphaMountain Categories Feed
       and publishes it to the `alphamountain` topic.
     definition: |
-      // tql2
       every {{ inputs.refresh-interval }} {
         load_http "https://batch.alphamountain.ai/category/feed/csv", data = {
           version: 1,
@@ -115,7 +112,6 @@ pipelines:
     description: |
       A pipeline that updates the `alphamountain-categories` context.
     definition: |
-      // tql2
       subscribe "alphamountain"
       where @name == "alphamountain.category"
       context::update "alphamountain-categories", key=hostname, create_timeout={{ inputs.threat-expiry }}
@@ -125,7 +121,6 @@ examples:
     description: |
       Shows the top ten threats from alphaMountain by score.
     definition: |
-      // tql2
       context::inspect "alphamountain-threats"
       this = value
       sort -score

--- a/cisco-umbrella-ocsf/package.yaml
+++ b/cisco-umbrella-ocsf/package.yaml
@@ -20,7 +20,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       subscribe "cisco"
       where @name == "cisco.umbrella.dns"
       // Move original event into dedicated field.

--- a/cisco-umbrella/package.yaml
+++ b/cisco-umbrella/package.yaml
@@ -46,7 +46,6 @@ pipelines:
       onboarding any that are detected. Any new files are downloaded, decompressed,
       parsed, and published as `cisco.umbrella.dns` events onto the `cisco` topic.
     definition: |
-      // tql2
       every {{ inputs.poll-frequency }} {
         shell r#"
           # TODO: We want to switch to `remote {config}` as the first operator for

--- a/demo-node/package.yaml
+++ b/demo-node/package.yaml
@@ -22,7 +22,6 @@ pipelines:
       Load Suricata Eve JSON logs from a GCS bucket and import them into the
       demo node.
     definition: |
-      // tql2
       from "https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst" {
         decompress_zstd
         read_suricata
@@ -35,7 +34,6 @@ pipelines:
     description: |
       Load Zeek TSV logs from a GCS bucket and import them into the demo node.
     definition: |
-      // tql2
       from "https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst" {
         decompress_zstd
         read_zeek_tsv
@@ -47,7 +45,6 @@ examples:
     description: |
       Use the `where` operator to zero in on one particular schema.
     definition: |
-      // tql2
       export
       where @name == "suricata.alert"
 
@@ -57,7 +54,6 @@ examples:
       schema. We use it to show some of all Zeek TSV logs to get an idea of our
       dataset.
     definition: |
-      // tql2
       export
       where "zeek" in @name
       taste 10
@@ -67,7 +63,6 @@ examples:
       Use the `where` operator with a more complex expression to identify
       long-running connections in a specific CIDR subnet.
     definition: |
-      // tql2
       export
       where @name == "zeek.conn"
       where id.orig_h in 10.10.5.0/25
@@ -77,7 +72,6 @@ examples:
     description: |
       Use the `top` operator to see the top 5 hitters in Zeek notice logs.
     definition: |
-      // tql2
       export
       where @name == "zeek.notice"
       top msg

--- a/feodo/package.yaml
+++ b/feodo/package.yaml
@@ -23,7 +23,6 @@ pipelines:
     name: Update Feodo Context
     description: A pipeline that periodically refreshes the Feodo lookup-table context.
     definition: |
-      // tql2
       every 1h {
         load_http "https://feodotracker.abuse.ch/downloads/ipblocklist_aggressive.csv"
         read_csv comments=true
@@ -35,6 +34,5 @@ examples:
   - name: Enrich Feodo
     description: Evaluate the `src_ip` field of the input data against the Feodo IP Blocklist.
     definition: |
-      // tql2
       export
       context::enrich "feodo", key=dst_ip

--- a/fortinet-fortigate/package.yaml
+++ b/fortinet-fortigate/package.yaml
@@ -23,7 +23,6 @@ pipelines:
     name: Onboard FortiGate logs via UDP
     description: A pipeline for ingesting and processing FortiGate logs received via UDP.
     definition: |
-      // tql2
       from "{{ inputs.syslog-url }}" {
         read_syslog
       }

--- a/foxio/package.yaml
+++ b/foxio/package.yaml
@@ -71,7 +71,6 @@ pipelines:
       A pipeline that periodically fetches the FoxIO JA4+ database and
       publishes it to the `foxio` topic.
     definition: |
-      // tql2
       every {{ inputs.refresh-interval }} {
         load_http "https://ja4db.com/api/read/"
         read_json arrays_of_objects=true
@@ -85,7 +84,6 @@ pipelines:
       A pipeline that extracts JA4 fingerprints and updates the corresponding
       context.
     definition: |
-      // tql2
       subscribe "foxio"
       where ja4_fingerprint != null
       context::update "ja4", key=ja4_fingerprint
@@ -96,7 +94,6 @@ pipelines:
       A pipeline that extracts JA4S fingerprints and updates the corresponding
       context.
     definition: |
-      // tql2
       subscribe "foxio"
       where ja4s_fingerprint != null
       context::update "ja4s", key=ja4s_fingerprint
@@ -107,7 +104,6 @@ pipelines:
       A pipeline that extracts JA4H fingerprints and updates the corresponding
       context.
     definition: |
-      // tql2
       subscribe "foxio"
       where ja4h_fingerprint != null
       context::update "ja4h", key=ja4h_fingerprint
@@ -118,7 +114,6 @@ pipelines:
       A pipeline that extracts JA4X fingerprints and updates the corresponding
       context.
     definition: |
-      // tql2
       subscribe "foxio"
       where ja4x_fingerprint != null
       context::update "ja4x", key=ja4x_fingerprint
@@ -129,7 +124,6 @@ pipelines:
       A pipeline that extracts JA4T fingerprints and updates the corresponding
       context.
     definition: |
-      // tql2
       subscribe "foxio"
       where ja4t_fingerprint != null
       context::update "ja4t", key=ja4t_fingerprint
@@ -140,7 +134,6 @@ pipelines:
       A pipeline that extracts JA4TS fingerprints and updates the corresponding
       context.
     definition: |
-      // tql2
       subscribe "foxio"
       where ja4ts_fingerprint != null
       context::update "ja4ts", key=ja4ts_fingerprint
@@ -151,7 +144,6 @@ pipelines:
       A pipeline that extracts JA4TScan fingerprints and updates the
       corresponding context.
     definition: |
-      // tql2
       subscribe "foxio"
       where ja4tscan_fingerprint != null
       context::update "ja4tscan", key=ja4tscan_fingerprint
@@ -163,7 +155,6 @@ examples:
       package](https://github.com/FoxIO-LLC/ja4/tree/main/zeek) to enrich your
       Zeek logs with JA4+ fingerprints.
     definition: |
-      // tql2
       subscribe "zeek"
       where @name == "zeek.conn"
       context::enrich "ja4t", key=ja4t
@@ -174,7 +165,6 @@ examples:
       Shows a bar chart of the top-10 most common operating systems in the JA4+
       database.
     definition: |
-      // tql2
       load_http "https://ja4db.com/api/read/"
       read_json arrays_of_objects=true
       where os != null
@@ -187,7 +177,6 @@ examples:
       Shows a bar chart of the top-10 most common applications in the JA4+
       database.
     definition: |
-      // tql2
       load_http "https://ja4db.com/api/read/"
       read_json arrays_of_objects=true
       where application != null
@@ -199,5 +188,4 @@ examples:
     description: |
       Shows all entries of the FoxIO JA+s database.
     definition: |
-      // tql2
       context::inspect "ja4"

--- a/paloalto/package.yaml
+++ b/paloalto/package.yaml
@@ -116,7 +116,6 @@ pipelines:
        All other log types get forwarded including their raw Syslog framing as
        `paloalto.unknown` events.
     definition: |
-      // tql2
       from "{{ inputs.url }}" {
         read_syslog
       }

--- a/slack/package.yaml
+++ b/slack/package.yaml
@@ -26,7 +26,6 @@ pipelines:
     description: |
       Forwards all events arriving on the topic `slack` to Slack.
     definition: |
-      // tql2
       // Slack requires every message to arrive in a JSON body in the format
       // `{text: "<message>"}`. To achieve that, we just write the content out
       // line by line and then read it back in, which gives us a human-readable
@@ -43,6 +42,5 @@ examples:
     description: |
       Sends the message "Hello, world! 👋" to Slack.
     definition: |
-      // tql2
       from { message: "Hello, world! 👋" }
       publish "slack"

--- a/sophos-ocsf/package.yaml
+++ b/sophos-ocsf/package.yaml
@@ -18,7 +18,6 @@ pipelines:
   map-core-detection-to-ocsf:
     name: Sophos Detection to OCSF Detection Finding
     definition: |
-      // tql2
       let $severity = {
         low: {name: "Low", id: 2},
         medium: {name: "Medium", id: 3},
@@ -157,7 +156,6 @@ pipelines:
   map-core-pua-clean-to-ocsf:
     name: Sophos PUA Clean to OCSF File Remediation Activity
     definition: |
-      // tql2
       let $severity = {
         low: {name: "Low", id: 2},
         medium: {name: "Medium", id: 3},
@@ -292,7 +290,6 @@ pipelines:
   map-web-filtering-blocked-to-ocsf:
     name: Sophos Web Filtering Blocked to OCSF Remediation Activity
     definition: |
-      // tql2
       let $severity = {
         low: {name: "Low", id: 2},
         medium: {name: "Medium", id: 3},

--- a/sophos/package.yaml
+++ b/sophos/package.yaml
@@ -38,7 +38,6 @@ pipelines:
       API](https://developer.sophos.com/docs/siem-v1/1/overview) for the
       `/events` endpoint, which offers events from the last 24h.
     definition: |
-      // tql2
       every {{ inputs.poll-frequency }} {
       shell r#"
       python3 <<END
@@ -98,7 +97,6 @@ pipelines:
       API](https://developer.sophos.com/docs/siem-v1/1/overview) for the
       `/alerts` endpoint, which offers alerts from the last 24h.
     definition: |
-      // tql2
       every {{ inputs.poll-frequency }} {
       shell r#"
       python3 <<END
@@ -152,7 +150,6 @@ examples:
     description: |
       Filter out high-severity events and project key columns.
     definition: |
-      // tql2
       subscribe "sophos"
       where @name == "sophos.event" and severity == "high"
       select user_id, endpoint_type, type, source, name, location
@@ -160,7 +157,6 @@ examples:
     description: |
       Show once per day the top values of the field `threat`.
     definition: |
-      // tql2
       subscribe "sophos"
       where @name == "sophos.alert" and threat != null
       every 1d {

--- a/splunk/package.yaml
+++ b/splunk/package.yaml
@@ -39,7 +39,6 @@ pipelines:
     name: Send data to Splunk
     description: Send data to a Splunk instance.
     definition: |
-      // tql2
       subscribe "{{ inputs.events_topic }}"
       to_splunk "{{ inputs.splunk_url }}",
         hec_token="{{ inputs.splunk_token }}",

--- a/sslbl/package.yaml
+++ b/sslbl/package.yaml
@@ -31,7 +31,6 @@ pipelines:
     description: |
       A pipeline that periodically refreshes the SSLBL lookup table.
     definition: |
-      // tql2
       every {{ inputs.refresh-interval }} {
         load_http "https://sslbl.abuse.ch/blacklist/sslblacklist.csv"
         read_csv comments=true, header="timestamp,SHA1,reason"
@@ -45,7 +44,6 @@ examples:
       Enriches the certificate SHA1 fingerprint from Suricata TLS logs with the
       SSLBL data.
     definition: |
-      // tql2
       subscribe "suricata"
       where @name == "suricata.tls"
       sha1 = tls.fingerprint.replace(":", "")
@@ -56,7 +54,6 @@ examples:
       Shows a bar chart of the top-10 reasons why a certificate is in the
       dataset.
     definition: |
-      // tql2
       context::inspect "sslbl"
       this = value
       top reason

--- a/suricata-ocsf/package.yaml
+++ b/suricata-ocsf/package.yaml
@@ -21,7 +21,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       let $proto_nums = {
         TCP: 6,
         UDP: 17,
@@ -87,7 +86,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       let $rcode_id = {
         NOERROR: 0,
         FORMERROR: 1,
@@ -202,7 +200,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       let $activity_id = {
         FILE_SUPERSEDE: 1,
         FILE_OPEN: 2,
@@ -281,7 +278,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       subscribe "suricata"
       where @name == "suricata.alert"
       this = { suricata: this }
@@ -337,7 +333,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       let $activity_id = {
         CONNECT: 1,
         DELETE: 2,
@@ -430,7 +425,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       let $activity_id = {
         CONNECT: 1,
         DELETE: 2,
@@ -534,7 +528,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       subscribe "suricata"
       where @name == "suricata.ssh"
       this = { suricata: this }
@@ -577,7 +570,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       let $activity_id = {
         STOR: 1,
         STOU: 1,
@@ -653,7 +645,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       subscribe "suricata"
       where @name == "suricata.smtp"
       this = { suricata: this }
@@ -705,7 +696,6 @@ pipelines:
     restart-on-error: 5m
     disabled: true
     definition: |
-      // tql2
       subscribe "suricata"
       where @name == "suricata.tls"
       this = { suricata: this }
@@ -791,7 +781,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       subscribe "suricata"
       where @name == "suricata.snmp"
       this = { suricata: this }
@@ -853,7 +842,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       subscribe "suricata"
       where @name == "suricata.sip"
       this = { suricata: this }
@@ -915,7 +903,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       subscribe "suricata"
       where @name == "suricata.ikev2"
       this = { suricata: this }
@@ -977,7 +964,6 @@ pipelines:
     restart-on-error: 5m
     disabled: false
     definition: |
-      // tql2
       subscribe "suricata"
       where @name == "suricata.mqtt"
       this = { suricata: this }
@@ -1041,7 +1027,6 @@ pipelines:
     restart-on-error: 5m
     disabled: true
     definition: |
-      // tql2
       subscribe "suricata"
       where @name == "suricata.krb5"
       this = { suricata: this }
@@ -1104,7 +1089,6 @@ pipelines:
     restart-on-error: 5m
     disabled: true
     definition: |
-      // tql2
       let $activity_id = {
         discover: 1,
         offer: 2,

--- a/suricata/package.yaml
+++ b/suricata/package.yaml
@@ -29,7 +29,6 @@ pipelines:
       `suricata` topic.
     restart-on-error: true
     definition: |
-      // tql2
       load_file "{{ inputs.eve-path }}", follow=true
       read_suricata
       publish "suricata"
@@ -40,7 +39,6 @@ pipelines:
       Persist events published on the topic `suricata`.
     disabled: true
     definition: |
-      // tql2
       subscribe "suricata"
       import
 
@@ -49,7 +47,6 @@ examples:
     description: |
       View all Suricata alerts persisted in the last day.
     definition: |
-      // tql2
       export
       where @name == "suricata.alert"
       let $ts = now() - 1d

--- a/threatfox/package.yaml
+++ b/threatfox/package.yaml
@@ -91,7 +91,6 @@ pipelines:
     description: |
       A pipeline that puts (IP, port) tuples into the corresponding context.
     definition: |
-      // tql2
       subscribe "threatfox"
       where ioc_type == "ip:port"
       ioc = ioc.parse_grok("%{IP:ip}:%{NUMBER:port}")
@@ -102,7 +101,6 @@ pipelines:
     description: |
       A pipeline that puts domains into the corresponding context.
     definition: |
-      // tql2
       subscribe "threatfox"
       where ioc_type == "domain"
       context::update "threatfox-domains", key=ioc
@@ -112,7 +110,6 @@ pipelines:
     description: |
       A pipeline that puts URLs into the corresponding context.
     definition: |
-      // tql2
       subscribe "threatfox"
       where ioc_type == "url"
       context::update "threatfox-urls", key=ioc
@@ -122,7 +119,6 @@ pipelines:
     description: |
       A pipeline that puts domains into the corresponding context.
     definition: |
-      // tql2
       subscribe "threatfox"
       where ioc_type.ends_with("hash")
       context::update "threatfox-hashes", key=ioc
@@ -132,7 +128,6 @@ examples:
     description: |
       Enriches Zeek DNS logs with the ThreatFox IOCs of type `domain`.
     definition: |
-      // tql2
       subscribe "zeek"
       where @name == "zeek.dns"
       context::enrich "threatfox-domains", key=query
@@ -141,7 +136,6 @@ examples:
     description: |
       Shows a bar chart that plots the number of IOCs per confidence level.
     definition: |
-      // tql2
       from "https://threatfox-api.abuse.ch/api/v1/", data = {
         query: "get_iocs",
         days: 7
@@ -156,7 +150,6 @@ examples:
     description: |
       Shows a bar chart that plots the number of IOCs per confidence level.
     definition: |
-      // tql2
       from "https://threatfox-api.abuse.ch/api/v1/", data = {
         query: "get_iocs",
         days: 7
@@ -172,7 +165,6 @@ examples:
     description: |
       Shows a table of all ThreatFox IOCs of type `domain`.
     definition: |
-      // tql2
       context::inspect "threatfox-domains"
       select data
       unroll data

--- a/zeek/package.yaml
+++ b/zeek/package.yaml
@@ -35,7 +35,6 @@ pipelines:
     name: Onboard Zeek Logs from a File
     description: Connects a Zeek data source on the network.
     definition: |
-      // tql2
       load_file "{{ inputs.log-file }}"
       read_zeek_{{ inputs.log-format }}
       publish "zeek"
@@ -45,7 +44,6 @@ pipelines:
     name: Onboard Zeek Logs via TCP
     description: Connects a Zeek data source on the network.
     definition: |
-      // tql2
       from "tcp://{{ inputs.listen-endpoint }}" { read_zeek_{{ inputs.log-format }} }
       publish "zeek"
     disabled: true
@@ -55,7 +53,6 @@ examples:
     description: |
       A line chart displaying how many Zeek events arrived in the last 3 hours.
     definition: |
-        // tql2
         metrics "operator"
         let $ts = now() - 3h
         where timestamp > $ts


### PR DESCRIPTION
This PR removes all `//tql2` comments from our packages. These are no longer needed and existed only during a transitory phase.
