### PR TITLE
Simplify nullable list spreads

### DIFF
--- a/alphamountain/operators/ocsf/map.tql
+++ b/alphamountain/operators/ocsf/map.tql
@@ -146,17 +146,17 @@ if _category_ids? != null {
 }
 
 osint.answers = [
-  ...(am.sections?.dns?.ipv4? else []).map(ip => {
+  ...am.sections?.dns?.ipv4?.map(ip => {
     class: "IN",
     type: "A",
     rdata: ip.string(),
   }),
-  ...(am.sections?.dns?.ipv6? else []).map(ip => {
+  ...am.sections?.dns?.ipv6?.map(ip => {
     class: "IN",
     type: "AAAA",
     rdata: ip.string(),
   }),
-  ...(am.sections?.pdns? else []).where(x => x.ip? != null).map(x => {
+  ...am.sections?.pdns?.where(x => x.ip? != null).map(x => {
     class: "IN",
     type: "A",
     rdata: x.ip.string(),

--- a/microsoft/operators/graph/ocsf/events/defender_incident.tql
+++ b/microsoft/operators/graph/ocsf/events/defender_incident.tql
@@ -67,8 +67,8 @@ if graph.priorityScore? != null {
 
 if graph.customTags? != null or graph.systemTags? != null {
   ocsf.metadata.labels = [
-    ...(move graph.customTags? else []),
-    ...(move graph.systemTags? else []),
+    ...move graph.customTags?,
+    ...move graph.systemTags?,
   ]
   if ocsf.metadata.labels.length() == 0 {
     drop ocsf.metadata.labels

--- a/slack/operators/alert.tql
+++ b/slack/operators/alert.tql
@@ -48,7 +48,7 @@ _slack_blocks = [
       type: "mrkdwn",
       text: f"*Severity:* {$severity}",
     }],
-  }] if $severity != null else []),
+  }] if $severity != null),
 ]
 select text=f"{$title}: {_slack_text}", thread_ts=$thread_ts, blocks=_slack_blocks
 each {


### PR DESCRIPTION
## 🔍 Problem

- TNZ-692 makes null list spread fragments empty and warning-free.
- A few library operators still carried explicit `else []` fallbacks around optional spread fragments.

## 🛠️ Solution

- Remove redundant empty-list fallbacks from nullable TQL spreads.
- Keep optional access in place so missing fields still resolve to null before spreading.

## 💬 Review

- Focus on the null-vs-missing boundary in the simplified spread expressions.
- Validated with the main-branch Tenzir binary via focused package tests and the full library suite.

<sub>
Docs PR: tenzir/docs#383<br>
Related: tenzir/tenzir#6258<br>
References TNZ-692
</sub>