### PR TITLE
Fix typos in MISP package.yaml

### DIFF
--- a/misp/package.yaml
+++ b/misp/package.yaml
@@ -55,7 +55,7 @@ pipelines:
       }
       unroll response
       this = response.Event
-      // Fix up types because we pass raw=true to read_ndjson above.
+      // Fix up types because we pass raw=true to read_json above.
       timestamp = from_epoch(int(timestamp) * 1s)
       @name = "misp.event"
       publish "misp"
@@ -167,7 +167,7 @@ pipelines:
       ocsf.status_id = $analysis_status[move misp.analysis]? else 0
       drop misp.Attribute?
       // TODO: consider mapping the Galaxy in the future. For now, we drop
-      // it because it is indredibly bulky.
+      // it because it is incredibly bulky.
       drop misp.Galaxy?
       // ------ Finalize --------
       this = {...ocsf, unmapped: misp}
@@ -176,7 +176,7 @@ pipelines:
       publish "ocsf"
 
   send-events-with-osint-as-sightings:
-    name: Submit OCSF events with OSINT profile as to MISP as sightings
+    name: Submit OCSF events with OSINT profile to MISP as sightings
     description: |
       Sends sightings to MISP for all events that have an OSINT profile.
     definition: |
@@ -215,7 +215,7 @@ examples:
       }
       unroll response
       this = response.Event
-      // Fix up types because we pass raw=true to read_ndjson above.
+      // Fix up types because we pass raw=true to read_json above.
       timestamp = from_epoch(int(timestamp) * 1s)
       @name = "misp.event"
       publish "misp"


### PR DESCRIPTION
This PR fixes 4 typos in the MISP package.yaml file:

1. `indredibly` → `incredibly`
2. `as to MISP as` → `to MISP as` 
3. `read_ndjson` → `read_json` (2 occurrences in comments - the actual code uses `read_json`)