### PR TITLE
Remove empty contexts field from vpc flow logs package

### DIFF
--- a/aws-vpcflow/package.yaml
+++ b/aws-vpcflow/package.yaml
@@ -31,8 +31,6 @@ inputs:
       Whether to remove files after processing them. Possible values are 'true' or 'false'.
     default: "false"
 
-contexts:
-
 pipelines:
   ingest-from-s3:
     name: Ingest VPC Flow Logs from S3


### PR DESCRIPTION
This causes an installation failure, because the node validates that `contexts` must be a record.
