### PR TITLE
Expand Windows Event Log OCSF mappings

### DIFF
--- a/microsoft/changelog/unreleased/windows-authorize-session-ocsf-mapping.md
+++ b/microsoft/changelog/unreleased/windows-authorize-session-ocsf-mapping.md
@@ -1,0 +1,12 @@
+---
+title: Windows authorize session OCSF mapping
+type: feature
+authors:
+  - mavam
+  - codex
+prs:
+  - 148
+created: 2026-06-02T08:30:07.026165Z
+---
+
+The `microsoft::windows::ocsf::map` operator now maps Windows Security Event ID 4672, "Special privileges assigned to new logon", to OCSF Authorize Session (3003) with the Assign Privileges activity.

--- a/microsoft/operators/windows/ocsf/events/authorize_session.tql
+++ b/microsoft/operators/windows/ocsf/events/authorize_session.tql
@@ -1,0 +1,22 @@
+---
+description: Special Privileges Assigned to New Logon (EID 4672) → OCSF Authorize Session (3003, Assign Privileges)
+---
+
+@name = "ocsf.authorize_session"
+
+ocsf.category_uid = 3
+ocsf.class_uid = 3003
+ocsf.activity_id = 1  // Assign Privileges
+ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+
+ocsf.user = {
+  uid: move windows.EventData.SubjectUserSid,
+  name: move windows.EventData.SubjectUserName,
+  domain: move windows.EventData.SubjectDomainName,
+}
+
+ocsf.session = {
+  uid_alt: move windows.EventData.SubjectLogonId,
+}
+
+ocsf.privileges = (move windows.EventData.PrivilegeList).split_regex(r"\s+")

--- a/microsoft/operators/windows/ocsf/map.tql
+++ b/microsoft/operators/windows/ocsf/map.tql
@@ -15,7 +15,7 @@ ocsf.raw_data_size = $log.length_bytes()
 windows = $log.parse_winlog()
 
 ocsf.metadata = {
-  event_code: (move windows.System.EventID).string(),
+  event_code: windows.System.EventID.string(),
   extensions: [{name: "win"}],
   log_format: "xml",
   log_name: move windows.System.Channel,
@@ -32,6 +32,7 @@ ocsf.metadata = {
   profiles: ["host"],
   version: "1.8.0",
 }
+windows.System.EventID = windows.System.EventID.int()
 drop windows.System.Provider
 drop windows.System.TimeCreated
 
@@ -48,101 +49,101 @@ ocsf.device = {
 // "-" is the universal Windows sentinel for "not applicable/empty".
 replace what="-", with=null
 
-match ocsf.metadata.event_code {
-  "100" | "101" | "102" | "129" | "200" | "201" => {
+match windows.System.EventID {
+  99..103 | 129 | 199..202 => {
     microsoft::windows::ocsf::events::task_run
   }
-  "106" | "140" | "141" => {
+  106 | 139..142 => {
     microsoft::windows::ocsf::events::task_lifecycle
   }
-  "1000" => {
+  1000 => {
     microsoft::windows::ocsf::events::application_error
   }
-  "1001" => {
+  1001 => {
     microsoft::windows::ocsf::events::application_crash_report
   }
-  "1002" => {
+  1002 => {
     microsoft::windows::ocsf::events::application_hang
   }
-  "1006" | "1007" => {
+  1005..1008 => {
     microsoft::windows::ocsf::events::defender_threat
   }
-  "1102" => {
+  1102 => {
     microsoft::windows::ocsf::events::eventlog_clear
   }
-  "1116" | "1117" => {
+  1115..1118 => {
     microsoft::windows::ocsf::events::defender_detection
   }
-  "1121" => {
+  1121 => {
     microsoft::windows::ocsf::events::defender_asr
   }
-  "2000" => {
+  2000 => {
     microsoft::windows::ocsf::events::defender_signature_update
   }
-  "4100" => {
+  4100 => {
     microsoft::windows::ocsf::events::powershell_error
   }
-  "4103" => {
+  4103 => {
     microsoft::windows::ocsf::events::powershell_module_logging
   }
-  "4104" => {
+  4104 => {
     microsoft::windows::ocsf::events::powershell_script_block
   }
-  "4105" | "4106" => {
+  4104..4107 => {
     microsoft::windows::ocsf::events::powershell_script_block_invocation
   }
-  "4624" => {
+  4624 => {
     microsoft::windows::ocsf::events::logon
   }
-  "4625" => {
+  4625 => {
     microsoft::windows::ocsf::events::logon_failed
   }
-  "4648" => {
+  4648 => {
     microsoft::windows::ocsf::events::explicit_credential_logon
   }
-  "4688" => {
+  4688 => {
     microsoft::windows::ocsf::events::process_create
   }
-  "4697" => {
+  4697 => {
     microsoft::windows::ocsf::events::service_install
   }
-  "4698" => {
+  4698 => {
     microsoft::windows::ocsf::events::scheduled_task_create
   }
-  "4720" | "4722" | "4723" | "4724" | "4725" | "4726" => {
+  4720 | 4721..4727 => {
     microsoft::windows::ocsf::events::account_change
   }
-  "4727" | "4728" | "4729" | "4730" | "4731" | "4732" | "4733" | "4734" |
-  "4754" | "4755" | "4756" | "4757" | "4758" => {
+  4726..4735 | 4753..4759 => {
     microsoft::windows::ocsf::events::group_management
   }
-  "4769" => {
+  4769 => {
     microsoft::windows::ocsf::events::kerberos_service_ticket
   }
-  "4771" => {
+  4771 => {
     microsoft::windows::ocsf::events::kerberos_preauth_failed
   }
-  "4776" => {
+  4776 => {
     microsoft::windows::ocsf::events::ntlm_auth
   }
-  "5001" | "5007" => {
+  5001 | 5007 => {
     microsoft::windows::ocsf::events::defender_tamper
   }
-  "6005" => {
+  6005 => {
     microsoft::windows::ocsf::events::eventlog_start
   }
-  "6006" => {
+  6006 => {
     microsoft::windows::ocsf::events::eventlog_stop
   }
-  "7034" => {
+  7034 => {
     microsoft::windows::ocsf::events::service_crashed
   }
-  "7045" => {
+  7045 => {
     microsoft::windows::ocsf::events::service_install_scm
   }
   _ => {
     microsoft::windows::ocsf::base
   }
 }
+drop windows.System.EventID
 
 this = {...ocsf, unmapped: windows}

--- a/microsoft/operators/windows/ocsf/map.tql
+++ b/microsoft/operators/windows/ocsf/map.tql
@@ -101,6 +101,9 @@ match windows.System.EventID {
   4648 => {
     microsoft::windows::ocsf::events::explicit_credential_logon
   }
+  4672 => {
+    microsoft::windows::ocsf::events::authorize_session
+  }
   4688 => {
     microsoft::windows::ocsf::events::process_create
   }

--- a/microsoft/tests/inputs/eid-4672.xml
+++ b/microsoft/tests/inputs/eid-4672.xml
@@ -1,0 +1,23 @@
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+  <System>
+    <Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-A5BA-3E3B0328C30D}"/>
+    <EventID>4672</EventID>
+    <Version>0</Version>
+    <Level>0</Level>
+    <Task>12548</Task>
+    <Keywords>0x8020000000000000</Keywords>
+    <TimeCreated SystemTime="2024-03-23T12:34:56.789012300Z"/>
+    <EventRecordID>98762</EventRecordID>
+    <Correlation/>
+    <Execution ProcessID="4" ThreadID="64"/>
+    <Channel>Security</Channel>
+    <Computer>DC01.corp.local</Computer>
+  </System>
+  <EventData>
+    <Data Name="SubjectUserSid">S-1-5-18</Data>
+    <Data Name="SubjectUserName">SYSTEM</Data>
+    <Data Name="SubjectDomainName">NT AUTHORITY</Data>
+    <Data Name="SubjectLogonId">0x3e7</Data>
+    <Data Name="PrivilegeList">SeAssignPrimaryTokenPrivilege SeTcbPrivilege SeSecurityPrivilege SeTakeOwnershipPrivilege SeLoadDriverPrivilege SeBackupPrivilege SeRestorePrivilege SeDebugPrivilege SeAuditPrivilege SeSystemEnvironmentPrivilege SeImpersonatePrivilege</Data>
+  </EventData>
+</Event>

--- a/microsoft/tests/ocsf/eid-4672.tql
+++ b/microsoft/tests/ocsf/eid-4672.tql
@@ -1,0 +1,9 @@
+from_file f"{env("TENZIR_INPUTS")}/eid-4672.xml" {
+  read_all
+}
+microsoft::windows::ocsf::map data
+ocsf::derive
+ocsf::cast
+
+// Ensure deterministic tests.
+drop metadata.processed_time

--- a/microsoft/tests/ocsf/eid-4672.txt
+++ b/microsoft/tests/ocsf/eid-4672.txt
@@ -1,0 +1,74 @@
+{
+  activity_id: 1,
+  activity_name: "Assign Privileges",
+  category_name: "Identity & Access Management",
+  category_uid: 3,
+  class_name: "Authorize Session",
+  class_uid: 3003,
+  device: {
+    hostname: "DC01.corp.local",
+  },
+  metadata: {
+    event_code: "4672",
+    extensions: [
+      {
+        name: "win",
+      },
+    ],
+    log_format: "xml",
+    log_level: "0",
+    log_name: "Security",
+    log_version: "0",
+    logged_time: 2024-03-23T12:34:56.789012300Z,
+    original_event_uid: "98762",
+    product: {
+      name: "Microsoft-Windows-Security-Auditing",
+      uid: "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+      vendor_name: "Microsoft",
+    },
+    profiles: [
+      "host",
+    ],
+    version: "1.8.0",
+  },
+  privileges: [
+    "SeAssignPrimaryTokenPrivilege",
+    "SeTcbPrivilege",
+    "SeSecurityPrivilege",
+    "SeTakeOwnershipPrivilege",
+    "SeLoadDriverPrivilege",
+    "SeBackupPrivilege",
+    "SeRestorePrivilege",
+    "SeDebugPrivilege",
+    "SeAuditPrivilege",
+    "SeSystemEnvironmentPrivilege",
+    "SeImpersonatePrivilege",
+  ],
+  raw_data: "<Event xmlns=\"http://schemas.microsoft.com/win/2004/08/events/event\">\n  <System>\n    <Provider Name=\"Microsoft-Windows-Security-Auditing\" Guid=\"{54849625-5478-4994-A5BA-3E3B0328C30D}\"/>\n    <EventID>4672</EventID>\n    <Version>0</Version>\n    <Level>0</Level>\n    <Task>12548</Task>\n    <Keywords>0x8020000000000000</Keywords>\n    <TimeCreated SystemTime=\"2024-03-23T12:34:56.789012300Z\"/>\n    <EventRecordID>98762</EventRecordID>\n    <Correlation/>\n    <Execution ProcessID=\"4\" ThreadID=\"64\"/>\n    <Channel>Security</Channel>\n    <Computer>DC01.corp.local</Computer>\n  </System>\n  <EventData>\n    <Data Name=\"SubjectUserSid\">S-1-5-18</Data>\n    <Data Name=\"SubjectUserName\">SYSTEM</Data>\n    <Data Name=\"SubjectDomainName\">NT AUTHORITY</Data>\n    <Data Name=\"SubjectLogonId\">0x3e7</Data>\n    <Data Name=\"PrivilegeList\">SeAssignPrimaryTokenPrivilege SeTcbPrivilege SeSecurityPrivilege SeTakeOwnershipPrivilege SeLoadDriverPrivilege SeBackupPrivilege SeRestorePrivilege SeDebugPrivilege SeAuditPrivilege SeSystemEnvironmentPrivilege SeImpersonatePrivilege</Data>\n  </EventData>\n</Event>\n",
+  raw_data_size: 1086,
+  session: {
+    uid_alt: "0x3e7",
+  },
+  severity: "Informational",
+  severity_id: 1,
+  time: 2024-03-23T12:34:56.789012300Z,
+  type_name: "Authorize Session: Assign Privileges",
+  type_uid: 300301,
+  unmapped: {
+    System: {
+      Task: 12548,
+      Keywords: "0x8020000000000000",
+      Correlation: null,
+      Execution: {
+        ProcessID: 4,
+        ThreadID: 64,
+      },
+    },
+    EventData: {},
+  },
+  user: {
+    domain: "NT AUTHORITY",
+    name: "SYSTEM",
+    uid: "S-1-5-18",
+  },
+}


### PR DESCRIPTION
## 🔍 Problem

The Microsoft package did not dispatch several related Windows Event IDs, and Windows Security Event ID 4672 fell back to the generic OCSF base event even though OCSF has a specific Authorize Session class for privileges assigned at logon.

## 🛠️ Solution

- Dispatch Windows Event IDs as integers so related events can be covered with numeric ranges.
- Add OCSF Authorize Session coverage for Windows Security Event ID 4672.
- Include fixture coverage and a changelog entry for the new mapping.

## 💬 Review

Focus on the expanded Event ID ranges and the 4672 mapping to OCSF `Authorize Session: Assign Privileges`. The Microsoft OCSF test subset passes locally with `uvx tenzir-test microsoft/tests/ocsf`.