### PR TITLE
Validate TQL syntax in CI

### DIFF
--- a/.github/scripts/check-tql-syntax.sh
+++ b/.github/scripts/check-tql-syntax.sh
@@ -32,6 +32,8 @@ list_changed_files() {
     list_all_files
     return
   }
+  # Check only local commits being pushed. On main, this means commits ahead of
+  # origin/main; remote-only changes are not part of the pre-push check.
   git diff --name-only -z --diff-filter=ACMRT "$base" HEAD -- \
     "${pipeline_files[@]}"
 }

--- a/.github/scripts/check-tql-syntax.sh
+++ b/.github/scripts/check-tql-syntax.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 jobs="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '4')"
 
+# Ignore data test inputs here; the second pass parses them with read_tql.
 git ls-files -z '*.tql' ':!:*/tests/inputs/*.tql' |
   xargs -0 -n 1 -P "$jobs" bash -c '
     (($# == 0)) || uvx --prerelease allow tenzir --dump-ast -f "$1" >/dev/null

--- a/.github/scripts/check-tql-syntax.sh
+++ b/.github/scripts/check-tql-syntax.sh
@@ -1,16 +1,47 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-jobs="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '4')"
+# Validate TQL pipeline syntax with the prerelease Tenzir parser.
+# CI checks all tracked pipelines; pre-push uses --changed for files changed
+# since the merge base with the upstream branch.
 
-# Ignore data test inputs here; the second pass parses them with read_tql.
-git ls-files -z '*.tql' ':!:*/tests/inputs/*.tql' |
-  xargs -0 -n 1 -P "$jobs" bash -c '
-    (($# == 0)) || uvx --prerelease allow tenzir --dump-ast -f "$1" >/dev/null
-  ' _
+parallelism="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '8')"
+tenzir=(uvx --prerelease allow tenzir)
 
-git ls-files -z '*/tests/inputs/*.tql' |
-  xargs -0 -n 1 -P "$jobs" bash -c '
-    (($# == 0)) || TQL_SYNTAX_FILE="$1" uvx --prerelease allow tenzir \
-      '\''from_file f"{env("TQL_SYNTAX_FILE")}" { read_tql }'\'' >/dev/null
-  ' _
+# Skip data test inputs; they are fixtures, not pipelines.
+pipeline_files=('*.tql' ':!:*/tests/inputs/*.tql')
+
+list_all_files() {
+  git ls-files -z "${pipeline_files[@]}"
+}
+
+base_ref() {
+  git rev-parse --verify --quiet '@{upstream}' >/dev/null &&
+    git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' &&
+    return
+  git rev-parse --verify --quiet origin/HEAD >/dev/null && printf 'origin/HEAD\n'
+}
+
+list_changed_files() {
+  local base ref
+  ref="$(base_ref)" || {
+    list_all_files
+    return
+  }
+  base="$(git merge-base HEAD "$ref")" || {
+    list_all_files
+    return
+  }
+  git diff --name-only -z --diff-filter=ACMRT "$base" HEAD -- \
+    "${pipeline_files[@]}"
+}
+
+files=()
+while IFS= read -r -d '' file; do
+  files+=("$file")
+done < <([[ "${1:-}" == "--changed" ]] && list_changed_files || list_all_files)
+
+((${#files[@]} == 0)) && exit 0
+
+printf '%s\0' "${files[@]}" |
+  xargs -0 -n 1 -P "$parallelism" "${tenzir[@]}" --dump-ast -f >/dev/null

--- a/.github/scripts/check-tql-syntax.sh
+++ b/.github/scripts/check-tql-syntax.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export TENZIR_BINARY="${TENZIR_BINARY:-uvx tenzir}"
+
+read -r -a tenzir <<< "$TENZIR_BINARY"
+if ((${#tenzir[@]} == 0)); then
+  printf 'error: TENZIR_BINARY must not be empty\n' >&2
+  exit 2
+fi
+
+files=()
+if (($# > 0)); then
+  files=("$@")
+else
+  while IFS= read -r -d '' file; do
+    files+=("$file")
+  done < <(git ls-files -z '*.tql')
+fi
+
+if ((${#files[@]} == 0)); then
+  exit 0
+fi
+
+jobs="${TQL_SYNTAX_JOBS:-}"
+if [[ -z "$jobs" ]]; then
+  if command -v nproc >/dev/null 2>&1; then
+    jobs="$(nproc)"
+  else
+    jobs="$(sysctl -n hw.ncpu 2>/dev/null || printf '4')"
+  fi
+fi
+
+if [[ ! "$jobs" =~ ^[1-9][0-9]*$ ]]; then
+  printf 'error: TQL_SYNTAX_JOBS must be a positive integer\n' >&2
+  exit 2
+fi
+
+"${tenzir[@]}" --help >/dev/null
+
+printf 'Checking %d TQL files with %s\n' "${#files[@]}" "$TENZIR_BINARY"
+
+printf '%s\0' "${files[@]}" |
+  xargs -0 -n 1 -P "$jobs" bash -c '
+    set -euo pipefail
+
+    read -r -a tenzir <<< "$TENZIR_BINARY"
+    file="$1"
+
+    if [[ "$file" == */tests/inputs/*.tql ]]; then
+      if ! TQL_SYNTAX_FILE="$file" "${tenzir[@]}" \
+        '\''from_file f"{env("TQL_SYNTAX_FILE")}" { read_tql }'\'' >/dev/null; then
+        printf "::error file=%s::invalid TQL data\n" "$file" >&2
+        exit 1
+      fi
+      exit 0
+    fi
+
+    if ! "${tenzir[@]}" --dump-ast -f "$file" >/dev/null; then
+      printf "::error file=%s::invalid TQL pipeline\n" "$file" >&2
+      exit 1
+    fi
+  ' _

--- a/.github/scripts/check-tql-syntax.sh
+++ b/.github/scripts/check-tql-syntax.sh
@@ -1,63 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export TENZIR_BINARY="${TENZIR_BINARY:-uvx tenzir}"
+jobs="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '4')"
 
-read -r -a tenzir <<< "$TENZIR_BINARY"
-if ((${#tenzir[@]} == 0)); then
-  printf 'error: TENZIR_BINARY must not be empty\n' >&2
-  exit 2
-fi
-
-files=()
-if (($# > 0)); then
-  files=("$@")
-else
-  while IFS= read -r -d '' file; do
-    files+=("$file")
-  done < <(git ls-files -z '*.tql')
-fi
-
-if ((${#files[@]} == 0)); then
-  exit 0
-fi
-
-jobs="${TQL_SYNTAX_JOBS:-}"
-if [[ -z "$jobs" ]]; then
-  if command -v nproc >/dev/null 2>&1; then
-    jobs="$(nproc)"
-  else
-    jobs="$(sysctl -n hw.ncpu 2>/dev/null || printf '4')"
-  fi
-fi
-
-if [[ ! "$jobs" =~ ^[1-9][0-9]*$ ]]; then
-  printf 'error: TQL_SYNTAX_JOBS must be a positive integer\n' >&2
-  exit 2
-fi
-
-"${tenzir[@]}" --help >/dev/null
-
-printf 'Checking %d TQL files with %s\n' "${#files[@]}" "$TENZIR_BINARY"
-
-printf '%s\0' "${files[@]}" |
+git ls-files -z '*.tql' ':!:*/tests/inputs/*.tql' |
   xargs -0 -n 1 -P "$jobs" bash -c '
-    set -euo pipefail
+    (($# == 0)) || uvx --prerelease allow tenzir --dump-ast -f "$1" >/dev/null
+  ' _
 
-    read -r -a tenzir <<< "$TENZIR_BINARY"
-    file="$1"
-
-    if [[ "$file" == */tests/inputs/*.tql ]]; then
-      if ! TQL_SYNTAX_FILE="$file" "${tenzir[@]}" \
-        '\''from_file f"{env("TQL_SYNTAX_FILE")}" { read_tql }'\'' >/dev/null; then
-        printf "::error file=%s::invalid TQL data\n" "$file" >&2
-        exit 1
-      fi
-      exit 0
-    fi
-
-    if ! "${tenzir[@]}" --dump-ast -f "$file" >/dev/null; then
-      printf "::error file=%s::invalid TQL pipeline\n" "$file" >&2
-      exit 1
-    fi
+git ls-files -z '*/tests/inputs/*.tql' |
+  xargs -0 -n 1 -P "$jobs" bash -c '
+    (($# == 0)) || TQL_SYNTAX_FILE="$1" uvx --prerelease allow tenzir \
+      '\''from_file f"{env("TQL_SYNTAX_FILE")}" { read_tql }'\'' >/dev/null
   ' _

--- a/.github/workflows/tenzir-test.yml
+++ b/.github/workflows/tenzir-test.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Parse TQL files
         shell: bash
-        env:
-          TENZIR_BINARY: uvx --prerelease allow tenzir
         run: ./.github/scripts/check-tql-syntax.sh
 
   tenzir-test:

--- a/.github/workflows/tenzir-test.yml
+++ b/.github/workflows/tenzir-test.yml
@@ -8,6 +8,22 @@ on:
       - main
 
 jobs:
+  tql-syntax:
+    name: Validate TQL syntax
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Parse TQL files
+        shell: bash
+        env:
+          TENZIR_BINARY: uvx --prerelease allow tenzir
+        run: ./.github/scripts/check-tql-syntax.sh
+
   tenzir-test:
     name: Test packages (${{ matrix.tenzir.channel }})
     runs-on: ubuntu-latest

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,4 +1,4 @@
 pre-push:
   commands:
     tql-syntax:
-      run: ./.github/scripts/check-tql-syntax.sh
+      run: ./.github/scripts/check-tql-syntax.sh --changed

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,4 @@
+pre-push:
+  commands:
+    tql-syntax:
+      run: ./.github/scripts/check-tql-syntax.sh

--- a/microsoft/examples/graph-defender-alerts-to-ocsf.tql
+++ b/microsoft/examples/graph-defender-alerts-to-ocsf.tql
@@ -3,7 +3,7 @@ name: Microsoft Defender alerts → OCSF
 description: Fetch Microsoft Defender alerts from Microsoft Graph and map them to OCSF Detection Finding events.
 ---
 
-microsoft::graph::defender::alerts
+microsoft::graph::defender::alerts \
   tenant_id="TENANT_ID",
   client_id="CLIENT_ID",
   client_secret=secret("CLIENT_SECRET"),

--- a/microsoft/examples/graph-intune-managed-devices-to-ocsf.tql
+++ b/microsoft/examples/graph-intune-managed-devices-to-ocsf.tql
@@ -3,7 +3,7 @@ name: Microsoft Intune managed devices → OCSF
 description: Fetch Microsoft Intune managed devices from Microsoft Graph and map them to OCSF Device Inventory Info events.
 ---
 
-microsoft::graph::intune::managed_devices
+microsoft::graph::intune::managed_devices \
   tenant_id="TENANT_ID",
   client_id="CLIENT_ID",
   client_secret=secret("CLIENT_SECRET")

--- a/microsoft/examples/graph-sign-ins-to-ocsf.tql
+++ b/microsoft/examples/graph-sign-ins-to-ocsf.tql
@@ -3,7 +3,7 @@ name: Microsoft Graph sign-ins → OCSF
 description: Fetch recent Microsoft Entra ID sign-in logs and map them to OCSF Authentication events.
 ---
 
-microsoft::graph::sign_ins
+microsoft::graph::sign_ins \
   tenant_id="TENANT_ID",
   client_id="CLIENT_ID",
   client_secret=secret("CLIENT_SECRET"),


### PR DESCRIPTION
## 🔍 Problem

- Package tests only exercise the TQL files covered by package test cases.
- Invalid TQL in examples or fixtures can land without a repository-wide parser gate.

## 🛠️ Solution

- Add a reusable syntax checker for tracked `.tql` files.
- Validate pipeline files with `tenzir --dump-ast -f`.
- Validate `tests/inputs/*.tql` data fixtures through `read_tql`.
- Run the checker in GitHub Actions with the latest prerelease Tenzir CLI.
- Fix existing Microsoft Graph examples so the new gate starts from a passing baseline.

## 💬 Review

- Check whether `tests/inputs/*.tql` is the right convention for TQL data fixtures.
- Check whether the syntax gate should stay prerelease-only or also run against the latest release channel.