### PR TITLE
Silence warning when tags are not present

### DIFF
--- a/misp/package.yaml
+++ b/misp/package.yaml
@@ -160,7 +160,7 @@ pipelines:
         external_uid: x.uuid,
         severity_id: ocsf.severity_id,
         // TODO: Figure out how to assign `null` if no tlp tag in the source.
-        tlp: misp.Tag.where(x => x.name.starts_with("tlp:"))[0]?.name?.slice(begin=4).to_upper(),
+        tlp: misp.Tag?.where(x => x.name.starts_with("tlp:"))[0]?.name?.slice(begin=4).to_upper(),
         type_id: $type_ids[x.type]? else 99,
         value: x.value,
       })


### PR DESCRIPTION
This PR silences a warning when tags are not present.
