### PR TITLE
Suppress warnings in OCSF OSINT enrichment

### DIFF
--- a/ocsf-osint/package.yaml
+++ b/ocsf-osint/package.yaml
@@ -68,21 +68,21 @@ pipelines:
       subscribe $input
       where @name.starts_with("ocsf")
       if category_uid == 4 { // Network Activity
-        if src_endpoint.has("ip") {
+        if src_endpoint?.ip? != null {
           context::enrich "ocsf-osint",
             key=src_endpoint.ip,
             format="ocsf",
             mode="append",
             into=enrichments
         }
-        if dst_endpoint?.has("ip") {
+        if dst_endpoint?.ip? != null {
           context::enrich "ocsf-osint",
             key=dst_endpoint.ip,
             format="ocsf",
             mode="append",
             into=enrichments
         }
-        if class_uid == 4003 and query.has("hostname") { // DNS Activity
+        if class_uid == 4003 and query?.hostname? != null { // DNS Activity
           context::enrich "ocsf-osint",
             key=query.hostname,
             format="ocsf",


### PR DESCRIPTION
Fields may not always exist. This is now respected.
