### PR TITLE
Update dataset URLs to new base URL

### DIFF
--- a/demo-data-generator/package.yaml
+++ b/demo-data-generator/package.yaml
@@ -38,7 +38,7 @@ pipelines:
 
       every $period {
         from {
-          url: "https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst",
+          url: "https://datasets.tenzir.tools/M57/zeek-all.log.zst",
         }
       }
       http url {
@@ -65,7 +65,7 @@ pipelines:
 
       every $period {
         from {
-          url: "https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst",
+          url: "https://datasets.tenzir.tools/M57/suricata.json.zst",
         }
       }
       http url {

--- a/demo-node/package.yaml
+++ b/demo-node/package.yaml
@@ -22,7 +22,7 @@ pipelines:
       Load Suricata Eve JSON logs from a GCS bucket and import them into the
       demo node.
     definition: |
-      from "https://storage.googleapis.com/tenzir-datasets/M57/suricata.json.zst" {
+      from "https://datasets.tenzir.tools/M57/suricata.json.zst" {
         decompress_zstd
         read_suricata
       }
@@ -34,7 +34,7 @@ pipelines:
     description: |
       Load Zeek TSV logs from a GCS bucket and import them into the demo node.
     definition: |
-      from "https://storage.googleapis.com/tenzir-datasets/M57/zeek-all.log.zst" {
+      from "https://datasets.tenzir.tools/M57/zeek-all.log.zst" {
         decompress_zstd
         read_zeek_tsv
       }


### PR DESCRIPTION
Change dataset URLs from storage.googleapis.com/tenzir-datasets to datasets.tenzir.tools