### PR TITLE
Add agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Tenzir Library
+
+This repository hosts the Tenzir Library, a collection of
+[packages](https://docs.tenzir.com/explanations/packages.md) that
+contain user-defined operators, pipelines, examples, and context definitions.
+
+Each directory is one package, except for directories that begin with `.github`.
+
+## Workflows
+
+All key workflows are well-supported by agents. See
+<https://docs.tenzir.com/guides/ai-workbench/use-agent-skills.md> for a list
+of relevant agent skills during package development.
+
+Always load the `tenzir-docs` skill when working with TQL content.
+
+Prefer running the following commands through `uvx` instead of executing them
+locally, unless you are testing a specific feature that's not available in the
+respective latest release:
+
+- `tenzir`
+- `tenzir-node`
+- `tenzir-test`
+- `tenzir-ship`
+
+E.g., run `uvx tenzir -f path/to/pipe.tql` to execute a TQL program.
+
+### Evolve a package
+
+Use the `tenzir-manage-packages` skill to manage the lifecycle of a package.
+
+### Test packages
+
+Use [tenzir-test](https://docs.tenzir.com/reference/test-framework.md) for
+testing packages.
+
+Primary operations:
+
+- `uvx tenzir-test` runs all tests on every package in the library
+- `uvx tenzir-test <pkg>` runs all tests for the package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository hosts the Tenzir Library, a collection of
 [packages](https://docs.tenzir.com/explanations/packages.md) that
 contain user-defined operators, pipelines, examples, and context definitions.
 
-Each directory is one package, except for directories that begin with `.github`.
+Every top-level directory that does not start with `.` is a package.
 
 ## Workflows
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📚 Tenzir Library
 
-This repository contains a collection of open-source
+This repository hosts the official collection of content
 [packages](https://docs.tenzir.com/explanations/packages/) for Tenzir.
 
 ## 🚀 Install packages


### PR DESCRIPTION
## 🔍 Problem

- Agents need repository-specific guidance for package development workflows.
- The README description does not match the library positioning as directly as it could.

## 🛠️ Solution

- Add `AGENTS.md` with package-development workflow guidance, relevant skills, and preferred `uvx` command usage.
- Tighten the README opening description.

## 💬 Review

- Documentation-only change; focus on whether the agent workflow guidance is complete and accurate.