### PR TITLE
Validate TQL with `--dump-ir` instead of `--dump-ast`

### DIFF
--- a/.github/scripts/check-tql-syntax.sh
+++ b/.github/scripts/check-tql-syntax.sh
@@ -1,19 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Validate TQL pipeline syntax with the prerelease Tenzir parser.
-# CI checks all tracked pipelines; pre-push uses --changed for files changed
-# since the merge base with the upstream branch.
+# Validate TQL syntax for tracked files with the prerelease Tenzir CLI.
+#
+# Example and test pipelines are complete pipelines, so we compile them all the
+# way to IR (--dump-ir), which resolves operators, their arguments, and
+# references on top of parsing. Operator definitions are parameterized templates
+# whose arguments only bind at the call site, so they cannot be compiled
+# standalone; we check their syntax with --dump-ast. They are still exercised
+# through IR by the test pipelines that call them.
+#
+# CI checks all tracked files; pre-push uses --changed for files changed since
+# the merge base with the upstream branch.
 
 parallelism="$(getconf _NPROCESSORS_ONLN 2>/dev/null || printf '8')"
 tenzir=(uvx --prerelease allow tenzir)
 
-# Skip data test inputs; they are fixtures, not pipelines.
-pipeline_files=('*.tql' ':!:*/tests/inputs/*.tql')
+# Loading the repository as a package directory lets IR resolve the
+# package-defined operators that examples and test pipelines reference.
+TENZIR_PACKAGE_DIRS="$(git rev-parse --show-toplevel)"
+export TENZIR_PACKAGE_DIRS
 
-list_all_files() {
-  git ls-files -z "${pipeline_files[@]}"
-}
+# Operator definitions: syntax-only check (templates can't compile standalone).
+operator_files=('*/operators/*.tql')
+# Examples and test pipelines: full IR compilation. Skip data test inputs; they
+# are fixtures, not pipelines.
+pipeline_files=('*.tql' ':!:*/tests/inputs/*.tql' ':!:*/operators/*.tql')
 
 base_ref() {
   git rev-parse --verify --quiet '@{upstream}' >/dev/null &&
@@ -22,28 +34,42 @@ base_ref() {
   git rev-parse --verify --quiet origin/HEAD >/dev/null && printf 'origin/HEAD\n'
 }
 
-list_changed_files() {
+list_files() {
+  if [[ "${changed}" != 1 ]]; then
+    git ls-files -z "$@"
+    return
+  fi
   local base ref
   ref="$(base_ref)" || {
-    list_all_files
+    git ls-files -z "$@"
     return
   }
   base="$(git merge-base HEAD "$ref")" || {
-    list_all_files
+    git ls-files -z "$@"
     return
   }
   # Check only local commits being pushed. On main, this means commits ahead of
   # origin/main; remote-only changes are not part of the pre-push check.
-  git diff --name-only -z --diff-filter=ACMRT "$base" HEAD -- \
-    "${pipeline_files[@]}"
+  git diff --name-only -z --diff-filter=ACMRT "$base" HEAD -- "$@"
 }
 
-files=()
-while IFS= read -r -d '' file; do
-  files+=("$file")
-done < <([[ "${1:-}" == "--changed" ]] && list_changed_files || list_all_files)
+# Run the given dump flag over all files matching the trailing pathspecs.
+check() {
+  local flag="$1"
+  shift
+  local files=()
+  while IFS= read -r -d '' file; do
+    files+=("$file")
+  done < <(list_files "$@")
+  ((${#files[@]} == 0)) && return 0
+  printf '%s\0' "${files[@]}" |
+    xargs -0 -n 1 -P "$parallelism" "${tenzir[@]}" "$flag" -f >/dev/null
+}
 
-((${#files[@]} == 0)) && exit 0
+changed=0
+[[ "${1:-}" == "--changed" ]] && changed=1
 
-printf '%s\0' "${files[@]}" |
-  xargs -0 -n 1 -P "$parallelism" "${tenzir[@]}" --dump-ast -f >/dev/null
+rc=0
+check --dump-ir "${pipeline_files[@]}" || rc=1
+check --dump-ast "${operator_files[@]}" || rc=1
+exit "$rc"

--- a/dcso/examples/tie.tql
+++ b/dcso/examples/tie.tql
@@ -6,7 +6,9 @@ description: |
 ---
 
 every 1h {
-  dcso::tie::fetch
+  dcso::tie::fetch \
+    api_user_secret=secret("DCSO_TIE_API_USER"),
+    api_key_secret=secret("DCSO_TIE_API_KEY")
 }
 dcso::tie::ocsf::map
 ocsf::derive

--- a/dcso/operators/tie/fetch.tql
+++ b/dcso/operators/tie/fetch.tql
@@ -19,9 +19,9 @@ let $api_user = $api_user_secret
 let $api_key = $api_key_secret
 let $auth = f"Basic {encode_base64($api_user + ":" + $api_key)}"
 let $headers = {Authorization: $auth}
-let $paginate = response => f"{$url}&next={response.next}" if response.hasMore
 
-from_http $url, headers=$headers, paginate=$paginate {
+from_http $url, headers=$headers,
+  paginate=(response => f"{$url}&next={response.next}" if response.hasMore) {
   // Using raw=true is a good as it gets right now until we have union
   // types. We need this because events shape-shift frequently, especially
   // within lists.

--- a/okta/examples/from-http.tql
+++ b/okta/examples/from-http.tql
@@ -6,6 +6,6 @@ description: >-
 
 let $domain = "example.okta.com"
 every 30s {
-  okta::fetch $domain
+  okta::fetch $domain, bearer_token=secret("OKTA_BEARER_TOKEN")
 }
 publish "okta"

--- a/okta/operators/fetch.tql
+++ b/okta/operators/fetch.tql
@@ -10,8 +10,10 @@ args:
      default: 200
    - name: bearer_token
      type: secret
+     default: null
    - name: swss_token
      type: secret
+     default: null
 ---
 
 // See:

--- a/splunk/examples/send_to_splunk.tql
+++ b/splunk/examples/send_to_splunk.tql
@@ -8,4 +8,4 @@ subscribe "splunk"
 to_splunk "https://localhost:8080",
   hec_token="SPLUNK_HEC_TOKEN",
   index="main",
-  skip_peer_verification=true
+  tls={skip_peer_verification: true}

--- a/zeek/examples/last-3-hour-volume.tql
+++ b/zeek/examples/last-3-hour-volume.tql
@@ -16,4 +16,4 @@ summarize \
   duration = duration.sum()
 chart_area \
   x=timestamp,
-  y={ingress_per_second: bytes / duration.as_secs()}
+  y={ingress_per_second: bytes / duration.count_seconds()}


### PR DESCRIPTION
## 🔍 Problem

- The TQL syntax gate from #151 only *parses* pipelines (`--dump-ast`), so it
  misses everything that surfaces during compilation: unknown
  operators/functions, wrong arguments, and unresolved references.

## 🛠️ Solution

- Compile example and test pipelines all the way to IR (`--dump-ir`), loading
  the repository as a package directory so package-defined operators resolve.
- Keep operator definitions on `--dump-ast`. They are parameterized templates
  whose arguments only bind at the call site, so they cannot compile
  standalone; they are still exercised through IR by the test pipelines that
  call them.
- Fix the pipelines the stronger gate flags (two were real bugs):
  - `dcso::tie::fetch`: inline the pagination lambda (IR rejects lambda-valued
    `let` bindings).
  - `okta::fetch`: default `bearer_token`/`swss_token` to null — the body
    already treats them as alternatives, but both were marked required.
  - splunk example: `to_splunk` has no `skip_peer_verification`; nest it under
    `tls={skip_peer_verification: true}`.
  - zeek example: replace the non-existent `duration.as_secs()` with
    `count_seconds()`.
  - dcso/okta examples: pass the secrets their operators require.

## 💬 Review

- No changelog entries: the dcso/okta operators are unreleased v6-port work
  (#147), and per #151 baseline fixes for the gate don't get entries.
- Operator templates can't be IR-validated standalone — confirm AST-only is
  acceptable for them (test pipelines provide the IR coverage).
