### PR TITLE
Fix demo package operators

### DIFF
--- a/demo/operators/suricata.tql
+++ b/demo/operators/suricata.tql
@@ -21,9 +21,9 @@ every $period {
     read_suricata
     head 30k
   }
+  where $first <= timestamp and timestamp <= $last
+  sort timestamp
 }
-where $first <= timestamp and timestamp <= $last
-sort timestamp
 // Drop some very frequent data to get a more even distribution.
 if @name == "suricata.dns" {
   if random() > 0.01 {

--- a/demo/operators/zeek.tql
+++ b/demo/operators/zeek.tql
@@ -20,7 +20,7 @@ every $period {
     decompress_zstd
     read_zeek_tsv
   }
+  where $first <= ts and ts <= $last
+  sort ts
 }
-where $first <= ts and ts <= $last
-sort ts
 delay ts, start=$first, speed=$factor


### PR DESCRIPTION
The demo packages generator operators did never produce data and caused
an unbounded memory growth as they collected more and more data into
`sort`, which never finished due to its input never finishing.
