### PR TITLE
Scope package mappers to events

### DIFF
--- a/abusech/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/abusech/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,22 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:14.148769Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+```

--- a/abusech/operators/feodo/ocsf/map.tql
+++ b/abusech/operators/feodo/ocsf/map.tql
@@ -1,43 +1,49 @@
 ---
 description: Feodo Tracker rows → OCSF OSINT Inventory Info
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {feodo: this}
+$event = {...$event, feodo: $event, ocsf: {}}
 
-osint = {}
-osint.category = "botnet c2"
-osint.confidence_id = 3
-osint.created_time = time(feodo.first_seen_utc)
-drop feodo.first_seen_utc
-osint.malware = [{
+$event.osint = {}
+$event.osint.category = "botnet c2"
+$event.osint.confidence_id = 3
+$event.osint.created_time = time($event.feodo.first_seen_utc)
+drop $event.feodo.first_seen_utc
+$event.osint.malware = [{
   classification_ids: [0],
-  name: move feodo.malware,
+  name: move $event.feodo.malware,
   provider: "Feodo Tracker",
 }]
-osint.severity_id = 4
-osint.src_url = "https://feodotracker.abuse.ch/downloads/ipblocklist_aggressive.csv"
-osint.type_id = 1
-osint.value = string(move feodo.dst_ip)
-osint.vendor_name = "abuse.ch"
+$event.osint.severity_id = 4
+$event.osint.src_url = "https://feodotracker.abuse.ch/downloads/ipblocklist_aggressive.csv"
+$event.osint.type_id = 1
+$event.osint.value = string(move $event.feodo.dst_ip)
+$event.osint.vendor_name = "abuse.ch"
 
-ocsf = {}
-ocsf.activity_id = 2
-ocsf.actor = {
+$event.ocsf = {}
+$event.ocsf.activity_id = 2
+$event.ocsf.actor = {
   app_name: "Tenzir",
 }
-ocsf.category_uid = 5
-ocsf.class_uid = 5021
-ocsf.metadata = {
+$event.ocsf.category_uid = 5
+$event.ocsf.class_uid = 5021
+$event.ocsf.metadata = {
   product: {
     name: "Feodo Tracker",
     vendor_name: "abuse.ch",
   },
   version: "1.8.0",
 }
-ocsf.osint = [move osint]
-ocsf.severity_id = 1
-ocsf.time = ocsf.osint[0].created_time
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.osint = [move $event.osint]
+$event.ocsf.severity_id = 1
+$event.ocsf.time = $event.ocsf.osint[0].created_time
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-this = {...ocsf, unmapped: feodo}
+$event = {...$event.ocsf, unmapped: $event.feodo}
 @name = "ocsf.osint_inventory_info"

--- a/abusech/operators/malwarebazaar/ocsf/map.tql
+++ b/abusech/operators/malwarebazaar/ocsf/map.tql
@@ -1,80 +1,86 @@
 ---
 description: MalwareBazaar samples → OCSF OSINT Inventory Info
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {mb: this}
+$event = {...$event, mb: $event, ocsf: {}}
 
-file = {}
-file.hashes = [
-  {algorithm_id: 1, value: mb.md5_hash} if mb.md5_hash? != null else null,
-  {algorithm_id: 2, value: mb.sha1_hash} if mb.sha1_hash? != null else null,
-  {algorithm_id: 3, value: mb.sha256_hash} if mb.sha256_hash? != null else null,
-  {algorithm_id: 5, value: mb.ssdeep} if mb.ssdeep? != null else null,
-  {algorithm_id: 6, value: mb.tlsh} if mb.tlsh? != null else null,
-  {algorithm_id: 14, value: mb.sha3_384_hash} if mb.sha3_384_hash? != null else null,
-  {algorithm_id: 18, value: mb.imphash} if mb.imphash? != null else null,
+$event.file = {}
+$event.file.hashes = [
+  {algorithm_id: 1, value: $event.mb.md5_hash} if $event.mb.md5_hash? != null else null,
+  {algorithm_id: 2, value: $event.mb.sha1_hash} if $event.mb.sha1_hash? != null else null,
+  {algorithm_id: 3, value: $event.mb.sha256_hash} if $event.mb.sha256_hash? != null else null,
+  {algorithm_id: 5, value: $event.mb.ssdeep} if $event.mb.ssdeep? != null else null,
+  {algorithm_id: 6, value: $event.mb.tlsh} if $event.mb.tlsh? != null else null,
+  {algorithm_id: 14, value: $event.mb.sha3_384_hash} if $event.mb.sha3_384_hash? != null else null,
+  {algorithm_id: 18, value: $event.mb.imphash} if $event.mb.imphash? != null else null,
 ].collect()
-file.ext = move mb.file_type?
-file.mime_type = move mb.file_type_mime?
-file.name = move mb.file_name? else mb.sha256_hash
-file.size = move mb.file_size?
-file.type_id = 1
+$event.file.ext = move $event.mb.file_type?
+$event.file.mime_type = move $event.mb.file_type_mime?
+$event.file.name = move $event.mb.file_name? else $event.mb.sha256_hash
+$event.file.size = move $event.mb.file_size?
+$event.file.type_id = 1
 
-osint = {}
-osint.category = "malware sample"
-osint.confidence_id = 3
-osint.created_time = time(mb.first_seen)
-drop mb.first_seen
-if mb.last_seen? != null {
-  osint.modified_time = time(mb.last_seen)
-  drop mb.last_seen
+$event.osint = {}
+$event.osint.category = "malware sample"
+$event.osint.confidence_id = 3
+$event.osint.created_time = time($event.mb.first_seen)
+drop $event.mb.first_seen
+if $event.mb.last_seen? != null {
+  $event.osint.modified_time = time($event.mb.last_seen)
+  drop $event.mb.last_seen
 }
-if mb.reporter? != null {
-  osint.creator = {
-    name: move mb.reporter,
+if $event.mb.reporter? != null {
+  $event.osint.creator = {
+    name: move $event.mb.reporter,
   }
 }
-if mb.signature? != null {
-  osint.malware = [{
+if $event.mb.signature? != null {
+  $event.osint.malware = [{
     classification_ids: [0],
-    name: move mb.signature,
+    name: move $event.mb.signature,
     provider: "MalwareBazaar",
   }]
 }
-osint.file = move file
-osint.labels = move mb.tags?
-osint.severity_id = 4
-osint.src_url = "https://bazaar.abuse.ch/sample/" + mb.sha256_hash
-osint.type_id = 4
-osint.value = mb.sha256_hash
-osint.vendor_name = "abuse.ch"
+$event.osint.file = move $event.file
+$event.osint.labels = move $event.mb.tags?
+$event.osint.severity_id = 4
+$event.osint.src_url = "https://bazaar.abuse.ch/sample/" + $event.mb.sha256_hash
+$event.osint.type_id = 4
+$event.osint.value = $event.mb.sha256_hash
+$event.osint.vendor_name = "abuse.ch"
 
-drop mb.md5_hash?,
-     mb.sha1_hash?,
-     mb.sha256_hash?,
-     mb.ssdeep?,
-     mb.tlsh?,
-     mb.sha3_384_hash?,
-     mb.imphash?
+drop $event.mb.md5_hash?,
+     $event.mb.sha1_hash?,
+     $event.mb.sha256_hash?,
+     $event.mb.ssdeep?,
+     $event.mb.tlsh?,
+     $event.mb.sha3_384_hash?,
+     $event.mb.imphash?
 
-ocsf = {}
-ocsf.activity_id = 2
-ocsf.actor = {
+$event.ocsf = {}
+$event.ocsf.activity_id = 2
+$event.ocsf.actor = {
   app_name: "Tenzir",
 }
-ocsf.category_uid = 5
-ocsf.class_uid = 5021
-ocsf.metadata = {
+$event.ocsf.category_uid = 5
+$event.ocsf.class_uid = 5021
+$event.ocsf.metadata = {
   product: {
     name: "MalwareBazaar",
     vendor_name: "abuse.ch",
   },
   version: "1.8.0",
 }
-ocsf.osint = [move osint]
-ocsf.severity_id = 1
-ocsf.time = ocsf.osint[0].created_time
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.osint = [move $event.osint]
+$event.ocsf.severity_id = 1
+$event.ocsf.time = $event.ocsf.osint[0].created_time
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-this = {...ocsf, unmapped: mb}
+$event = {...$event.ocsf, unmapped: $event.mb}
 @name = "ocsf.osint_inventory_info"

--- a/abusech/operators/sslbl/ocsf/map.tql
+++ b/abusech/operators/sslbl/ocsf/map.tql
@@ -1,38 +1,44 @@
 ---
 description: SSLBL rows → OCSF OSINT Inventory Info
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {sslbl: this}
+$event = {...$event, sslbl: $event, ocsf: {}}
 
-osint = {}
-osint.category = move sslbl.reason
-osint.confidence_id = 3
-osint.created_time = time(sslbl.timestamp)
-drop sslbl.timestamp
-osint.severity_id = 4
-osint.src_url = "https://sslbl.abuse.ch/blacklist/sslblacklist.csv"
-osint.type_id = 7
-osint.value = move sslbl.SHA1
-osint.vendor_name = "abuse.ch"
+$event.osint = {}
+$event.osint.category = move $event.sslbl.reason
+$event.osint.confidence_id = 3
+$event.osint.created_time = time($event.sslbl.timestamp)
+drop $event.sslbl.timestamp
+$event.osint.severity_id = 4
+$event.osint.src_url = "https://sslbl.abuse.ch/blacklist/sslblacklist.csv"
+$event.osint.type_id = 7
+$event.osint.value = move $event.sslbl.SHA1
+$event.osint.vendor_name = "abuse.ch"
 
-ocsf = {}
-ocsf.activity_id = 2
-ocsf.actor = {
+$event.ocsf = {}
+$event.ocsf.activity_id = 2
+$event.ocsf.actor = {
   app_name: "Tenzir",
 }
-ocsf.category_uid = 5
-ocsf.class_uid = 5021
-ocsf.metadata = {
+$event.ocsf.category_uid = 5
+$event.ocsf.class_uid = 5021
+$event.ocsf.metadata = {
   product: {
     name: "SSLBL",
     vendor_name: "abuse.ch",
   },
   version: "1.8.0",
 }
-ocsf.osint = [move osint]
-ocsf.severity_id = 1
-ocsf.time = ocsf.osint[0].created_time
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.osint = [move $event.osint]
+$event.ocsf.severity_id = 1
+$event.ocsf.time = $event.ocsf.osint[0].created_time
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-this = {...ocsf, unmapped: sslbl}
+$event = {...$event.ocsf, unmapped: $event.sslbl}
 @name = "ocsf.osint_inventory_info"

--- a/abusech/operators/threatfox/ocsf/map.tql
+++ b/abusech/operators/threatfox/ocsf/map.tql
@@ -1,8 +1,14 @@
 ---
 description: ThreatFox indicators → OCSF OSINT Inventory Info
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {threatfox: this}
+$event = {...$event, threatfox: $event, ocsf: {}}
 
 let $type_ids = {
   domain: 2,
@@ -15,68 +21,68 @@ let $type_ids = {
   url: 5,
 }
 
-osint = {}
-if threatfox.confidence_level? != null {
-  match threatfox.confidence_level {
+$event.osint = {}
+if $event.threatfox.confidence_level? != null {
+  match $event.threatfox.confidence_level {
     -1..30 => {
-      osint.confidence_id = 1
+      $event.osint.confidence_id = 1
     }
     29..70 => {
-      osint.confidence_id = 2
+      $event.osint.confidence_id = 2
     }
     _ => {
-      osint.confidence_id = 3
+      $event.osint.confidence_id = 3
     }
   }
-  osint.risk_score = move threatfox.confidence_level
+  $event.osint.risk_score = move $event.threatfox.confidence_level
 }
-if threatfox.first_seen? != null {
-  osint.created_time = parse_time(threatfox.first_seen, "%Y-%m-%d %H:%M:%S UTC")
-  drop threatfox.first_seen
+if $event.threatfox.first_seen? != null {
+  $event.osint.created_time = parse_time($event.threatfox.first_seen, "%Y-%m-%d %H:%M:%S UTC")
+  drop $event.threatfox.first_seen
 }
-if threatfox.last_seen? != null {
-  osint.modified_time = parse_time(threatfox.last_seen, "%Y-%m-%d %H:%M:%S UTC")
-  drop threatfox.last_seen
+if $event.threatfox.last_seen? != null {
+  $event.osint.modified_time = parse_time($event.threatfox.last_seen, "%Y-%m-%d %H:%M:%S UTC")
+  drop $event.threatfox.last_seen
 }
-if threatfox.malware_printable? != null or threatfox.malware? != null {
-  osint.malware = [{
+if $event.threatfox.malware_printable? != null or $event.threatfox.malware? != null {
+  $event.osint.malware = [{
     classification_ids: [0],
-    name: move threatfox.malware_printable? else move threatfox.malware?,
+    name: move $event.threatfox.malware_printable? else move $event.threatfox.malware?,
     provider: "ThreatFox",
   }]
 }
-osint.category = move threatfox.threat_type?
-osint.desc = move threatfox.threat_type_desc?
-osint.labels = move threatfox.tags?
-osint.references = [move threatfox.reference] if threatfox.reference? != null else null
-osint.src_url = "https://threatfox.abuse.ch/ioc/" + encode_url(threatfox.ioc)
-osint.type_id = $type_ids[threatfox.ioc_type]? else 99
-if osint.type_id == 99 {
-  osint.type = move threatfox.ioc_type
+$event.osint.category = move $event.threatfox.threat_type?
+$event.osint.desc = move $event.threatfox.threat_type_desc?
+$event.osint.labels = move $event.threatfox.tags?
+$event.osint.references = [move $event.threatfox.reference] if $event.threatfox.reference? != null else null
+$event.osint.src_url = "https://threatfox.abuse.ch/ioc/" + encode_url($event.threatfox.ioc)
+$event.osint.type_id = $type_ids[$event.threatfox.ioc_type]? else 99
+if $event.osint.type_id == 99 {
+  $event.osint.type = move $event.threatfox.ioc_type
 } else {
-  drop threatfox.ioc_type
+  drop $event.threatfox.ioc_type
 }
-osint.value = move threatfox.ioc
-osint.vendor_name = "abuse.ch"
+$event.osint.value = move $event.threatfox.ioc
+$event.osint.vendor_name = "abuse.ch"
 
-ocsf = {}
-ocsf.activity_id = 2
-ocsf.actor = {
+$event.ocsf = {}
+$event.ocsf.activity_id = 2
+$event.ocsf.actor = {
   app_name: "Tenzir",
 }
-ocsf.category_uid = 5
-ocsf.class_uid = 5021
-ocsf.metadata = {
+$event.ocsf.category_uid = 5
+$event.ocsf.class_uid = 5021
+$event.ocsf.metadata = {
   product: {
     name: "ThreatFox",
     vendor_name: "abuse.ch",
   },
   version: "1.8.0",
 }
-ocsf.osint = [move osint]
-ocsf.severity_id = 1
-ocsf.time = ocsf.osint[0].created_time? else now()
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.osint = [move $event.osint]
+$event.ocsf.severity_id = 1
+$event.ocsf.time = $event.ocsf.osint[0].created_time? else now()
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-this = {...ocsf, unmapped: threatfox}
+$event = {...$event.ocsf, unmapped: $event.threatfox}
 @name = "ocsf.osint_inventory_info"

--- a/abusech/operators/urlhaus/ocsf/map.tql
+++ b/abusech/operators/urlhaus/ocsf/map.tql
@@ -1,56 +1,62 @@
 ---
 description: URLhaus rows → OCSF OSINT Inventory Info
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {urlhaus: this}
+$event = {...$event, urlhaus: $event, ocsf: {}}
 
-osint = {}
-osint.category = move urlhaus.threat?
-osint.confidence_id = 3
-osint.created_time = time(urlhaus.dateadded)
-drop urlhaus.dateadded
-osint.external_uid = string(move urlhaus.id)
-if urlhaus.last_online? != null {
-  osint.modified_time = time(urlhaus.last_online)
-  drop urlhaus.last_online
+$event.osint = {}
+$event.osint.category = move $event.urlhaus.threat?
+$event.osint.confidence_id = 3
+$event.osint.created_time = time($event.urlhaus.dateadded)
+drop $event.urlhaus.dateadded
+$event.osint.external_uid = string(move $event.urlhaus.id)
+if $event.urlhaus.last_online? != null {
+  $event.osint.modified_time = time($event.urlhaus.last_online)
+  drop $event.urlhaus.last_online
 }
-if urlhaus.reporter? != null {
-  osint.creator = {
-    name: move urlhaus.reporter,
+if $event.urlhaus.reporter? != null {
+  $event.osint.creator = {
+    name: move $event.urlhaus.reporter,
   }
 }
-if urlhaus.tags? != null {
-  osint.labels = (move urlhaus.tags).split(",")
+if $event.urlhaus.tags? != null {
+  $event.osint.labels = (move $event.urlhaus.tags).split(",")
 }
-if urlhaus.urlhaus_link? != null {
-  osint.references = [urlhaus.urlhaus_link]
-  osint.src_url = move urlhaus.urlhaus_link
+if $event.urlhaus.urlhaus_link? != null {
+  $event.osint.references = [$event.urlhaus.urlhaus_link]
+  $event.osint.src_url = move $event.urlhaus.urlhaus_link
 } else {
-  osint.src_url = "https://urlhaus.abuse.ch/"
+  $event.osint.src_url = "https://urlhaus.abuse.ch/"
 }
-osint.severity_id = 4
-osint.type_id = 5
-osint.value = move urlhaus.url
-osint.vendor_name = "abuse.ch"
+$event.osint.severity_id = 4
+$event.osint.type_id = 5
+$event.osint.value = move $event.urlhaus.url
+$event.osint.vendor_name = "abuse.ch"
 
-ocsf = {}
-ocsf.activity_id = 2
-ocsf.actor = {
+$event.ocsf = {}
+$event.ocsf.activity_id = 2
+$event.ocsf.actor = {
   app_name: "Tenzir",
 }
-ocsf.category_uid = 5
-ocsf.class_uid = 5021
-ocsf.metadata = {
+$event.ocsf.category_uid = 5
+$event.ocsf.class_uid = 5021
+$event.ocsf.metadata = {
   product: {
     name: "URLhaus",
     vendor_name: "abuse.ch",
   },
   version: "1.8.0",
 }
-ocsf.osint = [move osint]
-ocsf.severity_id = 1
-ocsf.time = ocsf.osint[0].created_time
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.osint = [move $event.osint]
+$event.ocsf.severity_id = 1
+$event.ocsf.time = $event.ocsf.osint[0].created_time
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-this = {...ocsf, unmapped: urlhaus}
+$event = {...$event.ocsf, unmapped: $event.urlhaus}
 @name = "ocsf.osint_inventory_info"

--- a/alphamountain/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/alphamountain/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,22 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:14.936978Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+```

--- a/alphamountain/operators/ocsf/map.tql
+++ b/alphamountain/operators/ocsf/map.tql
@@ -1,229 +1,235 @@
 ---
 description: alphaMountain rows to OCSF OSINT Inventory Info.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {am: this}
+$event = {...$event, am: $event, ocsf: {}}
 
-osint = {
+$event.osint = {
   src_url: "https://www.alphamountain.ai/api/",
   vendor_name: "alphaMountain",
 }
 
-if am.uri? != null {
-  osint.value = move am.uri
-  osint.type_id = 5
-} else if am.hostname? != null {
-  osint.value = move am.hostname
-  osint.type_id = 2
-} else if am.domain? != null {
-  osint.value = move am.domain
-  osint.type_id = 2
-} else if am.sections?.whois?.domain? != null {
-  osint.value = am.sections.whois.domain
-  osint.type_id = 2
-} else if am.url? != null {
-  osint.value = move am.url
-  osint.type_id = 5
+if $event.am.uri? != null {
+  $event.osint.value = move $event.am.uri
+  $event.osint.type_id = 5
+} else if $event.am.hostname? != null {
+  $event.osint.value = move $event.am.hostname
+  $event.osint.type_id = 2
+} else if $event.am.domain? != null {
+  $event.osint.value = move $event.am.domain
+  $event.osint.type_id = 2
+} else if $event.am.sections?.whois?.domain? != null {
+  $event.osint.value = $event.am.sections.whois.domain
+  $event.osint.type_id = 2
+} else if $event.am.url? != null {
+  $event.osint.value = move $event.am.url
+  $event.osint.type_id = 5
 } else {
-  osint.type_id = 0
+  $event.osint.type_id = 0
 }
-if osint.value? != null {
-  _ip = ip(osint.value)
-  if _ip? != null {
-    osint.value = _ip.string()
-    osint.type_id = 1
+if $event.osint.value? != null {
+  $event._ip = ip($event.osint.value)
+  if $event._ip? != null {
+    $event.osint.value = $event._ip.string()
+    $event.osint.type_id = 1
   }
-  drop _ip
+  drop $event._ip
 }
 
-if am.score? != null {
-  _score = move am.score
-} else if am.threat?.score? != null {
-  _score = move am.threat.score
-} else if am.sections?.threat?.score? != null {
-  _score = move am.sections.threat.score
+if $event.am.score? != null {
+  $event._score = move $event.am.score
+} else if $event.am.threat?.score? != null {
+  $event._score = move $event.am.threat.score
+} else if $event.am.sections?.threat?.score? != null {
+  $event._score = move $event.am.sections.threat.score
 }
 
-if _score? != null {
-  osint.reputation = {
-    base_score: _score,
+if $event._score? != null {
+  $event.osint.reputation = {
+    base_score: $event._score,
     provider: "alphaMountain",
   }
 
-  _score_floor = _score.int()
-  match _score_floor {
+  $event._score_floor = $event._score.int()
+  match $event._score_floor {
     9 | 10 => {
-      osint.reputation.score_id = 10
+      $event.osint.reputation.score_id = 10
     }
     8 => {
-      osint.reputation.score_id = 9
+      $event.osint.reputation.score_id = 9
     }
     7 => {
-      osint.reputation.score_id = 8
+      $event.osint.reputation.score_id = 8
     }
     6 => {
-      osint.reputation.score_id = 7
+      $event.osint.reputation.score_id = 7
     }
     5 => {
-      osint.reputation.score_id = 6
+      $event.osint.reputation.score_id = 6
     }
     4 => {
-      osint.reputation.score_id = 5
+      $event.osint.reputation.score_id = 5
     }
     3 => {
-      osint.reputation.score_id = 4
+      $event.osint.reputation.score_id = 4
     }
     2 => {
-      osint.reputation.score_id = 3
+      $event.osint.reputation.score_id = 3
     }
-    0 | 1 if _score > 0 => {
-      osint.reputation.score_id = 2
+    0 | 1 if $event._score > 0 => {
+      $event.osint.reputation.score_id = 2
     }
     _ => {
-      osint.reputation.score_id = 1
+      $event.osint.reputation.score_id = 1
     }
   }
 
-  osint.risk_score = _score.round().int()
-  match _score_floor {
+  $event.osint.risk_score = $event._score.round().int()
+  match $event._score_floor {
     8 | 9 | 10 => {
-      osint.severity_id = 4
+      $event.osint.severity_id = 4
     }
     6 | 7 => {
-      osint.severity_id = 3
+      $event.osint.severity_id = 3
     }
     3 | 4 | 5 => {
-      osint.severity_id = 2
+      $event.osint.severity_id = 2
     }
     _ => {
-      osint.severity_id = 1
+      $event.osint.severity_id = 1
     }
   }
-  drop _score_floor
-  drop _score
+  drop $event._score_floor
+  drop $event._score
 }
 
-if am.confidence? != null {
-  _confidence = move am.confidence
-} else if am.category?.confidence? != null {
-  _confidence = move am.category.confidence
-} else if am.sections?.category?.confidence? != null {
-  _confidence = move am.sections.category.confidence
+if $event.am.confidence? != null {
+  $event._confidence = move $event.am.confidence
+} else if $event.am.category?.confidence? != null {
+  $event._confidence = move $event.am.category.confidence
+} else if $event.am.sections?.category?.confidence? != null {
+  $event._confidence = move $event.am.sections.category.confidence
 }
 
-if _confidence? != null {
-  _confidence_decile = (_confidence * 10).int()
-  match _confidence_decile {
+if $event._confidence? != null {
+  $event._confidence_decile = ($event._confidence * 10).int()
+  match $event._confidence_decile {
     8 | 9 | 10 => {
-      osint.confidence_id = 3
+      $event.osint.confidence_id = 3
     }
     5 | 6 | 7 => {
-      osint.confidence_id = 2
+      $event.osint.confidence_id = 2
     }
     _ => {
-      osint.confidence_id = 1
+      $event.osint.confidence_id = 1
     }
   }
-  drop _confidence_decile
-  drop _confidence
+  drop $event._confidence_decile
+  drop $event._confidence
 }
 
-if am.category_ids? != null {
-  _category_ids = move am.category_ids
-  osint.labels = move am.category_labels?
-} else if am.categories? != null {
-  _category_ids = move am.categories
-} else if am.category?.categories? != null {
-  _category_ids = move am.category.categories
-} else if am.sections?.category?.categories? != null {
-  _category_ids = move am.sections.category.categories
+if $event.am.category_ids? != null {
+  $event._category_ids = move $event.am.category_ids
+  $event.osint.labels = move $event.am.category_labels?
+} else if $event.am.categories? != null {
+  $event._category_ids = move $event.am.categories
+} else if $event.am.category?.categories? != null {
+  $event._category_ids = move $event.am.category.categories
+} else if $event.am.sections?.category?.categories? != null {
+  $event._category_ids = move $event.am.sections.category.categories
 }
 
-if _category_ids? != null {
-  osint.category = _category_ids.map(id => id.string()).join(",")
-  osint.labels = osint.labels? else _category_ids.map(id => f"alphaMountain category {id}")
-  drop _category_ids
+if $event._category_ids? != null {
+  $event.osint.category = $event._category_ids.map(id => id.string()).join(",")
+  $event.osint.labels = $event.osint.labels? else $event._category_ids.map(id => f"alphaMountain category {id}")
+  drop $event._category_ids
 }
 
-osint.answers = [
-  ...am.sections?.dns?.ipv4?.map(ip => {
+$event.osint.answers = [
+  ...$event.am.sections?.dns?.ipv4?.map(ip => {
     class: "IN",
     type: "A",
     rdata: ip.string(),
   }),
-  ...am.sections?.dns?.ipv6?.map(ip => {
+  ...$event.am.sections?.dns?.ipv6?.map(ip => {
     class: "IN",
     type: "AAAA",
     rdata: ip.string(),
   }),
-  ...am.sections?.pdns?.where(x => x.ip? != null).map(x => {
+  ...$event.am.sections?.pdns?.where(x => x.ip? != null).map(x => {
     class: "IN",
     type: "A",
     rdata: x.ip.string(),
   }),
 ]
-if osint.answers.length() == 0 {
-  drop osint.answers
+if $event.osint.answers.length() == 0 {
+  drop $event.osint.answers
 }
 
-if am.sections?.geo?.ipv4? != null and am.sections.geo.ipv4.length() > 0 {
-  _geo = am.sections.geo.ipv4[0]
-  osint.location = {
-    country: _geo.isoCode,
-    lat: _geo.latLng[0],
-    long: _geo.latLng[1],
+if $event.am.sections?.geo?.ipv4? != null and $event.am.sections.geo.ipv4.length() > 0 {
+  $event._geo = $event.am.sections.geo.ipv4[0]
+  $event.osint.location = {
+    country: $event._geo.isoCode,
+    lat: $event._geo.latLng[0],
+    long: $event._geo.latLng[1],
     provider: "alphaMountain",
   }
-  if _geo.asn? != null {
-    osint.autonomous_system = {
-      number: _geo.asn.number,
-      name: _geo.asn.organization,
+  if $event._geo.asn? != null {
+    $event.osint.autonomous_system = {
+      number: $event._geo.asn.number,
+      name: $event._geo.asn.organization,
     }
   }
-  drop _geo
+  drop $event._geo
 }
 
-if am.sections?.whois? != null {
-  osint.whois = {
-    domain: move am.sections.whois.domain?,
-    registrar: move am.sections.whois.registrar?,
-    created_time: time(move am.sections.whois.created?),
-    last_seen_time: time(move am.sections.whois.updated?),
+if $event.am.sections?.whois? != null {
+  $event.osint.whois = {
+    domain: move $event.am.sections.whois.domain?,
+    registrar: move $event.am.sections.whois.registrar?,
+    created_time: time(move $event.am.sections.whois.created?),
+    last_seen_time: time(move $event.am.sections.whois.updated?),
   }
-  osint.expiration_time = time(move am.sections.whois.expires?)
+  $event.osint.expiration_time = time(move $event.am.sections.whois.expires?)
 }
 
-if osint.severity_id? == null {
-  osint.severity_id = 1
+if $event.osint.severity_id? == null {
+  $event.osint.severity_id = 1
 }
-if osint.confidence_id? == null {
-  osint.confidence_id = 0
+if $event.osint.confidence_id? == null {
+  $event.osint.confidence_id = 0
 }
 
-ocsf = {}
-ocsf.activity_id = 2
-ocsf.actor = {
+$event.ocsf = {}
+$event.ocsf.activity_id = 2
+$event.ocsf.actor = {
   app_name: "Tenzir",
 }
-ocsf.category_uid = 5
-ocsf.class_uid = 5021
-ocsf.metadata = {
+$event.ocsf.category_uid = 5
+$event.ocsf.class_uid = 5021
+$event.ocsf.metadata = {
   product: {
     name: "alphaMountain API",
     vendor_name: "alphaMountain",
   },
   version: "1.8.0",
 }
-ocsf.osint = [move osint]
-ocsf.severity_id = 1
-if (am.has("score") and am.score == null) or
-   (am.has("categories") and am.categories == null) {
-  ocsf.status_id = 99
-  ocsf.status = "Removed"
-  ocsf.status_detail = "alphaMountain feed removal"
+$event.ocsf.osint = [move $event.osint]
+$event.ocsf.severity_id = 1
+if ($event.am.has("score") and $event.am.score == null) or
+   ($event.am.has("categories") and $event.am.categories == null) {
+  $event.ocsf.status_id = 99
+  $event.ocsf.status = "Removed"
+  $event.ocsf.status_detail = "alphaMountain feed removal"
 }
-ocsf.time = now()
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.time = now()
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-this = {...ocsf, unmapped: am}
+$event = {...$event.ocsf, unmapped: $event.am}
 @name = "ocsf.osint_inventory_info"

--- a/amazon/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/amazon/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,25 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:00.996294Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+amazon::vpc_flow::ocsf::map vpc_flow, raw=message
+```
+
+After:
+
+```tql
+amazon::vpc_flow::ocsf::map event=vpc_flow
+vpc_flow.raw_data = move message
+vpc_flow.raw_data_size = vpc_flow.raw_data.length_bytes()
+this = vpc_flow
+```

--- a/amazon/examples/vpc-flow-cloudwatch-to-s3.tql
+++ b/amazon/examples/vpc-flow-cloudwatch-to-s3.tql
@@ -15,7 +15,10 @@ from_amazon_cloudwatch $log_group,
   start=now() - 1h,
   end=now()
 amazon::vpc_flow::parse_v7_ecs field=message, into=vpc_flow
-amazon::vpc_flow::ocsf::map vpc_flow, raw=message
+amazon::vpc_flow::ocsf::map event=vpc_flow
+vpc_flow.raw_data = move message
+vpc_flow.raw_data_size = vpc_flow.raw_data.length_bytes()
+this = vpc_flow
 ocsf::derive
 ocsf::cast
 region = cloud.region if cloud.region != null else $region

--- a/amazon/examples/vpc-flow-to-ocsf.tql
+++ b/amazon/examples/vpc-flow-to-ocsf.tql
@@ -7,6 +7,6 @@ description: |
 
 subscribe "amazon"
 where @name == "amazon.vpc_flow"
-amazon::vpc_flow::ocsf::map this
+amazon::vpc_flow::ocsf::map
 ocsf::derive
 publish "ocsf"

--- a/amazon/examples/vpc-flow-to-security-lake.tql
+++ b/amazon/examples/vpc-flow-to-security-lake.tql
@@ -15,7 +15,10 @@ from_amazon_cloudwatch $log_group,
   mode="live",
   aws_region=$region
 amazon::vpc_flow::parse_v7_ecs field=message, into=vpc_flow
-amazon::vpc_flow::ocsf::map vpc_flow, raw=message
+amazon::vpc_flow::ocsf::map event=vpc_flow
+vpc_flow.raw_data = move message
+vpc_flow.raw_data_size = vpc_flow.raw_data.length_bytes()
+this = vpc_flow
 ocsf::derive
 ocsf::cast
 amazon::security_lake::cast

--- a/amazon/operators/route53/ocsf/map.tql
+++ b/amazon/operators/route53/ocsf/map.tql
@@ -5,15 +5,11 @@ description: |
   Transforms Route53 Resolver Query Log events into OCSF-compliant DNS Activity
   events with support for DNS Firewall rule dispositions.
 args:
-  positional:
-    - name: event
-      type: field
-      description: Parsed Route53 Resolver Query Log record.
   named:
-    - name: raw
+    - name: event
+      description: The field that holds the event to map.
       type: field
-      default: null
-      description: Raw Route53 Resolver Query Log record to preserve in OCSF `raw_data`.
+      default: this
 ---
 
 // --- Constants --------------------------------
@@ -66,39 +62,32 @@ let $firewall_actions = {
 
 // --- Preamble ---------------------------------
 
-ocsf = {}
-
-if $raw != null {
-  ocsf.raw_data = $raw
-  ocsf.raw_data_size = $raw.length_bytes()
-}
-
 where $event != null
-route53 = $event
+$event = {...$event, route53: $event, ocsf: {}}
 
 // --- OCSF: classification attributes ----------
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4003
-ocsf.severity_id = 1
-ocsf.activity_id = 6
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4003
+$event.ocsf.severity_id = 1
+$event.ocsf.activity_id = 6
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.cloud = {
+$event.ocsf.cloud = {
   account: {
-    uid: move route53.account_id?,
+    uid: move $event.route53.account_id?,
   },
-  region: move route53.region?,
+  region: move $event.route53.region?,
   provider: "AWS",
 }
 
-ocsf.metadata = {
+$event.ocsf.metadata = {
   product: {
     name: "Amazon Route 53",
     vendor_name: "AWS",
-    version: route53.version?.string(),
+    version: $event.route53.version?.string(),
     feature: {
       name: "Resolver Query Logs",
     },
@@ -106,100 +95,100 @@ ocsf.metadata = {
   version: "1.8.0",
   profiles: ["cloud"],
 }
-drop route53.version?
+drop $event.route53.version?
 
 // --- OCSF: occurrence attributes --------------
 
-ocsf.time = move route53.query_timestamp?
-ocsf.query_time = ocsf.time
+$event.ocsf.time = move $event.route53.query_timestamp?
+$event.ocsf.query_time = $event.ocsf.time
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.query = {
-  hostname: move route53.query_name?,
-  type: move route53.query_type?,
-  class: move route53.query_class?,
+$event.ocsf.query = {
+  hostname: move $event.route53.query_name?,
+  type: move $event.route53.query_type?,
+  class: move $event.route53.query_class?,
 }
 
-if route53.has("answers") and route53.answers.length() > 0 {
-  ocsf.answers = (move route53.answers).map(a => {
+if $event.route53.has("answers") and $event.route53.answers.length() > 0 {
+  $event.ocsf.answers = (move $event.route53.answers).map(a => {
     rdata: string(a.Rdata),
     type: a.Type,
     class: a.Class,
   })
-  ocsf.response_time = ocsf.time
+  $event.ocsf.response_time = $event.ocsf.time
 } else {
-  drop route53.answers?
+  drop $event.route53.answers?
 }
 
 // Map DNS response codes to OCSF rcode_id values.
-if route53.has("rcode") {
-  ocsf.rcode_id = $rcode_id[route53.rcode] else 99
-  if ocsf.rcode_id == 99 {
-    ocsf.rcode = move route53.rcode
+if $event.route53.has("rcode") {
+  $event.ocsf.rcode_id = $rcode_id[$event.route53.rcode] else 99
+  if $event.ocsf.rcode_id == 99 {
+    $event.ocsf.rcode = move $event.route53.rcode
   } else {
-    drop route53.rcode
+    drop $event.route53.rcode
   }
-  ocsf.status_id = 1 if ocsf.rcode_id == 0 else 2
+  $event.ocsf.status_id = 1 if $event.ocsf.rcode_id == 0 else 2
 } else {
-  ocsf.status_id = 0
+  $event.ocsf.status_id = 0
 }
 
 // --- OCSF: network attributes -----------------
 
-if route53.has("srcaddr") {
-  ocsf.src_endpoint.ip = ip(move route53.srcaddr)
-  ocsf.connection_info.protocol_ver_id = 6 if ocsf.src_endpoint.ip.is_v6() else 4
+if $event.route53.has("srcaddr") {
+  $event.ocsf.src_endpoint.ip = ip(move $event.route53.srcaddr)
+  $event.ocsf.connection_info.protocol_ver_id = 6 if $event.ocsf.src_endpoint.ip.is_v6() else 4
 }
-if route53.has("srcport") {
-  ocsf.src_endpoint.port = int(move route53.srcport)
+if $event.route53.has("srcport") {
+  $event.ocsf.src_endpoint.port = int(move $event.route53.srcport)
 }
-if route53.has("vpc_id") {
-  ocsf.src_endpoint.vpc_uid = move route53.vpc_id
+if $event.route53.has("vpc_id") {
+  $event.ocsf.src_endpoint.vpc_uid = move $event.route53.vpc_id
 }
-if route53.srcids?.instance? != null {
-  ocsf.src_endpoint.instance_uid = move route53.srcids.instance
+if $event.route53.srcids?.instance? != null {
+  $event.ocsf.src_endpoint.instance_uid = move $event.route53.srcids.instance
 }
 
 // Resolver endpoint info goes to dst_endpoint since it's the DNS server.
-if route53.srcids?.resolver_endpoint? != null {
-  ocsf.dst_endpoint.uid = move route53.srcids.resolver_endpoint
+if $event.route53.srcids?.resolver_endpoint? != null {
+  $event.ocsf.dst_endpoint.uid = move $event.route53.srcids.resolver_endpoint
 }
-if route53.srcids?.resolver_network_interface? != null {
-  ocsf.dst_endpoint.interface_uid = move route53.srcids.resolver_network_interface
+if $event.route53.srcids?.resolver_network_interface? != null {
+  $event.ocsf.dst_endpoint.interface_uid = move $event.route53.srcids.resolver_network_interface
 }
-drop route53.srcids?
+drop $event.route53.srcids?
 
-if route53.has("transport") {
-  ocsf.connection_info.protocol_name = route53.transport.to_lower()
-  ocsf.connection_info.protocol_num = $proto_nums[route53.transport] else -1
-  drop route53.transport
+if $event.route53.has("transport") {
+  $event.ocsf.connection_info.protocol_name = $event.route53.transport.to_lower()
+  $event.ocsf.connection_info.protocol_num = $proto_nums[$event.route53.transport] else -1
+  drop $event.route53.transport
 }
 
 // --- DNS Firewall (security_control profile) --
 
-if route53.has("firewall_rule_action") {
-  ocsf.metadata.profiles = ["cloud", "security_control"]
-  if $firewall_actions[route53.firewall_rule_action]? != null {
-    ocsf.action_id = $firewall_actions[route53.firewall_rule_action].action_id
-    ocsf.disposition_id = $firewall_actions[route53.firewall_rule_action].disposition_id
-    if $firewall_actions[route53.firewall_rule_action].is_alert? != null {
-      ocsf.is_alert = $firewall_actions[route53.firewall_rule_action].is_alert
+if $event.route53.has("firewall_rule_action") {
+  $event.ocsf.metadata.profiles = ["cloud", "security_control"]
+  if $firewall_actions[$event.route53.firewall_rule_action]? != null {
+    $event.ocsf.action_id = $firewall_actions[$event.route53.firewall_rule_action].action_id
+    $event.ocsf.disposition_id = $firewall_actions[$event.route53.firewall_rule_action].disposition_id
+    if $firewall_actions[$event.route53.firewall_rule_action].is_alert? != null {
+      $event.ocsf.is_alert = $firewall_actions[$event.route53.firewall_rule_action].is_alert
     }
   } else {
-    ocsf.action_id = 99
-    ocsf.action = route53.firewall_rule_action
-    ocsf.disposition_id = 99
-    ocsf.disposition = route53.firewall_rule_action
+    $event.ocsf.action_id = 99
+    $event.ocsf.action = $event.route53.firewall_rule_action
+    $event.ocsf.disposition_id = 99
+    $event.ocsf.disposition = $event.route53.firewall_rule_action
   }
-  drop route53.firewall_rule_action
-  ocsf.firewall_rule = {
-    uid: move route53.firewall_rule_group_id?,
-    match_details: [move route53.firewall_domain_list_id] if route53.firewall_domain_list_id? != null else null,
+  drop $event.route53.firewall_rule_action
+  $event.ocsf.firewall_rule = {
+    uid: move $event.route53.firewall_rule_group_id?,
+    match_details: [move $event.route53.firewall_domain_list_id] if $event.route53.firewall_domain_list_id? != null else null,
   }
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.dns_activity"
-this = {...ocsf, unmapped: route53}
+$event = {...$event.ocsf, unmapped: $event.route53}

--- a/amazon/operators/vpc_flow/ocsf/map.tql
+++ b/amazon/operators/vpc_flow/ocsf/map.tql
@@ -6,190 +6,179 @@ description: |
   events with support for traffic path, flow direction, and security control
   dispositions.
 args:
-  positional:
-    - name: event
-      type: field
-      description: Parsed VPC Flow Log record.
   named:
-    - name: raw
+    - name: event
+      description: The field that holds the event to map.
       type: field
-      default: null
-      description: Raw VPC Flow Log line to preserve in OCSF `raw_data`.
+      default: this
 ---
 
-ocsf = {}
-
-if $raw != null {
-  ocsf.raw_data = $raw
-  ocsf.raw_data_size = $raw.length_bytes()
-}
-
 where $event != null
-vpc_flow = $event
+$event = {...$event, vpc_flow: $event, ocsf: {}}
 
 // --- OCSF: classification attributes ----------
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
-ocsf.severity_id = 1
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
+$event.ocsf.severity_id = 1
 
 // --- OCSF: context attributes -----------------
 
-ocsf.cloud = {
+$event.ocsf.cloud = {
   account: {
-    uid: (move vpc_flow.account_id?).string(),
+    uid: (move $event.vpc_flow.account_id?).string(),
   },
-  region: move vpc_flow.region?,
-  zone: move vpc_flow.az_id?,
+  region: move $event.vpc_flow.region?,
+  zone: move $event.vpc_flow.az_id?,
   provider: "AWS",
 }
 
-ocsf.metadata = {
+$event.ocsf.metadata = {
   version: "1.8.0",
   product: {
     name: "Amazon VPC",
     vendor_name: "AWS",
-    version: vpc_flow.version?.string(),
+    version: $event.vpc_flow.version?.string(),
     feature: {
       name: "Flow Logs",
     },
   },
   profiles: ["cloud", "security_control"],
 }
-drop vpc_flow.version?
+drop $event.vpc_flow.version?
 
 // --- OCSF: occurrence attributes --------------
 
-ocsf.start_time = move vpc_flow.start?
-ocsf.end_time = move vpc_flow.end?
-ocsf.time = ocsf.start_time
-ocsf.duration = count_milliseconds(ocsf.end_time - ocsf.start_time).round()
+$event.ocsf.start_time = move $event.vpc_flow.start?
+$event.ocsf.end_time = move $event.vpc_flow.end?
+$event.ocsf.time = $event.ocsf.start_time
+$event.ocsf.duration = count_milliseconds($event.ocsf.end_time - $event.ocsf.start_time).round()
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.traffic = {
-  bytes: move vpc_flow.bytes?,
-  packets: move vpc_flow.packets?,
+$event.ocsf.traffic = {
+  bytes: move $event.vpc_flow.bytes?,
+  packets: move $event.vpc_flow.packets?,
 }
 
-ocsf.connection_info = {
-  protocol_num: move vpc_flow.protocol?,
-  tcp_flags: move vpc_flow.tcp_flags?,
+$event.ocsf.connection_info = {
+  protocol_num: move $event.vpc_flow.protocol?,
+  tcp_flags: move $event.vpc_flow.tcp_flags?,
 }
 
-ocsf.status_code = move vpc_flow.log_status?
+$event.ocsf.status_code = move $event.vpc_flow.log_status?
 
-ocsf.src_endpoint = {
-  port: move vpc_flow.srcport?,
-  svc_name: move vpc_flow.pkt_src_aws_service?,
+$event.ocsf.src_endpoint = {
+  port: move $event.vpc_flow.srcport?,
+  svc_name: move $event.vpc_flow.pkt_src_aws_service?,
 }
 
-ocsf.dst_endpoint = {
-  port: move vpc_flow.dstport?,
-  svc_name: move vpc_flow.pkt_dst_aws_service?,
+$event.ocsf.dst_endpoint = {
+  port: move $event.vpc_flow.dstport?,
+  svc_name: move $event.vpc_flow.pkt_dst_aws_service?,
 }
 
 // --- Security control: action/disposition -----
 
-if vpc_flow.action? == "REJECT" {
-  ocsf.activity_id = 2
-  ocsf.action_id = 2
-  ocsf.disposition_id = 2
+if $event.vpc_flow.action? == "REJECT" {
+  $event.ocsf.activity_id = 2
+  $event.ocsf.action_id = 2
+  $event.ocsf.disposition_id = 2
 } else {
-  ocsf.activity_id = 6
-  ocsf.action_id = 1
-  ocsf.disposition_id = 1
+  $event.ocsf.activity_id = 6
+  $event.ocsf.action_id = 1
+  $event.ocsf.disposition_id = 1
 }
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-drop vpc_flow.action?
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+drop $event.vpc_flow.action?
 
-if vpc_flow.reject_reason? != null {
-  ocsf.status_detail = move vpc_flow.reject_reason
+if $event.vpc_flow.reject_reason? != null {
+  $event.ocsf.status_detail = move $event.vpc_flow.reject_reason
 }
 
 // --- Traffic path (v5+) -----------------------
 
-if vpc_flow.traffic_path? != null {
-  ocsf.connection_info.boundary_id = move vpc_flow.traffic_path
+if $event.vpc_flow.traffic_path? != null {
+  $event.ocsf.connection_info.boundary_id = move $event.vpc_flow.traffic_path
   // AWS traffic path values 1 and 2 are not the same as OCSF boundary IDs.
-  if ocsf.connection_info.boundary_id >= 1 and ocsf.connection_info.boundary_id <= 8 {
-    ocsf.connection_info.boundary_id = ocsf.connection_info.boundary_id + 3
+  if $event.ocsf.connection_info.boundary_id >= 1 and $event.ocsf.connection_info.boundary_id <= 8 {
+    $event.ocsf.connection_info.boundary_id = $event.ocsf.connection_info.boundary_id + 3
   }
 }
 
 // --- Flow direction and endpoint assignment ---
 
-if vpc_flow.flow_direction? == "ingress" {
-  ocsf.connection_info.direction_id = 1
-  ocsf.dst_endpoint.interface_uid = move vpc_flow.interface_id?
-  ocsf.dst_endpoint.vpc_uid = move vpc_flow.vpc_id?
-  ocsf.dst_endpoint.instance_uid = move vpc_flow.instance_id?
-  ocsf.dst_endpoint.subnet_uid = move vpc_flow.subnet_id?
-} else if vpc_flow.flow_direction? == "egress" {
-  ocsf.connection_info.direction_id = 2
-  ocsf.src_endpoint.interface_uid = move vpc_flow.interface_id?
-  ocsf.src_endpoint.vpc_uid = move vpc_flow.vpc_id?
-  ocsf.src_endpoint.instance_uid = move vpc_flow.instance_id?
-  ocsf.src_endpoint.subnet_uid = move vpc_flow.subnet_id?
+if $event.vpc_flow.flow_direction? == "ingress" {
+  $event.ocsf.connection_info.direction_id = 1
+  $event.ocsf.dst_endpoint.interface_uid = move $event.vpc_flow.interface_id?
+  $event.ocsf.dst_endpoint.vpc_uid = move $event.vpc_flow.vpc_id?
+  $event.ocsf.dst_endpoint.instance_uid = move $event.vpc_flow.instance_id?
+  $event.ocsf.dst_endpoint.subnet_uid = move $event.vpc_flow.subnet_id?
+} else if $event.vpc_flow.flow_direction? == "egress" {
+  $event.ocsf.connection_info.direction_id = 2
+  $event.ocsf.src_endpoint.interface_uid = move $event.vpc_flow.interface_id?
+  $event.ocsf.src_endpoint.vpc_uid = move $event.vpc_flow.vpc_id?
+  $event.ocsf.src_endpoint.instance_uid = move $event.vpc_flow.instance_id?
+  $event.ocsf.src_endpoint.subnet_uid = move $event.vpc_flow.subnet_id?
 }
-drop vpc_flow.flow_direction?
+drop $event.vpc_flow.flow_direction?
 
 // --- IP address handling ----------------------
 // pkt_srcaddr/pkt_dstaddr are the original addresses; srcaddr/dstaddr may
 // differ when NAT or intermediate devices are involved.
 
-if vpc_flow.pkt_srcaddr? != vpc_flow.srcaddr? and vpc_flow.pkt_srcaddr? != null {
-  ocsf.src_endpoint.ip = move vpc_flow.pkt_srcaddr
-  ocsf.src_endpoint.intermediate_ips = [move vpc_flow.srcaddr?]
+if $event.vpc_flow.pkt_srcaddr? != $event.vpc_flow.srcaddr? and $event.vpc_flow.pkt_srcaddr? != null {
+  $event.ocsf.src_endpoint.ip = move $event.vpc_flow.pkt_srcaddr
+  $event.ocsf.src_endpoint.intermediate_ips = [move $event.vpc_flow.srcaddr?]
 } else {
-  ocsf.src_endpoint.ip = move vpc_flow.srcaddr?
-  drop vpc_flow.pkt_srcaddr?
+  $event.ocsf.src_endpoint.ip = move $event.vpc_flow.srcaddr?
+  drop $event.vpc_flow.pkt_srcaddr?
 }
 
-if vpc_flow.pkt_dstaddr? != vpc_flow.dstaddr? and vpc_flow.pkt_dstaddr? != null {
-  ocsf.dst_endpoint.ip = move vpc_flow.pkt_dstaddr
-  ocsf.dst_endpoint.intermediate_ips = [move vpc_flow.dstaddr?]
+if $event.vpc_flow.pkt_dstaddr? != $event.vpc_flow.dstaddr? and $event.vpc_flow.pkt_dstaddr? != null {
+  $event.ocsf.dst_endpoint.ip = move $event.vpc_flow.pkt_dstaddr
+  $event.ocsf.dst_endpoint.intermediate_ips = [move $event.vpc_flow.dstaddr?]
 } else {
-  ocsf.dst_endpoint.ip = move vpc_flow.dstaddr?
-  drop vpc_flow.pkt_dstaddr?
+  $event.ocsf.dst_endpoint.ip = move $event.vpc_flow.dstaddr?
+  drop $event.vpc_flow.pkt_dstaddr?
 }
 
-if (ocsf.src_endpoint.ip? != null and ocsf.src_endpoint.ip.is_v6()) or
-   (ocsf.dst_endpoint.ip? != null and ocsf.dst_endpoint.ip.is_v6()) {
-  ocsf.connection_info.protocol_ver_id = 6
-} else if ocsf.src_endpoint.ip? != null or ocsf.dst_endpoint.ip? != null {
-  ocsf.connection_info.protocol_ver_id = 4
+if ($event.ocsf.src_endpoint.ip? != null and $event.ocsf.src_endpoint.ip.is_v6()) or
+   ($event.ocsf.dst_endpoint.ip? != null and $event.ocsf.dst_endpoint.ip.is_v6()) {
+  $event.ocsf.connection_info.protocol_ver_id = 6
+} else if $event.ocsf.src_endpoint.ip? != null or $event.ocsf.dst_endpoint.ip? != null {
+  $event.ocsf.connection_info.protocol_ver_id = 4
 }
 
-drop vpc_flow.type?
+drop $event.vpc_flow.type?
 
 // --- ECS metadata (v7+) -----------------------
 
-if vpc_flow.ecs_cluster_arn? != null {
-  vpc_flow.ecs = {
-    cluster_arn: move vpc_flow.ecs_cluster_arn?,
-    cluster_name: move vpc_flow.ecs_cluster_name?,
-    container_instance_arn: move vpc_flow.ecs_container_instance_arn?,
-    container_instance_id: move vpc_flow.ecs_container_instance_id?,
-    container_id: move vpc_flow.ecs_container_id?,
-    second_container_id: move vpc_flow.ecs_second_container_id?,
-    service_name: move vpc_flow.ecs_service_name?,
-    task_definition_arn: move vpc_flow.ecs_task_definition_arn?,
-    task_arn: move vpc_flow.ecs_task_arn?,
-    task_id: move vpc_flow.ecs_task_id?,
+if $event.vpc_flow.ecs_cluster_arn? != null {
+  $event.vpc_flow.ecs = {
+    cluster_arn: move $event.vpc_flow.ecs_cluster_arn?,
+    cluster_name: move $event.vpc_flow.ecs_cluster_name?,
+    container_instance_arn: move $event.vpc_flow.ecs_container_instance_arn?,
+    container_instance_id: move $event.vpc_flow.ecs_container_instance_id?,
+    container_id: move $event.vpc_flow.ecs_container_id?,
+    second_container_id: move $event.vpc_flow.ecs_second_container_id?,
+    service_name: move $event.vpc_flow.ecs_service_name?,
+    task_definition_arn: move $event.vpc_flow.ecs_task_definition_arn?,
+    task_arn: move $event.vpc_flow.ecs_task_arn?,
+    task_id: move $event.vpc_flow.ecs_task_id?,
   }
 }
 
 // --- Additional fields ------------------------
 
-if vpc_flow.sublocation_type? != null {
-  ocsf.cloud.sublocation = {
-    type: move vpc_flow.sublocation_type,
-    uid: move vpc_flow.sublocation_id?,
+if $event.vpc_flow.sublocation_type? != null {
+  $event.ocsf.cloud.sublocation = {
+    type: move $event.vpc_flow.sublocation_type,
+    uid: move $event.vpc_flow.sublocation_id?,
   }
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.network_activity"
-this = {...ocsf, unmapped: vpc_flow}
+$event = {...$event.ocsf, unmapped: $event.vpc_flow}

--- a/amazon/tests/route53/ocsf-null-event.tql
+++ b/amazon/tests/route53/ocsf-null-event.tql
@@ -5,4 +5,4 @@ timeout: 30
 from {
   event: null,
 }
-amazon::route53::ocsf::map event
+amazon::route53::ocsf::map event=event

--- a/amazon/tests/route53/ocsf.tql
+++ b/amazon/tests/route53/ocsf.tql
@@ -6,7 +6,10 @@ from_file f"{env("TENZIR_INPUTS")}/route53-query-logs.ndjson" {
   read_lines
 }
 event = line.parse_json()
-amazon::route53::ocsf::map event, raw=line
+amazon::route53::ocsf::map event=event
+event.raw_data = move line
+event.raw_data_size = event.raw_data.length_bytes()
+this = event
 ocsf::derive
 ocsf::cast
 sort time

--- a/amazon/tests/vpc_flow/ocsf-null-event.tql
+++ b/amazon/tests/vpc_flow/ocsf-null-event.tql
@@ -5,4 +5,4 @@ timeout: 30
 from {
   vpc_flow: null,
 }
-amazon::vpc_flow::ocsf::map vpc_flow
+amazon::vpc_flow::ocsf::map event=vpc_flow

--- a/amazon/tests/vpc_flow/ocsf.tql
+++ b/amazon/tests/vpc_flow/ocsf.tql
@@ -2,7 +2,10 @@ from_file f"{env("TENZIR_INPUTS")}/cloudwatch-v2.ndjson" {
   read_ndjson
 }
 amazon::vpc_flow::parse_v2 field=message, into=vpc_flow
-amazon::vpc_flow::ocsf::map vpc_flow, raw=message
+amazon::vpc_flow::ocsf::map event=vpc_flow
+vpc_flow.raw_data = move message
+vpc_flow.raw_data_size = vpc_flow.raw_data.length_bytes()
+this = vpc_flow
 ocsf::derive
 ocsf::cast
 sort time, type_uid

--- a/checkpoint/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/checkpoint/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,22 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:15.702248Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+```

--- a/checkpoint/operators/ocsf/base.tql
+++ b/checkpoint/operators/ocsf/base.tql
@@ -1,14 +1,19 @@
 ---
 description: "Check Point → OCSF Base Event (0)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.base_event"
 
-ocsf.category_uid = 0
-ocsf.class_uid = 0
-ocsf.activity_id = 0
-ocsf.type_uid = 0
+$event.ocsf.category_uid = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.type_uid = 0
 
-if ocsf.time? == null {
-  ocsf.time = now()
+if $event.ocsf.time? == null {
+  $event.ocsf.time = now()
 }

--- a/checkpoint/operators/ocsf/events/api_activity.tql
+++ b/checkpoint/operators/ocsf/events/api_activity.tql
@@ -1,41 +1,46 @@
 ---
 description: "Check Point WEB_API → OCSF API Activity (6003)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.api_activity"
 
-ocsf.metadata.profiles = ["host"]
+$event.ocsf.metadata.profiles = ["host"]
 
-ocsf.category_uid = 6
-ocsf.class_uid = 6003
+$event.ocsf.category_uid = 6
+$event.ocsf.class_uid = 6003
 let $activities = {
   Create: 1,
   Read: 2,
   Update: 3,
   Delete: 4,
 }
-ocsf.activity_id = $activities[checkpoint.action?]? else 0
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = $activities[$event.checkpoint.action?]? else 0
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-ocsf.api = {
-  operation: checkpoint.action? else checkpoint.subject? else "unknown",
+$event.ocsf.api = {
+  operation: $event.checkpoint.action? else $event.checkpoint.subject? else "unknown",
 }
-drop checkpoint.action?
+drop $event.checkpoint.action?
 
-checkpoint::ocsf::status
+checkpoint::ocsf::status event=$event
 
-if checkpoint.user? != null {
-  ocsf.actor.user.name = move checkpoint.user
+if $event.checkpoint.user? != null {
+  $event.ocsf.actor.user.name = move $event.checkpoint.user
 }
-if checkpoint.src? != null {
-  ocsf.src_endpoint.ip = move checkpoint.src
+if $event.checkpoint.src? != null {
+  $event.ocsf.src_endpoint.ip = move $event.checkpoint.src
 }
-if checkpoint.object? != null or checkpoint.objecttype? != null {
-  ocsf.resources = [{
-    name: move checkpoint.object?,
-    type: move checkpoint.objecttype?,
+if $event.checkpoint.object? != null or $event.checkpoint.objecttype? != null {
+  $event.ocsf.resources = [{
+    name: move $event.checkpoint.object?,
+    type: move $event.checkpoint.objecttype?,
   }]
 }
-if checkpoint.subject? != null {
-  ocsf.api.request.uid = move checkpoint.subject
+if $event.checkpoint.subject? != null {
+  $event.ocsf.api.request.uid = move $event.checkpoint.subject
 }

--- a/checkpoint/operators/ocsf/events/data_security_finding.tql
+++ b/checkpoint/operators/ocsf/events/data_security_finding.tql
@@ -1,66 +1,71 @@
 ---
 description: "Check Point DLP/Content Awareness → OCSF Data Security Finding (2006)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.data_security_finding"
 
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 2
-ocsf.class_uid = 2006
-ocsf.activity_id = 1  // Create
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-ocsf.is_alert = true
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2006
+$event.ocsf.activity_id = 1  // Create
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+$event.ocsf.is_alert = true
 
-checkpoint::ocsf::security_control_outcome
+checkpoint::ocsf::security_control_outcome event=$event
 
-ocsf.finding_info = {
-  title: checkpoint.data_type? else checkpoint.reason? else ocsf.message? else "Check Point DLP finding",
-  desc: checkpoint.reason?,
-  uid: ocsf.metadata.uid? else ocsf.metadata.original_event_uid?,
+$event.ocsf.finding_info = {
+  title: $event.checkpoint.data_type? else $event.checkpoint.reason? else $event.ocsf.message? else "Check Point DLP finding",
+  desc: $event.checkpoint.reason?,
+  uid: $event.ocsf.metadata.uid? else $event.ocsf.metadata.original_event_uid?,
   analytic: {
-    name: checkpoint.policy? else "Check Point DLP",
+    name: $event.checkpoint.policy? else "Check Point DLP",
     type_id: 1,
-    uid: ocsf.metadata.uid? else ocsf.metadata.original_event_uid?,
+    uid: $event.ocsf.metadata.uid? else $event.ocsf.metadata.original_event_uid?,
   },
 }
 
-ocsf.data_security = {
+$event.ocsf.data_security = {
   data_lifecycle_state_id: 2,
   detection_system_id: 2,
-  detection_pattern: move checkpoint.data_type?,
+  detection_pattern: move $event.checkpoint.data_type?,
 }
-if checkpoint.policy? != null {
-  ocsf.data_security.policy.name = move checkpoint.policy
-}
-
-if checkpoint.object? != null {
-  ocsf.file.name = move checkpoint.object
-  ocsf.file.type_id = 1
-}
-if checkpoint.objecttype? != null {
-  ocsf.file.type_id = 99
-  ocsf.file.type = move checkpoint.objecttype
-}
-if checkpoint.size? != null {
-  ocsf.file.size = move checkpoint.size
+if $event.checkpoint.policy? != null {
+  $event.ocsf.data_security.policy.name = move $event.checkpoint.policy
 }
 
-if checkpoint.src? != null {
-  ocsf.src_endpoint.ip = move checkpoint.src
+if $event.checkpoint.object? != null {
+  $event.ocsf.file.name = move $event.checkpoint.object
+  $event.ocsf.file.type_id = 1
 }
-if checkpoint.dst? != null {
-  ocsf.dst_endpoint.ip = move checkpoint.dst
+if $event.checkpoint.objecttype? != null {
+  $event.ocsf.file.type_id = 99
+  $event.ocsf.file.type = move $event.checkpoint.objecttype
 }
-if checkpoint.service? != null {
-  ocsf.dst_endpoint.port = move checkpoint.service
+if $event.checkpoint.size? != null {
+  $event.ocsf.file.size = move $event.checkpoint.size
 }
-if checkpoint.user? != null {
-  ocsf.actor.user.name = move checkpoint.user
+
+if $event.checkpoint.src? != null {
+  $event.ocsf.src_endpoint.ip = move $event.checkpoint.src
 }
-if checkpoint.sender? != null {
-  ocsf.actor.user.email_addr = move checkpoint.sender
+if $event.checkpoint.dst? != null {
+  $event.ocsf.dst_endpoint.ip = move $event.checkpoint.dst
 }
-if checkpoint.reason? != null {
-  ocsf.status_detail = move checkpoint.reason
+if $event.checkpoint.service? != null {
+  $event.ocsf.dst_endpoint.port = move $event.checkpoint.service
+}
+if $event.checkpoint.user? != null {
+  $event.ocsf.actor.user.name = move $event.checkpoint.user
+}
+if $event.checkpoint.sender? != null {
+  $event.ocsf.actor.user.email_addr = move $event.checkpoint.sender
+}
+if $event.checkpoint.reason? != null {
+  $event.ocsf.status_detail = move $event.checkpoint.reason
 }

--- a/checkpoint/operators/ocsf/events/detection_finding.tql
+++ b/checkpoint/operators/ocsf/events/detection_finding.tql
@@ -1,64 +1,69 @@
 ---
 description: "Check Point detections → OCSF Detection Finding (2004)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.detection_finding"
 
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 2
-ocsf.class_uid = 2004
-ocsf.activity_id = 1  // Create
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-ocsf.is_alert = true
-ocsf.action_id = 3
-ocsf.disposition_id = 15
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2004
+$event.ocsf.activity_id = 1  // Create
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+$event.ocsf.is_alert = true
+$event.ocsf.action_id = 3
+$event.ocsf.disposition_id = 15
 
-ocsf.finding_info = {
+$event.ocsf.finding_info = {
   title: "Check Point detection",
-  desc: ocsf.message?,
-  uid: ocsf.metadata.uid? else ocsf.metadata.original_event_uid?,
+  desc: $event.ocsf.message?,
+  uid: $event.ocsf.metadata.uid? else $event.ocsf.metadata.original_event_uid?,
   analytic: {
     name: "Check Point detection",
     type_id: 1,
-    uid: ocsf.metadata.uid? else ocsf.metadata.original_event_uid?,
+    uid: $event.ocsf.metadata.uid? else $event.ocsf.metadata.original_event_uid?,
   },
 }
 
-if ocsf.message? != null {
-  ocsf.finding_info.title = ocsf.message
-  ocsf.finding_info.analytic.name = ocsf.message
+if $event.ocsf.message? != null {
+  $event.ocsf.finding_info.title = $event.ocsf.message
+  $event.ocsf.finding_info.analytic.name = $event.ocsf.message
 }
-if checkpoint.threat_name? != null {
-  ocsf.finding_info.title = checkpoint.threat_name
-  ocsf.finding_info.analytic.name = move checkpoint.threat_name
+if $event.checkpoint.threat_name? != null {
+  $event.ocsf.finding_info.title = $event.checkpoint.threat_name
+  $event.ocsf.finding_info.analytic.name = move $event.checkpoint.threat_name
 }
-if checkpoint.protection_name? != null {
-  ocsf.finding_info.desc = checkpoint.protection_name
-  ocsf.finding_info.analytic.name = move checkpoint.protection_name
+if $event.checkpoint.protection_name? != null {
+  $event.ocsf.finding_info.desc = $event.checkpoint.protection_name
+  $event.ocsf.finding_info.analytic.name = move $event.checkpoint.protection_name
 }
-if checkpoint.confidence_level? != null {
+if $event.checkpoint.confidence_level? != null {
   let $confidence = {
     Low: 1,
     Medium: 2,
     High: 3,
   }
-  ocsf.confidence_id = $confidence[checkpoint.confidence_level]? else 99
-  if ocsf.confidence_id == 99 {
-    ocsf.confidence = checkpoint.confidence_level
+  $event.ocsf.confidence_id = $confidence[$event.checkpoint.confidence_level]? else 99
+  if $event.ocsf.confidence_id == 99 {
+    $event.ocsf.confidence = $event.checkpoint.confidence_level
   }
-  drop checkpoint.confidence_level
+  drop $event.checkpoint.confidence_level
 }
-if checkpoint.policy? != null {
-  ocsf.finding_info.analytic.category = move checkpoint.policy
+if $event.checkpoint.policy? != null {
+  $event.ocsf.finding_info.analytic.category = move $event.checkpoint.policy
 }
 
-ocsf.evidences = [{
-  src_endpoint: move ocsf.src_endpoint?,
-  dst_endpoint: move ocsf.dst_endpoint?,
-  connection_info: move ocsf.connection_info?,
+$event.ocsf.evidences = [{
+  src_endpoint: move $event.ocsf.src_endpoint?,
+  dst_endpoint: move $event.ocsf.dst_endpoint?,
+  connection_info: move $event.ocsf.connection_info?,
 }]
 
-if checkpoint.action? == "Detect" {
-  drop checkpoint.action
+if $event.checkpoint.action? == "Detect" {
+  drop $event.checkpoint.action
 }

--- a/checkpoint/operators/ocsf/events/email_activity.tql
+++ b/checkpoint/operators/ocsf/events/email_activity.tql
@@ -1,17 +1,22 @@
 ---
 description: "Check Point MTA/Anti-Spam/Email Security → OCSF Email Activity (4009)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.email_activity"
 
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4009
-ocsf.activity_id = 3  // Scan
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4009
+$event.ocsf.activity_id = 3  // Scan
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-checkpoint::ocsf::security_control_outcome
+checkpoint::ocsf::security_control_outcome event=$event
 
 let $direction_ids = {
   Inbound: 1,
@@ -19,34 +24,34 @@ let $direction_ids = {
   Incoming: 1,
   Outgoing: 2,
 }
-ocsf.direction_id = $direction_ids[checkpoint.direction?]? else $direction_ids[checkpoint.conn_direction?]? else 0
-drop checkpoint.direction?
-drop checkpoint.conn_direction?
+$event.ocsf.direction_id = $direction_ids[$event.checkpoint.direction?]? else $direction_ids[$event.checkpoint.conn_direction?]? else 0
+drop $event.checkpoint.direction?
+drop $event.checkpoint.conn_direction?
 
-ocsf.email = {
-  from: move checkpoint.sender?,
-  to: [move checkpoint.recipient?],
-  subject: move checkpoint.subject?,
-  size: move checkpoint.size?,
+$event.ocsf.email = {
+  from: move $event.checkpoint.sender?,
+  to: [move $event.checkpoint.recipient?],
+  subject: move $event.checkpoint.subject?,
+  size: move $event.checkpoint.size?,
 }
 
-if checkpoint.src? != null {
-  ocsf.src_endpoint.ip = move checkpoint.src
+if $event.checkpoint.src? != null {
+  $event.ocsf.src_endpoint.ip = move $event.checkpoint.src
 }
-if checkpoint.s_port? != null {
-  ocsf.src_endpoint.port = move checkpoint.s_port
+if $event.checkpoint.s_port? != null {
+  $event.ocsf.src_endpoint.port = move $event.checkpoint.s_port
 }
-if checkpoint.dst? != null {
-  ocsf.dst_endpoint.ip = move checkpoint.dst
+if $event.checkpoint.dst? != null {
+  $event.ocsf.dst_endpoint.ip = move $event.checkpoint.dst
 }
-if checkpoint.service_id? != null {
-  ocsf.protocol_name = move checkpoint.service_id
-} else if checkpoint.service? == 25 {
-  ocsf.protocol_name = "SMTP"
+if $event.checkpoint.service_id? != null {
+  $event.ocsf.protocol_name = move $event.checkpoint.service_id
+} else if $event.checkpoint.service? == 25 {
+  $event.ocsf.protocol_name = "SMTP"
 }
-if checkpoint.service? != null {
-  ocsf.dst_endpoint.port = move checkpoint.service
+if $event.checkpoint.service? != null {
+  $event.ocsf.dst_endpoint.port = move $event.checkpoint.service
 }
-if checkpoint.status? != null {
-  ocsf.status_detail = move checkpoint.status
+if $event.checkpoint.status? != null {
+  $event.ocsf.status_detail = move $event.checkpoint.status
 }

--- a/checkpoint/operators/ocsf/events/entity_management.tql
+++ b/checkpoint/operators/ocsf/events/entity_management.tql
@@ -1,13 +1,18 @@
 ---
 description: "Check Point management audit → OCSF Entity Management (3004)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.entity_management"
 
-ocsf.metadata.profiles = ["host"]
+$event.ocsf.metadata.profiles = ["host"]
 
-ocsf.category_uid = 3
-ocsf.class_uid = 3004
+$event.ocsf.category_uid = 3
+$event.ocsf.class_uid = 3004
 let $activities = {
   Create: 1,
   Read: 2,
@@ -17,32 +22,32 @@ let $activities = {
   Enable: 8,
   Disable: 9,
 }
-ocsf.activity_id = $activities[checkpoint.action?]? else 0
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-drop checkpoint.action?
+$event.ocsf.activity_id = $activities[$event.checkpoint.action?]? else 0
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+drop $event.checkpoint.action?
 
-checkpoint::ocsf::status
+checkpoint::ocsf::status event=$event
 
-if checkpoint.user? != null {
-  ocsf.actor.user.name = move checkpoint.user
+if $event.checkpoint.user? != null {
+  $event.ocsf.actor.user.name = move $event.checkpoint.user
 }
-if checkpoint.src? != null {
-  ocsf.src_endpoint.ip = move checkpoint.src
+if $event.checkpoint.src? != null {
+  $event.ocsf.src_endpoint.ip = move $event.checkpoint.src
 }
 
-ocsf.entity = {
-  name: move checkpoint.object?,
+$event.ocsf.entity = {
+  name: move $event.checkpoint.object?,
 }
-if checkpoint.objecttype?.to_lower().contains("rule") or
-   checkpoint.objecttype?.to_lower().contains("policy") {
-  ocsf.entity.type_id = 5
-  ocsf.entity.policy.name = ocsf.entity.name
-  ocsf.entity.policy.desc = move checkpoint.objecttype
+if $event.checkpoint.objecttype?.to_lower().contains("rule") or
+   $event.checkpoint.objecttype?.to_lower().contains("policy") {
+  $event.ocsf.entity.type_id = 5
+  $event.ocsf.entity.policy.name = $event.ocsf.entity.name
+  $event.ocsf.entity.policy.desc = move $event.checkpoint.objecttype
 } else {
-  ocsf.entity.type_id = 1
-  ocsf.entity.device.name = ocsf.entity.name
-  ocsf.entity.device.desc = move checkpoint.objecttype?
+  $event.ocsf.entity.type_id = 1
+  $event.ocsf.entity.device.name = $event.ocsf.entity.name
+  $event.ocsf.entity.device.desc = move $event.checkpoint.objecttype?
 }
-if checkpoint.subject? != null {
-  ocsf.comment = move checkpoint.subject
+if $event.checkpoint.subject? != null {
+  $event.ocsf.comment = move $event.checkpoint.subject
 }

--- a/checkpoint/operators/ocsf/events/network_activity.tql
+++ b/checkpoint/operators/ocsf/events/network_activity.tql
@@ -1,41 +1,46 @@
 ---
 description: "Check Point firewall traffic → OCSF Network Activity (4001)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.network_activity"
 
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
-ocsf.activity_id = 6  // Traffic
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
+$event.ocsf.activity_id = 6  // Traffic
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-match checkpoint.action? {
+match $event.checkpoint.action? {
   "Accept" => {
-    ocsf.action_id = 1
-    ocsf.disposition_id = 1
-    ocsf.status_id = 1
+    $event.ocsf.action_id = 1
+    $event.ocsf.disposition_id = 1
+    $event.ocsf.status_id = 1
   }
   "Drop" => {
-    ocsf.action_id = 2
-    ocsf.disposition_id = 6
-    ocsf.status_id = 2
+    $event.ocsf.action_id = 2
+    $event.ocsf.disposition_id = 6
+    $event.ocsf.status_id = 2
   }
   "Reject" => {
-    ocsf.action_id = 2
-    ocsf.disposition_id = 25
-    ocsf.status_id = 2
+    $event.ocsf.action_id = 2
+    $event.ocsf.disposition_id = 25
+    $event.ocsf.status_id = 2
   }
   _ => {
-    ocsf.action_id = 0
-    ocsf.disposition_id = 0
-    ocsf.status_id = 0
+    $event.ocsf.action_id = 0
+    $event.ocsf.disposition_id = 0
+    $event.ocsf.status_id = 0
   }
 }
 
-if checkpoint.action? in ["Accept", "Drop", "Reject"] {
-  drop checkpoint.action
+if $event.checkpoint.action? in ["Accept", "Drop", "Reject"] {
+  drop $event.checkpoint.action
 }
 
-checkpoint::ocsf::traffic
+checkpoint::ocsf::traffic event=$event

--- a/checkpoint/operators/ocsf/events/tunnel_activity.tql
+++ b/checkpoint/operators/ocsf/events/tunnel_activity.tql
@@ -1,13 +1,18 @@
 ---
 description: "Check Point VPN/Mobile Access → OCSF Tunnel Activity (4014)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.tunnel_activity"
 
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4014
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4014
 let $activities = {
   Connect: 1,
   Login: 1,
@@ -17,37 +22,37 @@ let $activities = {
   "Log Out": 2,
   Renew: 3,
 }
-ocsf.activity_id = $activities[checkpoint.action?]? else 0
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-drop checkpoint.action?
+$event.ocsf.activity_id = $activities[$event.checkpoint.action?]? else 0
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+drop $event.checkpoint.action?
 
-checkpoint::ocsf::status
+checkpoint::ocsf::status event=$event
 
-if checkpoint.src? != null {
-  ocsf.src_endpoint.ip = move checkpoint.src
+if $event.checkpoint.src? != null {
+  $event.ocsf.src_endpoint.ip = move $event.checkpoint.src
 }
-if checkpoint.s_port? != null {
-  ocsf.src_endpoint.port = move checkpoint.s_port
+if $event.checkpoint.s_port? != null {
+  $event.ocsf.src_endpoint.port = move $event.checkpoint.s_port
 }
-if checkpoint.dst? != null {
-  ocsf.dst_endpoint.ip = move checkpoint.dst
+if $event.checkpoint.dst? != null {
+  $event.ocsf.dst_endpoint.ip = move $event.checkpoint.dst
 }
-if checkpoint.service? != null {
-  ocsf.dst_endpoint.port = move checkpoint.service
+if $event.checkpoint.service? != null {
+  $event.ocsf.dst_endpoint.port = move $event.checkpoint.service
 }
-if checkpoint.user? != null {
-  ocsf.user.name = move checkpoint.user
+if $event.checkpoint.user? != null {
+  $event.ocsf.user.name = move $event.checkpoint.user
 }
-if checkpoint.session? != null {
-  ocsf.session.uid = move checkpoint.session
+if $event.checkpoint.session? != null {
+  $event.ocsf.session.uid = move $event.checkpoint.session
 }
-if checkpoint.vpn_feature? != null {
-  ocsf.tunnel_type_id = 99
-  ocsf.tunnel_type = move checkpoint.vpn_feature
+if $event.checkpoint.vpn_feature? != null {
+  $event.ocsf.tunnel_type_id = 99
+  $event.ocsf.tunnel_type = move $event.checkpoint.vpn_feature
 }
-if checkpoint.proto? != null {
-  ocsf.connection_info.protocol_num = move checkpoint.proto
+if $event.checkpoint.proto? != null {
+  $event.ocsf.connection_info.protocol_num = move $event.checkpoint.proto
 }
-ocsf.protocol_name = "VPN"
+$event.ocsf.protocol_name = "VPN"
 
-checkpoint::ocsf::traffic
+checkpoint::ocsf::traffic event=$event

--- a/checkpoint/operators/ocsf/events/web_resource_access_activity.tql
+++ b/checkpoint/operators/ocsf/events/web_resource_access_activity.tql
@@ -1,62 +1,67 @@
 ---
 description: "Check Point URL/Application Control → OCSF Web Resource Access Activity (6004)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.web_resource_access_activity"
 
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 6
-ocsf.class_uid = 6004
+$event.ocsf.category_uid = 6
+$event.ocsf.class_uid = 6004
 
-match checkpoint.action? {
+match $event.checkpoint.action? {
   "Accept" | "Allow" => {
-    ocsf.activity_id = 1
-    ocsf.action_id = 1
-    ocsf.disposition_id = 1
-    ocsf.status_id = 1
+    $event.ocsf.activity_id = 1
+    $event.ocsf.action_id = 1
+    $event.ocsf.disposition_id = 1
+    $event.ocsf.status_id = 1
   }
   "Drop" | "Prevent" | "Reject" => {
-    ocsf.activity_id = 2
-    ocsf.action_id = 2
-    ocsf.disposition_id = 2
-    ocsf.status_id = 2
+    $event.ocsf.activity_id = 2
+    $event.ocsf.action_id = 2
+    $event.ocsf.disposition_id = 2
+    $event.ocsf.status_id = 2
   }
   _ => {
-    ocsf.activity_id = 0
-    ocsf.action_id = 0
-    ocsf.disposition_id = 0
-    ocsf.status_id = 0
+    $event.ocsf.activity_id = 0
+    $event.ocsf.action_id = 0
+    $event.ocsf.disposition_id = 0
+    $event.ocsf.status_id = 0
   }
 }
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-drop checkpoint.action?
+drop $event.checkpoint.action?
 
-if checkpoint.url? != null {
-  ocsf.http_request.url.path = checkpoint.url
-  ocsf.web_resources = [{
-    url_string: move checkpoint.url,
+if $event.checkpoint.url? != null {
+  $event.ocsf.http_request.url.path = $event.checkpoint.url
+  $event.ocsf.web_resources = [{
+    url_string: move $event.checkpoint.url,
   }]
 } else {
-  ocsf.http_request = {}
-  ocsf.web_resources = [{
-    name: ocsf.message? else "web resource",
+  $event.ocsf.http_request = {}
+  $event.ocsf.web_resources = [{
+    name: $event.ocsf.message? else "web resource",
   }]
 }
 
-if checkpoint.src? != null {
-  ocsf.src_endpoint.ip = move checkpoint.src
+if $event.checkpoint.src? != null {
+  $event.ocsf.src_endpoint.ip = move $event.checkpoint.src
 }
-if checkpoint.s_port? != null {
-  ocsf.src_endpoint.port = move checkpoint.s_port
+if $event.checkpoint.s_port? != null {
+  $event.ocsf.src_endpoint.port = move $event.checkpoint.s_port
 }
-if checkpoint.sname? != null {
-  ocsf.src_endpoint.hostname = move checkpoint.sname
+if $event.checkpoint.sname? != null {
+  $event.ocsf.src_endpoint.hostname = move $event.checkpoint.sname
 }
-if checkpoint.user? != null {
-  ocsf.actor.user.name = move checkpoint.user
+if $event.checkpoint.user? != null {
+  $event.ocsf.actor.user.name = move $event.checkpoint.user
 }
-if checkpoint.reason? != null {
-  ocsf.status_detail = move checkpoint.reason
+if $event.checkpoint.reason? != null {
+  $event.ocsf.status_detail = move $event.checkpoint.reason
 }

--- a/checkpoint/operators/ocsf/map.tql
+++ b/checkpoint/operators/ocsf/map.tql
@@ -1,9 +1,14 @@
 ---
 description: Check Point → OCSF
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {checkpoint: this}
-ocsf = {}
+$event = {...$event, checkpoint: $event, ocsf: {}}
 
 let $severities = {
   Accept: 1,
@@ -12,8 +17,8 @@ let $severities = {
   Prevent: 2,
   Reject: 2,
 }
-ocsf.severity_id = $severities[checkpoint.action?]? else 0
-if checkpoint.severity? != null {
+$event.ocsf.severity_id = $severities[$event.checkpoint.action?]? else 0
+if $event.checkpoint.severity? != null {
   let $severity_names = {
     informational: 1,
     info: 1,
@@ -23,11 +28,11 @@ if checkpoint.severity? != null {
     critical: 5,
     fatal: 6,
   }
-  ocsf.severity_id = $severity_names[checkpoint.severity.string().to_lower()]? else ocsf.severity_id
-  drop checkpoint.severity
+  $event.ocsf.severity_id = $severity_names[$event.checkpoint.severity.string().to_lower()]? else $event.ocsf.severity_id
+  drop $event.checkpoint.severity
 }
 
-ocsf.metadata = {
+$event.ocsf.metadata = {
   product: {
     vendor_name: "Check Point",
     name: "Check Point Firewall",
@@ -35,91 +40,91 @@ ocsf.metadata = {
   profiles: ["host"],
   version: "1.8.0",
 }
-if checkpoint.product? != null {
-  ocsf.metadata.product.name = move checkpoint.product
+if $event.checkpoint.product? != null {
+  $event.ocsf.metadata.product.name = move $event.checkpoint.product
 }
-if checkpoint.loguid? != null {
-  ocsf.metadata.uid = move checkpoint.loguid
+if $event.checkpoint.loguid? != null {
+  $event.ocsf.metadata.uid = move $event.checkpoint.loguid
 }
-if checkpoint.logid? != null {
-  ocsf.metadata.event_code = (move checkpoint.logid).string()
+if $event.checkpoint.logid? != null {
+  $event.ocsf.metadata.event_code = (move $event.checkpoint.logid).string()
 }
-if checkpoint.h_version? != null {
-  ocsf.metadata.log_version = (move checkpoint.h_version).string()
+if $event.checkpoint.h_version? != null {
+  $event.ocsf.metadata.log_version = (move $event.checkpoint.h_version).string()
 }
-if checkpoint.sequencenum? != null {
-  ocsf.metadata.original_event_uid = (move checkpoint.sequencenum).string()
+if $event.checkpoint.sequencenum? != null {
+  $event.ocsf.metadata.original_event_uid = (move $event.checkpoint.sequencenum).string()
 }
-if checkpoint.syslog? != null {
-  ocsf.metadata.log_format = "syslog"
+if $event.checkpoint.syslog? != null {
+  $event.ocsf.metadata.log_format = "syslog"
 }
-if checkpoint.action? != null {
-  ocsf.metadata.log_name = checkpoint.action
+if $event.checkpoint.action? != null {
+  $event.ocsf.metadata.log_name = $event.checkpoint.action
 }
 
-if checkpoint.time? == null and checkpoint.syslog?.timestamp? != null {
-  ocsf.time = move checkpoint.syslog.timestamp
+if $event.checkpoint.time? == null and $event.checkpoint.syslog?.timestamp? != null {
+  $event.ocsf.time = move $event.checkpoint.syslog.timestamp
 }
-if checkpoint.time? != null {
-  ocsf.time = move checkpoint.time
+if $event.checkpoint.time? != null {
+  $event.ocsf.time = move $event.checkpoint.time
 }
-if checkpoint.action? != null {
-  ocsf.message = checkpoint.action
+if $event.checkpoint.action? != null {
+  $event.ocsf.message = $event.checkpoint.action
 }
-if checkpoint.message_info? != null {
-  ocsf.message = move checkpoint.message_info
+if $event.checkpoint.message_info? != null {
+  $event.ocsf.message = move $event.checkpoint.message_info
 }
 
 // Prefer the Check Point payload hostname over the syslog header hostname,
 // because forwarded syslog headers often identify a relay.
-if checkpoint.hostname? == null and checkpoint.syslog?.hostname? != null {
-  ocsf.device.hostname = (move checkpoint.syslog.hostname).string()
+if $event.checkpoint.hostname? == null and $event.checkpoint.syslog?.hostname? != null {
+  $event.ocsf.device.hostname = (move $event.checkpoint.syslog.hostname).string()
 }
-if checkpoint.hostname? != null {
-  ocsf.device.hostname = (move checkpoint.hostname).string()
+if $event.checkpoint.hostname? != null {
+  $event.ocsf.device.hostname = (move $event.checkpoint.hostname).string()
 }
-if checkpoint.origin? != null {
-  ocsf.device.ip = move checkpoint.origin
+if $event.checkpoint.origin? != null {
+  $event.ocsf.device.ip = move $event.checkpoint.origin
 }
 
 match @name {
   "checkpoint.firewall.threat" | "checkpoint.firewall.detection" => {
-    checkpoint::ocsf::security_context
-    checkpoint::ocsf::events::detection_finding
+    checkpoint::ocsf::security_context event=$event
+    checkpoint::ocsf::events::detection_finding event=$event
   }
   "checkpoint.firewall.network" => {
-    checkpoint::ocsf::security_context
-    checkpoint::ocsf::events::network_activity
+    checkpoint::ocsf::security_context event=$event
+    checkpoint::ocsf::events::network_activity event=$event
   }
   "checkpoint.firewall.web_resource" => {
-    checkpoint::ocsf::events::web_resource_access_activity
+    checkpoint::ocsf::events::web_resource_access_activity event=$event
   }
   "checkpoint.firewall.dlp" => {
-    checkpoint::ocsf::events::data_security_finding
+    checkpoint::ocsf::events::data_security_finding event=$event
   }
   "checkpoint.firewall.email" => {
-    checkpoint::ocsf::events::email_activity
+    checkpoint::ocsf::events::email_activity event=$event
   }
   "checkpoint.firewall.vpn" => {
-    checkpoint::ocsf::events::tunnel_activity
+    checkpoint::ocsf::events::tunnel_activity event=$event
   }
   "checkpoint.management.api" => {
-    checkpoint::ocsf::events::api_activity
+    checkpoint::ocsf::events::api_activity event=$event
   }
   "checkpoint.management.audit" => {
-    checkpoint::ocsf::events::entity_management
+    checkpoint::ocsf::events::entity_management event=$event
   }
-  _ if checkpoint.action? == "Detect" or checkpoint.message_info? != null => {
-    checkpoint::ocsf::security_context
-    checkpoint::ocsf::events::detection_finding
+  _ if $event.checkpoint.action? == "Detect" or $event.checkpoint.message_info? != null => {
+    checkpoint::ocsf::security_context event=$event
+    checkpoint::ocsf::events::detection_finding event=$event
   }
-  _ if checkpoint.action? != null => {
-    checkpoint::ocsf::security_context
-    checkpoint::ocsf::events::network_activity
+  _ if $event.checkpoint.action? != null => {
+    checkpoint::ocsf::security_context event=$event
+    checkpoint::ocsf::events::network_activity event=$event
   }
   _ => {
-    checkpoint::ocsf::base
+    checkpoint::ocsf::base event=$event
   }
 }
 
-this = {...ocsf, unmapped: checkpoint}
+$event = {...$event.ocsf, unmapped: $event.checkpoint}

--- a/checkpoint/operators/ocsf/security_context.tql
+++ b/checkpoint/operators/ocsf/security_context.tql
@@ -1,115 +1,120 @@
 ---
 description: Apply shared Check Point security-control context
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-if checkpoint.hll_key? != null {
-  ocsf.connection_info.uid = (move checkpoint.hll_key).string()
+if $event.checkpoint.hll_key? != null {
+  $event.ocsf.connection_info.uid = (move $event.checkpoint.hll_key).string()
 }
-if checkpoint.proto? != null {
-  match checkpoint.proto {
+if $event.checkpoint.proto? != null {
+  match $event.checkpoint.proto {
     1 => {
-      ocsf.connection_info.protocol_name = "icmp"
+      $event.ocsf.connection_info.protocol_name = "icmp"
     }
     6 => {
-      ocsf.connection_info.protocol_name = "tcp"
+      $event.ocsf.connection_info.protocol_name = "tcp"
     }
     17 => {
-      ocsf.connection_info.protocol_name = "udp"
+      $event.ocsf.connection_info.protocol_name = "udp"
     }
     _ => {}
   }
-  ocsf.connection_info.protocol_num = move checkpoint.proto
+  $event.ocsf.connection_info.protocol_num = move $event.checkpoint.proto
 }
-if checkpoint.protocol_name? != null {
-  ocsf.connection_info.protocol_name = move checkpoint.protocol_name
+if $event.checkpoint.protocol_name? != null {
+  $event.ocsf.connection_info.protocol_name = move $event.checkpoint.protocol_name
 }
 
 let $connection_direction_ids = {
   Incoming: 1,
   Outgoing: 2,
 }
-if $connection_direction_ids[checkpoint.conn_direction?]? != null {
-  ocsf.connection_info.direction_id = $connection_direction_ids[checkpoint.conn_direction?]
+if $connection_direction_ids[$event.checkpoint.conn_direction?]? != null {
+  $event.ocsf.connection_info.direction_id = $connection_direction_ids[$event.checkpoint.conn_direction?]
 }
-drop checkpoint.conn_direction?
-if checkpoint.inzone? != null and checkpoint.outzone? != null {
-  if checkpoint.inzone == "Internal" and checkpoint.outzone == "Internal" {
-    ocsf.connection_info.direction_id = 3
-  } else if checkpoint.inzone == "External" and checkpoint.outzone != "External" {
-    ocsf.connection_info.direction_id = 1
-  } else if checkpoint.inzone != "External" and checkpoint.outzone == "External" {
-    ocsf.connection_info.direction_id = 2
+drop $event.checkpoint.conn_direction?
+if $event.checkpoint.inzone? != null and $event.checkpoint.outzone? != null {
+  if $event.checkpoint.inzone == "Internal" and $event.checkpoint.outzone == "Internal" {
+    $event.ocsf.connection_info.direction_id = 3
+  } else if $event.checkpoint.inzone == "External" and $event.checkpoint.outzone != "External" {
+    $event.ocsf.connection_info.direction_id = 1
+  } else if $event.checkpoint.inzone != "External" and $event.checkpoint.outzone == "External" {
+    $event.ocsf.connection_info.direction_id = 2
   }
 }
 
-if checkpoint.src? != null {
-  ocsf.src_endpoint.ip = move checkpoint.src
+if $event.checkpoint.src? != null {
+  $event.ocsf.src_endpoint.ip = move $event.checkpoint.src
 }
-if checkpoint.s_port? != null {
-  ocsf.src_endpoint.port = move checkpoint.s_port
+if $event.checkpoint.s_port? != null {
+  $event.ocsf.src_endpoint.port = move $event.checkpoint.s_port
 }
-if checkpoint.sname? != null {
-  ocsf.src_endpoint.hostname = move checkpoint.sname
+if $event.checkpoint.sname? != null {
+  $event.ocsf.src_endpoint.hostname = move $event.checkpoint.sname
 }
-if checkpoint.inzone? != null {
-  ocsf.src_endpoint.zone = move checkpoint.inzone
+if $event.checkpoint.inzone? != null {
+  $event.ocsf.src_endpoint.zone = move $event.checkpoint.inzone
 }
-if checkpoint.dst? != null {
-  ocsf.dst_endpoint.ip = move checkpoint.dst
+if $event.checkpoint.dst? != null {
+  $event.ocsf.dst_endpoint.ip = move $event.checkpoint.dst
 }
-if checkpoint.service? != null {
-  ocsf.dst_endpoint.port = move checkpoint.service
+if $event.checkpoint.service? != null {
+  $event.ocsf.dst_endpoint.port = move $event.checkpoint.service
 }
-if checkpoint.service_id? != null {
-  ocsf.dst_endpoint.svc_name = move checkpoint.service_id
+if $event.checkpoint.service_id? != null {
+  $event.ocsf.dst_endpoint.svc_name = move $event.checkpoint.service_id
 }
-if checkpoint.dname? != null {
-  ocsf.dst_endpoint.hostname = move checkpoint.dname
+if $event.checkpoint.dname? != null {
+  $event.ocsf.dst_endpoint.hostname = move $event.checkpoint.dname
 }
-if checkpoint.dst_domain_name? != null {
-  ocsf.dst_endpoint.domain = move checkpoint.dst_domain_name
+if $event.checkpoint.dst_domain_name? != null {
+  $event.ocsf.dst_endpoint.domain = move $event.checkpoint.dst_domain_name
 }
-if checkpoint.outzone? != null {
-  ocsf.dst_endpoint.zone = move checkpoint.outzone
-}
-
-if checkpoint.snatip? != null {
-  ocsf.src_endpoint.proxy_endpoint.ip = move checkpoint.snatip
-}
-if checkpoint.snatport? != null {
-  ocsf.src_endpoint.proxy_endpoint.port = move checkpoint.snatport
-}
-if checkpoint.dnatip? != null {
-  ocsf.dst_endpoint.proxy_endpoint.ip = move checkpoint.dnatip
-}
-if checkpoint.dnatport? != null {
-  ocsf.dst_endpoint.proxy_endpoint.port = move checkpoint.dnatport
+if $event.checkpoint.outzone? != null {
+  $event.ocsf.dst_endpoint.zone = move $event.checkpoint.outzone
 }
 
-if checkpoint.user? != null {
-  ocsf.actor.user.name = move checkpoint.user
+if $event.checkpoint.snatip? != null {
+  $event.ocsf.src_endpoint.proxy_endpoint.ip = move $event.checkpoint.snatip
 }
-if checkpoint.app_name? != null {
-  ocsf.app_name = move checkpoint.app_name
+if $event.checkpoint.snatport? != null {
+  $event.ocsf.src_endpoint.proxy_endpoint.port = move $event.checkpoint.snatport
+}
+if $event.checkpoint.dnatip? != null {
+  $event.ocsf.dst_endpoint.proxy_endpoint.ip = move $event.checkpoint.dnatip
+}
+if $event.checkpoint.dnatport? != null {
+  $event.ocsf.dst_endpoint.proxy_endpoint.port = move $event.checkpoint.dnatport
 }
 
-if checkpoint.rule_name? != null or checkpoint.rule_uid? != null {
-  ocsf.firewall_rule = {
-    name: checkpoint.rule_name[0]?
-      if type_of(checkpoint.rule_name?).kind == "list"
-      else checkpoint.rule_name?,
-    uid: checkpoint.rule_uid[0]?
-      if type_of(checkpoint.rule_uid?).kind == "list"
-      else checkpoint.rule_uid?,
+if $event.checkpoint.user? != null {
+  $event.ocsf.actor.user.name = move $event.checkpoint.user
+}
+if $event.checkpoint.app_name? != null {
+  $event.ocsf.app_name = move $event.checkpoint.app_name
+}
+
+if $event.checkpoint.rule_name? != null or $event.checkpoint.rule_uid? != null {
+  $event.ocsf.firewall_rule = {
+    name: $event.checkpoint.rule_name[0]?
+      if type_of($event.checkpoint.rule_name?).kind == "list"
+      else $event.checkpoint.rule_name?,
+    uid: $event.checkpoint.rule_uid[0]?
+      if type_of($event.checkpoint.rule_uid?).kind == "list"
+      else $event.checkpoint.rule_uid?,
   }
-  drop checkpoint.rule_name?
-  drop checkpoint.rule_uid?
+  drop $event.checkpoint.rule_name?
+  drop $event.checkpoint.rule_uid?
 }
 
-if ocsf.src_endpoint?.ip? != null or ocsf.dst_endpoint?.ip? != null {
-  ocsf.connection_info.protocol_ver_id = 4
+if $event.ocsf.src_endpoint?.ip? != null or $event.ocsf.dst_endpoint?.ip? != null {
+  $event.ocsf.connection_info.protocol_ver_id = 4
 }
-if (ocsf.src_endpoint?.ip? != null and ocsf.src_endpoint.ip.is_v6()) or
-   (ocsf.dst_endpoint?.ip? != null and ocsf.dst_endpoint.ip.is_v6()) {
-  ocsf.connection_info.protocol_ver_id = 6
+if ($event.ocsf.src_endpoint?.ip? != null and $event.ocsf.src_endpoint.ip.is_v6()) or
+   ($event.ocsf.dst_endpoint?.ip? != null and $event.ocsf.dst_endpoint.ip.is_v6()) {
+  $event.ocsf.connection_info.protocol_ver_id = 6
 }

--- a/checkpoint/operators/ocsf/security_control_outcome.tql
+++ b/checkpoint/operators/ocsf/security_control_outcome.tql
@@ -1,27 +1,32 @@
 ---
 description: Apply shared Check Point security-control action outcome
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-match checkpoint.action? {
+match $event.checkpoint.action? {
   "Accept" => {
-    ocsf.action_id = 1
-    ocsf.disposition_id = 1
-    ocsf.status_id = 1
+    $event.ocsf.action_id = 1
+    $event.ocsf.disposition_id = 1
+    $event.ocsf.status_id = 1
   }
   "Detect" => {
-    ocsf.action_id = 3
-    ocsf.disposition_id = 15
-    ocsf.status_id = 1
+    $event.ocsf.action_id = 3
+    $event.ocsf.disposition_id = 15
+    $event.ocsf.status_id = 1
   }
   "Drop" | "Prevent" | "Reject" => {
-    ocsf.action_id = 2
-    ocsf.disposition_id = 2
-    ocsf.status_id = 2
+    $event.ocsf.action_id = 2
+    $event.ocsf.disposition_id = 2
+    $event.ocsf.status_id = 2
   }
   _ => {
-    ocsf.action_id = 0
-    ocsf.disposition_id = 0
-    ocsf.status_id = 0
+    $event.ocsf.action_id = 0
+    $event.ocsf.disposition_id = 0
+    $event.ocsf.status_id = 0
   }
 }
-drop checkpoint.action?
+drop $event.checkpoint.action?

--- a/checkpoint/operators/ocsf/status.tql
+++ b/checkpoint/operators/ocsf/status.tql
@@ -1,14 +1,19 @@
 ---
 description: Apply shared Check Point status outcome
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-match checkpoint.status? {
+match $event.checkpoint.status? {
   "Success" => {
-    ocsf.status_id = 1
+    $event.ocsf.status_id = 1
   }
   "Failure" => {
-    ocsf.status_id = 2
+    $event.ocsf.status_id = 2
   }
   _ => {}
 }
-drop checkpoint.status?
+drop $event.checkpoint.status?

--- a/checkpoint/operators/ocsf/traffic.tql
+++ b/checkpoint/operators/ocsf/traffic.tql
@@ -1,27 +1,32 @@
 ---
 description: Apply shared Check Point traffic counters
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-ocsf.traffic = {
-  bytes: move checkpoint.bytes?,
-  bytes_in: move checkpoint.bytes_in?,
-  bytes_out: move checkpoint.bytes_out?,
-  packets: move checkpoint.packets?,
-  packets_in: move checkpoint.packets_in?,
-  packets_out: move checkpoint.packets_out?,
+$event.ocsf.traffic = {
+  bytes: move $event.checkpoint.bytes?,
+  bytes_in: move $event.checkpoint.bytes_in?,
+  bytes_out: move $event.checkpoint.bytes_out?,
+  packets: move $event.checkpoint.packets?,
+  packets_in: move $event.checkpoint.packets_in?,
+  packets_out: move $event.checkpoint.packets_out?,
 }
-if ocsf.traffic.bytes? == null and
-   ocsf.traffic.bytes_in? != null and
-   ocsf.traffic.bytes_out? != null {
-  ocsf.traffic.bytes = ocsf.traffic.bytes_in + ocsf.traffic.bytes_out
+if $event.ocsf.traffic.bytes? == null and
+   $event.ocsf.traffic.bytes_in? != null and
+   $event.ocsf.traffic.bytes_out? != null {
+  $event.ocsf.traffic.bytes = $event.ocsf.traffic.bytes_in + $event.ocsf.traffic.bytes_out
 }
-if ocsf.traffic.packets? == null and
-   ocsf.traffic.packets_in? != null and
-   ocsf.traffic.packets_out? != null {
-  ocsf.traffic.packets = ocsf.traffic.packets_in + ocsf.traffic.packets_out
+if $event.ocsf.traffic.packets? == null and
+   $event.ocsf.traffic.packets_in? != null and
+   $event.ocsf.traffic.packets_out? != null {
+  $event.ocsf.traffic.packets = $event.ocsf.traffic.packets_in + $event.ocsf.traffic.packets_out
 }
 
-if checkpoint.duration? != null and ocsf.time? != null {
-  ocsf.traffic.end_time = ocsf.time
-  ocsf.traffic.start_time = ocsf.time - (move checkpoint.duration)
+if $event.checkpoint.duration? != null and $event.ocsf.time? != null {
+  $event.ocsf.traffic.end_time = $event.ocsf.time
+  $event.ocsf.traffic.start_time = $event.ocsf.time - (move $event.checkpoint.duration)
 }

--- a/cisco/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/cisco/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,22 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:16.435958Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+```

--- a/cisco/operators/umbrella/ocsf/base.tql
+++ b/cisco/operators/umbrella/ocsf/base.tql
@@ -1,9 +1,14 @@
 ---
 description: Cisco Umbrella unsupported records → OCSF Base Event
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.base_event"
-ocsf.category_uid = 0
-ocsf.class_uid = 0
-ocsf.activity_id = 0
-ocsf.type_uid = 0
+$event.ocsf.category_uid = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.type_uid = 0

--- a/cisco/operators/umbrella/ocsf/events/dns.tql
+++ b/cisco/operators/umbrella/ocsf/events/dns.tql
@@ -1,34 +1,39 @@
 ---
 description: Cisco Umbrella DNS logs → OCSF DNS Activity
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.dns_activity"
-ocsf.category_uid = 4
-ocsf.class_uid = 4003
-ocsf.activity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4003
+$event.ocsf.activity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-if umbrella.timestamp? != null {
-  ocsf.time = move umbrella.timestamp
-  ocsf.query_time = ocsf.time
+if $event.umbrella.timestamp? != null {
+  $event.ocsf.time = move $event.umbrella.timestamp
+  $event.ocsf.query_time = $event.ocsf.time
 }
 
-if umbrella.external_ip? != null {
-  ocsf.src_endpoint.ip = move umbrella.external_ip
+if $event.umbrella.external_ip? != null {
+  $event.ocsf.src_endpoint.ip = move $event.umbrella.external_ip
 }
-if umbrella.internal_ip? != null {
-  ocsf.device.ip = move umbrella.internal_ip
+if $event.umbrella.internal_ip? != null {
+  $event.ocsf.device.ip = move $event.umbrella.internal_ip
 }
-ocsf.dst_endpoint.name = "Cisco Umbrella DNS"
+$event.ocsf.dst_endpoint.name = "Cisco Umbrella DNS"
 
-if umbrella.domain? != null {
-  ocsf.query.hostname = move umbrella.domain
+if $event.umbrella.domain? != null {
+  $event.ocsf.query.hostname = move $event.umbrella.domain
 }
-if umbrella.query_type? != null {
-  query_type = umbrella.query_type.parse_grok(r"%{NUMBER:value} \(%{WORD:name}\)")
-  ocsf.query.type = query_type.name
-  drop query_type
-  drop umbrella.query_type
+if $event.umbrella.query_type? != null {
+  $event.query_type = $event.umbrella.query_type.parse_grok(r"%{NUMBER:value} \(%{WORD:name}\)")
+  $event.ocsf.query.type = $event.query_type.name
+  drop $event.query_type
+  drop $event.umbrella.query_type
 }
 
 let $rcode_mapping = {
@@ -54,25 +59,25 @@ let $rcode_mapping = {
   BADTRUNC: {rcode_id: 22, rcode: "BADTRUNC"},
   BADCOOKIE: {rcode_id: 23, rcode: "BADCOOKIE"},
 }
-if umbrella.response_code? != null {
-  ocsf.rcode_id = $rcode_mapping[umbrella.response_code]?.rcode_id else 99
-  ocsf.rcode = $rcode_mapping[umbrella.response_code]?.rcode else umbrella.response_code
-  drop umbrella.response_code
+if $event.umbrella.response_code? != null {
+  $event.ocsf.rcode_id = $rcode_mapping[$event.umbrella.response_code]?.rcode_id else 99
+  $event.ocsf.rcode = $rcode_mapping[$event.umbrella.response_code]?.rcode else $event.umbrella.response_code
+  drop $event.umbrella.response_code
 }
 
-match umbrella.action? {
+match $event.umbrella.action? {
   "Allowed" => {
-    ocsf.action_id = 1
+    $event.ocsf.action_id = 1
   }
   "Denied" => {
-    ocsf.action_id = 2
+    $event.ocsf.action_id = 2
   }
   _ => {
-    ocsf.action_id = 0
+    $event.ocsf.action_id = 0
   }
 }
-if umbrella.action? != null {
-  ocsf.action = move umbrella.action
+if $event.umbrella.action? != null {
+  $event.ocsf.action = move $event.umbrella.action
 }
 
-ocsf.status_id = 1
+$event.ocsf.status_id = 1

--- a/cisco/operators/umbrella/ocsf/map.tql
+++ b/cisco/operators/umbrella/ocsf/map.tql
@@ -1,11 +1,16 @@
 ---
 description: Cisco Umbrella → OCSF
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {umbrella: this}
-ocsf = {}
+$event = {...$event, umbrella: $event, ocsf: {}}
 
-ocsf.metadata = {
+$event.ocsf.metadata = {
   product: {
     name: "Umbrella",
     vendor_name: "Cisco",
@@ -13,15 +18,15 @@ ocsf.metadata = {
   profiles: ["host", "security_control"],
   version: "1.8.0",
 }
-ocsf.severity_id = 1
+$event.ocsf.severity_id = 1
 
 match @name {
   "cisco.umbrella.dns" => {
-    cisco::umbrella::ocsf::events::dns
+    cisco::umbrella::ocsf::events::dns event=$event
   }
   _ => {
-    cisco::umbrella::ocsf::base
+    cisco::umbrella::ocsf::base event=$event
   }
 }
 
-this = {...ocsf, unmapped: umbrella}
+$event = {...$event.ocsf, unmapped: $event.umbrella}

--- a/dcso/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/dcso/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,22 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:17.167216Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+```

--- a/dcso/operators/tie/ocsf/map.tql
+++ b/dcso/operators/tie/ocsf/map.tql
@@ -1,61 +1,67 @@
 ---
 description: |
   DCSO TIE IOC → OCSF OSINT Inventory Info
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
 // Official schema definition: https://docs.dcso.de/docs/tie/tiev3/ioc_schema_definition
 
 // ------ OSINT Object --------
 
-this = {tie: this}
-osint = {}
+$event = {...$event, tie: $event, ocsf: {}}
+$event.osint = {}
 
 // MITRE ATT&CK
-tactics = tie.mitreTactics.map(x => {
+$event.tactics = $event.tie.mitreTactics.map(x => {
   tactic: {
     uid: x
   }
 })
-techniques = tie.mitreTechniques.map(x => {
+$event.techniques = $event.tie.mitreTechniques.map(x => {
   technique: {
     uid: x
   }
 })
-osint.attacks = [...(move tactics), ...(move techniques)]
-drop tie.mitreTactics, tie.mitreTechniques
+$event.osint.attacks = [...(move $event.tactics), ...(move $event.techniques)]
+drop $event.tie.mitreTactics, $event.tie.mitreTechniques
 
 // The OCSF OSINT object has just one campaign per IOC. This is arguably
 // incorrect, as an IOC can certainly be part of multiple campaigns.
 // Our workaround is to join the provided campaigns with a comma.
-osint.campaign = {
-  name: tie.targetCampaigns?.join(", ")
+$event.osint.campaign = {
+  name: $event.tie.targetCampaigns?.join(", ")
 }
-drop tie.targetCampaigns
+drop $event.tie.targetCampaigns
 
 // The TIE confidence is in [0,100].
-if tie.confidence? != null {
-  if tie.confidence < 30 {
-    osint.confidence_id = 1 // Low
-  } else if tie.confidence < 70 {
-    osint.confidence_id = 2 // Medium
+if $event.tie.confidence? != null {
+  if $event.tie.confidence < 30 {
+    $event.osint.confidence_id = 1 // Low
+  } else if $event.tie.confidence < 70 {
+    $event.osint.confidence_id = 2 // Medium
   } else {
-    osint.confidence_id = 3 // High
+    $event.osint.confidence_id = 3 // High
   }
-  drop tie.confidence
+  drop $event.tie.confidence
 }
-osint.created_time = move tie.created
-osint.labels = move tie.tags
+$event.osint.created_time = move $event.tie.created
+$event.osint.labels = move $event.tie.tags
 
 // This is not the best place to put the MISP event IDs.
-osint.malware = tie.malpedia?.map(x => {
+$event.osint.malware = $event.tie.malpedia?.map(x => {
   name: x,
   classification_ids: [0], // unknown
 })
-drop tie.malpedia
+drop $event.tie.malpedia
 
-osint.modified_time = move tie.modified
-osint.references = move tie.eventIDs
-osint.src_url = "https://api.dcso.de/tie/v3/iocs/" + encode_url(tie.ioc)
+$event.osint.modified_time = move $event.tie.modified
+$event.osint.references = move $event.tie.eventIDs
+$event.osint.src_url = "https://api.dcso.de/tie/v3/iocs/" + encode_url($event.tie.ioc)
 
 // Map threat actors.
 let $tlps = {
@@ -65,30 +71,30 @@ let $tlps = {
   "amber+strict": "AMBER STRICT",
   red: "RED",
 }
-osint.tlp = $tlps[move tie.tlpLevel]?
+$event.osint.tlp = $tlps[move $event.tie.tlpLevel]?
 // Same as above: our source has an array here but we must map it to a
 // singular object.
-osint.threat_actor = {
-  name: tie.threatActors?.join(", "),
+$event.osint.threat_actor = {
+  name: $event.tie.threatActors?.join(", "),
 }
-drop tie.threatActors
+drop $event.tie.threatActors
 
 // Map severity from [0,100].
-if tie.severity? != null {
-  if tie.severity < 20 {
-    osint.severity_id = 1 // Informational
-  } else if tie.severity < 40 {
-    osint.severity_id = 2 // Low
-  } else if tie.severity < 60 {
-    osint.severity_id = 3 // Medium
-  } else if tie.severity < 80 {
-    osint.severity_id = 4 // High
-  } else if tie.severity < 90 {
-    osint.severity_id = 5 // Critical
+if $event.tie.severity? != null {
+  if $event.tie.severity < 20 {
+    $event.osint.severity_id = 1 // Informational
+  } else if $event.tie.severity < 40 {
+    $event.osint.severity_id = 2 // Low
+  } else if $event.tie.severity < 60 {
+    $event.osint.severity_id = 3 // Medium
+  } else if $event.tie.severity < 80 {
+    $event.osint.severity_id = 4 // High
+  } else if $event.tie.severity < 90 {
+    $event.osint.severity_id = 5 // Critical
   } else {
-    osint.severity_id = 6 // Fatal
+    $event.osint.severity_id = 6 // Fatal
   }
-  drop tie.severity
+  drop $event.tie.severity
 }
 // Map IOC type.
 let $type_ids = {
@@ -111,25 +117,25 @@ let $type_ids = {
   url: 5,
   userAgent: 6,
 }
-osint.type_id = $type_ids[move tie.iocType]
-osint.value = move tie.ioc
+$event.osint.type_id = $type_ids[move $event.tie.iocType]
+$event.osint.value = move $event.tie.ioc
 
-osint.vendor_name = "DCSO"
+$event.osint.vendor_name = "DCSO"
 
 // ------ OSINT Inventory Info --------
 
-ocsf = {}
+$event.ocsf = {}
 // Classification
-ocsf.activity_id = 2
-ocsf.category_uid = 5
-ocsf.class_uid = 5021
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 2
+$event.ocsf.category_uid = 5
+$event.ocsf.class_uid = 5021
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 // Context
-ocsf.actor = {
+$event.ocsf.actor = {
   app_name: "Tenzir"
 }
-ocsf.metadata = {
+$event.ocsf.metadata = {
   product: {
     name: "TIE",
     vendor_name: "DCSO",
@@ -137,11 +143,11 @@ ocsf.metadata = {
   version: "1.8.0",
 }
 // Occurence
-ocsf.time = now()
+$event.ocsf.time = now()
 // Primary
-ocsf.osint = [move osint]
+$event.ocsf.osint = [move $event.osint]
 
 // ------ Epilogue --------
 
-this = {...ocsf, unmapped: tie}
+$event = {...$event.ocsf, unmapped: $event.tie}
 @name = "ocsf.osint_inventory_info"

--- a/fortinet/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/fortinet/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,25 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:23.2253Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope. Preserve raw log data by parsing first, mapping the parsed event, and assigning `raw_data` and `raw_data_size` after mapping.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+source.raw_data = move raw
+source.raw_data_size = source.raw_data.length_bytes()
+this = source
+```

--- a/fortinet/examples/from-file-to-ocsf.tql
+++ b/fortinet/examples/from-file-to-ocsf.tql
@@ -1,5 +1,9 @@
 from_file "fortigate.log" {
   read_lines
 }
-fortinet::fortigate::ocsf::map line
+fortinet = line.parse_kv()
+fortinet::fortigate::ocsf::map event=fortinet
+fortinet.raw_data = move line
+fortinet.raw_data_size = fortinet.raw_data.length_bytes()
+this = fortinet
 ocsf::derive

--- a/fortinet/examples/map-to-ocsf.tql
+++ b/fortinet/examples/map-to-ocsf.tql
@@ -3,7 +3,11 @@ name: FortiGate → OCSF
 ---
 
 subscribe "fortinet"
-fortinet::fortigate::ocsf::map content
+fortinet = content.parse_kv()
+fortinet::fortigate::ocsf::map event=fortinet
+fortinet.raw_data = move content
+fortinet.raw_data_size = fortinet.raw_data.length_bytes()
+this = fortinet
 fortinet::fortigate::ocsf::syslog
 ocsf::derive
 publish "ocsf"

--- a/fortinet/operators/fortigate/ocsf/base.tql
+++ b/fortinet/operators/fortigate/ocsf/base.tql
@@ -1,4 +1,11 @@
-  ocsf.activity_id = 0
-  ocsf.category_uid = 0
-  ocsf.class_uid = 0
-  ocsf.type_uid = 0
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
+  $event.ocsf.activity_id = 0
+  $event.ocsf.category_uid = 0
+  $event.ocsf.class_uid = 0
+  $event.ocsf.type_uid = 0

--- a/fortinet/operators/fortigate/ocsf/connection_info.tql
+++ b/fortinet/operators/fortigate/ocsf/connection_info.tql
@@ -3,18 +3,23 @@ description: >-
   Common FortiGate connection fields → OCSF connection_info.
   Maps proto → protocol_num, sessionid → uid (optional), and
   direction (incoming/outgoing) → direction_id.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-ocsf.connection_info = {
-  protocol_num: move fortinet.proto,
+$event.ocsf.connection_info = {
+  protocol_num: move $event.fortinet.proto,
   direction_id: 0,
 }
-if fortinet.sessionid? != null {
-  ocsf.connection_info.uid = (move fortinet.sessionid).string()
+if $event.fortinet.sessionid? != null {
+  $event.ocsf.connection_info.uid = (move $event.fortinet.sessionid).string()
 }
-if fortinet.direction? == "incoming" {
-  ocsf.connection_info.direction_id = 1
-} else if fortinet.direction? == "outgoing" {
-  ocsf.connection_info.direction_id = 2
+if $event.fortinet.direction? == "incoming" {
+  $event.ocsf.connection_info.direction_id = 1
+} else if $event.fortinet.direction? == "outgoing" {
+  $event.ocsf.connection_info.direction_id = 2
 }
-drop fortinet.direction?
+drop $event.fortinet.direction?

--- a/fortinet/operators/fortigate/ocsf/logs/anomaly.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/anomaly.tql
@@ -1,64 +1,69 @@
 ---
 description: "FortiGate anomaly/DoS logs → OCSF Detection Finding (2004)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.detection_finding"
 
-ocsf.category_uid = 2
-ocsf.class_uid = 2004
-ocsf.activity_id = 1  // Create: a new anomaly detection
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2004
+$event.ocsf.activity_id = 1  // Create: a new anomaly detection
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-ocsf.is_alert = true
+$event.ocsf.is_alert = true
 
-drop fortinet.eventtype
+drop $event.fortinet.eventtype
 
 // `attack` is the anomaly/DoS signature name; `attackid` is its numeric ID.
 // Cache attackid as a temp field so both uid slots can reference it without
 // consuming it on first use (let doesn't support move).
-ocsf._attackid = (move fortinet.attackid).string()
-ocsf.finding_info = {
-  uid: ocsf._attackid,
-  title: fortinet.attack,
-  src_url: move fortinet.ref,
+$event.ocsf._attackid = (move $event.fortinet.attackid).string()
+$event.ocsf.finding_info = {
+  uid: $event.ocsf._attackid,
+  title: $event.fortinet.attack,
+  src_url: move $event.fortinet.ref,
   analytic: {
     type_id: 1,  // Rule
-    uid: ocsf._attackid,
-    name: move fortinet.attack,
+    uid: $event.ocsf._attackid,
+    name: move $event.fortinet.attack,
   },
 }
-drop ocsf._attackid
+drop $event.ocsf._attackid
 
 // Network context goes into evidences for Detection Finding.
-fortinet::fortigate::ocsf::network_endpoints
-fortinet::fortigate::ocsf::connection_info
+fortinet::fortigate::ocsf::network_endpoints event=$event
+fortinet::fortigate::ocsf::connection_info event=$event
 // Only emit evidences when at least one endpoint IP is present.
-if ocsf.src_endpoint.ip? != null or ocsf.dst_endpoint.ip? != null {
-  ocsf.evidences = [{
-    src_endpoint: move ocsf.src_endpoint,
-    dst_endpoint: move ocsf.dst_endpoint,
-    connection_info: move ocsf.connection_info,
+if $event.ocsf.src_endpoint.ip? != null or $event.ocsf.dst_endpoint.ip? != null {
+  $event.ocsf.evidences = [{
+    src_endpoint: move $event.ocsf.src_endpoint,
+    dst_endpoint: move $event.ocsf.dst_endpoint,
+    connection_info: move $event.ocsf.connection_info,
   }]
 } else {
-  drop ocsf.src_endpoint?
-  drop ocsf.dst_endpoint?
-  drop ocsf.connection_info?
+  drop $event.ocsf.src_endpoint?
+  drop $event.ocsf.dst_endpoint?
+  drop $event.ocsf.connection_info?
 }
 
 // Security-control profile: `policytype` identifies the policy table (e.g.
 // "DoS-policy"); extend firewall_rule after the common UDO sets uid.
-fortinet::fortigate::ocsf::security_control
-if fortinet.policytype? != null {
-  ocsf.firewall_rule.type = move fortinet.policytype
+fortinet::fortigate::ocsf::security_control event=$event
+if $event.fortinet.policytype? != null {
+  $event.ocsf.firewall_rule.type = move $event.fortinet.policytype
 }
 
-if fortinet.action? != null {
+if $event.fortinet.action? != null {
   let $dispositions = {
     "clear_session": 6,   // Dropped
     pass: 1,
     block: 2,
   }
-  ocsf.disposition_id = $dispositions[move fortinet.action]? else 0
+  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
 }
 
-fortinet::fortigate::ocsf::risk
+fortinet::fortigate::ocsf::risk event=$event

--- a/fortinet/operators/fortigate/ocsf/logs/app_ctrl.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/app_ctrl.tql
@@ -1,5 +1,10 @@
 ---
 description: "FortiGate application control logs → OCSF Network Activity (4001)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.network_activity"
@@ -12,36 +17,36 @@ let $actions = {
   reset: 3,   // Reset
 }
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
-ocsf.activity_id = $actions[fortinet.action?]? else 0
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
+$event.ocsf.activity_id = $actions[$event.fortinet.action?]? else 0
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-drop fortinet.eventtype
+drop $event.fortinet.eventtype
 
-fortinet::fortigate::ocsf::network_endpoints
-ocsf.dst_endpoint.hostname = move fortinet.hostname
+fortinet::fortigate::ocsf::network_endpoints event=$event
+$event.ocsf.dst_endpoint.hostname = move $event.fortinet.hostname
 
-fortinet::fortigate::ocsf::connection_info
+fortinet::fortigate::ocsf::connection_info event=$event
 
 // `app` is the identified application; `appcat` is its category.
-if fortinet.app? != null {
-  ocsf.app_name = move fortinet.app
+if $event.fortinet.app? != null {
+  $event.ocsf.app_name = move $event.fortinet.app
 }
 
 // `applist` is the application control profile; used as policy.name instead
 // of `profile` since app-ctrl logs use applist for the applied rule set.
-fortinet::fortigate::ocsf::security_control
-if fortinet.applist? != null {
-  ocsf.policy = { name: move fortinet.applist }
+fortinet::fortigate::ocsf::security_control event=$event
+if $event.fortinet.applist? != null {
+  $event.ocsf.policy = { name: move $event.fortinet.applist }
 }
 
-if fortinet.action? != null {
+if $event.fortinet.action? != null {
   let $dispositions = {
     pass: 1,
     block: 2,
     drop: 6,
     reset: 21,
   }
-  ocsf.disposition_id = $dispositions[move fortinet.action]? else 0
+  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
 }

--- a/fortinet/operators/fortigate/ocsf/logs/authentication.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/authentication.tql
@@ -1,5 +1,10 @@
 ---
 description: "FortiGate user/system event logs → OCSF Authentication (3002)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.authentication"
@@ -11,74 +16,74 @@ let $actions = {
   authentication: 1,
 }
 
-ocsf.category_uid = 3
-ocsf.class_uid = 3002
-ocsf.activity_id = $actions[move fortinet.action]? else 0
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 3
+$event.ocsf.class_uid = 3002
+$event.ocsf.activity_id = $actions[move $event.fortinet.action]? else 0
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // The authenticating user.
-ocsf.user = {
-  name: move fortinet.user,
+$event.ocsf.user = {
+  name: move $event.fortinet.user,
 }
 
 // event/user: `group` is the local user group.
-if fortinet.group? != null {
-  ocsf.user.groups = [{ name: move fortinet.group }]
+if $event.fortinet.group? != null {
+  $event.ocsf.user.groups = [{ name: move $event.fortinet.group }]
 }
 
 // event/system: `profile` is the admin privilege profile; presence implies
 // an administrative account.
-if fortinet.profile? != null {
-  ocsf.user.type_id = 2  // Admin
-  ocsf.user.groups = [{ name: move fortinet.profile }]
+if $event.fortinet.profile? != null {
+  $event.ocsf.user.type_id = 2  // Admin
+  $event.ocsf.user.groups = [{ name: move $event.fortinet.profile }]
 }
 
-ocsf.src_endpoint = {
-  ip: move fortinet.srcip,
+$event.ocsf.src_endpoint = {
+  ip: move $event.fortinet.srcip,
   // event/user: `interface` is the ingress network interface.
-  interface_name: move fortinet.interface?,
+  interface_name: move $event.fortinet.interface?,
 }
 
-ocsf.dst_endpoint = {
-  ip: move fortinet.dstip,
+$event.ocsf.dst_endpoint = {
+  ip: move $event.fortinet.dstip,
 }
 
 // Both events involve a remote authentication attempt.
-ocsf.is_remote = true
+$event.ocsf.is_remote = true
 
 // `status` is the authentication outcome.
-if fortinet.status? != null {
+if $event.fortinet.status? != null {
   let $statuses = {
     success: 1,
     failed: 2,
   }
-  ocsf.status_id = $statuses[move fortinet.status]? else 0
+  $event.ocsf.status_id = $statuses[move $event.fortinet.status]? else 0
 }
 
 // event/system: `method` is the access method (e.g. "ssh", "https").
 // event/user: `authproto` carries the protocol and source, e.g. "TELNET(ip)".
-if fortinet.method? != null {
+if $event.fortinet.method? != null {
   // auth_protocol_id = 99 (Other): SSH, HTTPS etc. are not in the OCSF enum.
   // The string sibling is intentionally omitted; ocsf::derive rejects
   // non-enum values for auth_protocol even when the id is Other.
-  ocsf.auth_protocol_id = 99
-  drop fortinet.method?
-  ocsf.logon_type_id = 10  // Remote Interactive
+  $event.ocsf.auth_protocol_id = 99
+  drop $event.fortinet.method?
+  $event.ocsf.logon_type_id = 10  // Remote Interactive
 }
-if fortinet.authproto? != null {
-  ocsf.auth_protocol_id = 99
-  drop fortinet.authproto?
-  ocsf.logon_type_id = 8  // Network Cleartext
-  ocsf.is_cleartext = true
+if $event.fortinet.authproto? != null {
+  $event.ocsf.auth_protocol_id = 99
+  drop $event.fortinet.authproto?
+  $event.ocsf.logon_type_id = 8  // Network Cleartext
+  $event.ocsf.is_cleartext = true
 }
 
 // event/system: `ui` duplicates method + srcip (e.g. "ssh(ip)"), drop it.
-drop fortinet.ui?
+drop $event.fortinet.ui?
 
 // Security-control profile: event/user carries policyid.
-if fortinet.policyid? != null {
-  ocsf.metadata.profiles = ocsf.metadata.profiles.add("security_control")
-  ocsf.firewall_rule = {
-    uid: (move fortinet.policyid).string(),
+if $event.fortinet.policyid? != null {
+  $event.ocsf.metadata.profiles = $event.ocsf.metadata.profiles.add("security_control")
+  $event.ocsf.firewall_rule = {
+    uid: (move $event.fortinet.policyid).string(),
   }
 }

--- a/fortinet/operators/fortigate/ocsf/logs/cifs.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/cifs.tql
@@ -1,34 +1,39 @@
 ---
 description: "FortiGate CIFS/SMB inspection logs → OCSF SMB Activity (4006)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.smb_activity"
 
 // CIFS file filter: a file was blocked or allowed during a file transfer.
 // Map to File Open since the activity is a client trying to access a file.
-ocsf.category_uid = 4
-ocsf.class_uid = 4006
-ocsf.activity_id = 2  // File Open
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4006
+$event.ocsf.activity_id = 2  // File Open
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-drop fortinet.eventtype
+drop $event.fortinet.eventtype
 
-fortinet::fortigate::ocsf::network_endpoints
-fortinet::fortigate::ocsf::connection_info
+fortinet::fortigate::ocsf::network_endpoints event=$event
+fortinet::fortigate::ocsf::connection_info event=$event
 
 // `filename` and `filesize` describe the file being transferred.
 // `filetype` stays in unmapped: type_name requires type_id sibling.
-ocsf.file = {
-  name: move fortinet.filename,
-  size: move fortinet.filesize,
+$event.ocsf.file = {
+  name: move $event.fortinet.filename,
+  size: move $event.fortinet.filesize,
 }
 
-fortinet::fortigate::ocsf::security_control
+fortinet::fortigate::ocsf::security_control event=$event
 
-if fortinet.action? != null {
+if $event.fortinet.action? != null {
   let $dispositions = {
     blocked: 2,
     allowed: 1,
   }
-  ocsf.disposition_id = $dispositions[move fortinet.action]? else 0
+  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
 }

--- a/fortinet/operators/fortigate/ocsf/logs/dlp.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/dlp.tql
@@ -1,40 +1,45 @@
 ---
 description: "FortiGate DLP logs → OCSF Detection Finding (2004)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.detection_finding"
 
-ocsf.category_uid = 2
-ocsf.class_uid = 2004
-ocsf.activity_id = 1  // Create
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2004
+$event.ocsf.activity_id = 1  // Create
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-ocsf.is_alert = true
+$event.ocsf.is_alert = true
 
-drop fortinet.eventtype
+drop $event.fortinet.eventtype
 
 // `dlpextra` is the matched DLP rule/filter name; `filteridx` its index.
-ocsf.finding_info = {
-  uid: (move fortinet.filteridx).string(),
-  title: move fortinet.dlpextra,
+$event.ocsf.finding_info = {
+  uid: (move $event.fortinet.filteridx).string(),
+  title: move $event.fortinet.dlpextra,
   analytic: {
     type_id: 1,  // Rule
-    category: move fortinet.filtertype,
+    category: move $event.fortinet.filtertype,
   },
 }
 
 // Network context goes into evidences for Detection Finding.
 // `hostname` is consumed by the network_evidence UDO.
-fortinet::fortigate::ocsf::network_evidence
+fortinet::fortigate::ocsf::network_evidence event=$event
 
-fortinet::fortigate::ocsf::security_control
+fortinet::fortigate::ocsf::security_control event=$event
 
-if fortinet.action? != null {
+if $event.fortinet.action? != null {
   let $dispositions = {
     block: 2,
     allow: 1,
     log_only: 17,
     quarantine: 3,
   }
-  ocsf.disposition_id = $dispositions[move fortinet.action]? else 0
+  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
 }

--- a/fortinet/operators/fortigate/ocsf/logs/dns.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/dns.tql
@@ -1,5 +1,10 @@
 ---
 description: "FortiGate DNS filter logs → OCSF DNS Activity (4003)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.dns_activity"
@@ -10,46 +15,46 @@ let $activities = {
   "dns-response": 2,
 }
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4003
-ocsf.activity_id = $activities[move fortinet.eventtype]? else 0
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4003
+$event.ocsf.activity_id = $activities[move $event.fortinet.eventtype]? else 0
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-fortinet::fortigate::ocsf::network_endpoints
-ocsf.src_endpoint.mac = move fortinet.srcmac
+fortinet::fortigate::ocsf::network_endpoints event=$event
+$event.ocsf.src_endpoint.mac = move $event.fortinet.srcmac
 
-fortinet::fortigate::ocsf::connection_info
+fortinet::fortigate::ocsf::connection_info event=$event
 
-ocsf.query = {
-  hostname: move fortinet.qname,
-  class: move fortinet.qclass,
-  packet_uid: move fortinet.xid,
-  type: move fortinet.qtype,
+$event.ocsf.query = {
+  hostname: move $event.fortinet.qname,
+  class: move $event.fortinet.qclass,
+  packet_uid: move $event.fortinet.xid,
+  type: move $event.fortinet.qtype,
 }
 
 // DNS responses carry the resolved address(es).
-if fortinet.ipaddr? != null {
-  ocsf.answers = [{
-    rdata: (move fortinet.ipaddr).string(),
-    type: ocsf.query.type,
-    class: ocsf.query.class,
+if $event.fortinet.ipaddr? != null {
+  $event.ocsf.answers = [{
+    rdata: (move $event.fortinet.ipaddr).string(),
+    type: $event.ocsf.query.type,
+    class: $event.ocsf.query.class,
   }]
 }
 
 // Security-control profile
 
 // Only response events carry an action (pass/block); queries are observation-only.
-if fortinet.action? != null {
+if $event.fortinet.action? != null {
   let $dispositions = {
     pass: 1,
     block: 2,
     drop: 6,
     monitor: 17,
   }
-  ocsf.disposition_id = $dispositions[move fortinet.action]? else 0
+  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
 }
 
 // `profile` is the DNS filter profile (UTM security policy) applied to the session.
 // `policyid` is the firewall policy rule that matched the session, distinct from
 // the DNS filter profile above.
-fortinet::fortigate::ocsf::security_control
+fortinet::fortigate::ocsf::security_control event=$event

--- a/fortinet/operators/fortigate/ocsf/logs/emailfilter.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/emailfilter.tql
@@ -1,49 +1,54 @@
 ---
 description: "FortiGate email filter logs → OCSF Email Activity (4009)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.email_activity"
 
 // Email filter events are scan actions on in-transit email.
-ocsf.category_uid = 4
-ocsf.class_uid = 4009
-ocsf.activity_id = 3  // Scan
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4009
+$event.ocsf.activity_id = 3  // Scan
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-drop fortinet.eventtype
+drop $event.fortinet.eventtype
 
 // `direction` maps to OCSF direction_id for the email flow (Email Activity
 // class carries this at the top level, not in connection_info).
-ocsf.direction_id = 0
-if fortinet.direction? == "incoming" {
-  ocsf.direction_id = 1  // Inbound
-} else if fortinet.direction? == "outgoing" {
-  ocsf.direction_id = 2  // Outbound
+$event.ocsf.direction_id = 0
+if $event.fortinet.direction? == "incoming" {
+  $event.ocsf.direction_id = 1  // Inbound
+} else if $event.fortinet.direction? == "outgoing" {
+  $event.ocsf.direction_id = 2  // Outbound
 }
-drop fortinet.direction?
+drop $event.fortinet.direction?
 
 // Email envelope fields.
-ocsf.email = {
-  from: move fortinet.from,
-  to: [move fortinet.to],
-  subject: move fortinet.subject,
-  size: move fortinet.size,
+$event.ocsf.email = {
+  from: move $event.fortinet.from,
+  to: [move $event.fortinet.to],
+  subject: move $event.fortinet.subject,
+  size: move $event.fortinet.size,
 }
 
 // `service` identifies the email protocol (IMAPS, SMTPS, POP3S).
 // Use move so network_endpoints does not also map it to dst_endpoint.svc_name.
-ocsf.protocol_name = move fortinet.service
+$event.ocsf.protocol_name = move $event.fortinet.service
 
-fortinet::fortigate::ocsf::network_endpoints
+fortinet::fortigate::ocsf::network_endpoints event=$event
 // Email Activity has no connection_info field; proto/sessionid stay in unmapped.
 
-fortinet::fortigate::ocsf::security_control
+fortinet::fortigate::ocsf::security_control event=$event
 
-if fortinet.action? != null {
+if $event.fortinet.action? != null {
   let $dispositions = {
     blocked: 2,
     allowed: 1,
     monitored: 17,
   }
-  ocsf.disposition_id = $dispositions[move fortinet.action]? else 0
+  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
 }

--- a/fortinet/operators/fortigate/ocsf/logs/endpoint.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/endpoint.tql
@@ -1,5 +1,10 @@
 ---
 description: "FortiGate endpoint event logs → OCSF Tunnel Activity (4014)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.tunnel_activity"
@@ -10,38 +15,38 @@ let $actions = {
   close: 2,  // Close
 }
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4014
-ocsf.activity_id = $actions[move fortinet.action]? else 0
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4014
+$event.ocsf.activity_id = $actions[move $event.fortinet.action]? else 0
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // `connection_type` is the VPN type (e.g. "sslvpn").
-ocsf.protocol_name = move fortinet.connection_type
+$event.ocsf.protocol_name = move $event.fortinet.connection_type
 
 // `ip` is the client endpoint IP; `name` is the device name.
-ocsf.src_endpoint = {
-  ip: move fortinet.ip,
-  hostname: move fortinet.name,
+$event.ocsf.src_endpoint = {
+  ip: move $event.fortinet.ip,
+  hostname: move $event.fortinet.name,
 }
 
 // `user` is the authenticated FortiClient user.
-if fortinet.user? != null {
-  ocsf.user = {
-    name: move fortinet.user,
+if $event.fortinet.user? != null {
+  $event.ocsf.user = {
+    name: move $event.fortinet.user,
   }
 }
 
 // `fctuid` is the FortiClient unique device identifier; use as session uid.
-if fortinet.fctuid? != null {
-  ocsf.session = {
-    uid: move fortinet.fctuid,
+if $event.fortinet.fctuid? != null {
+  $event.ocsf.session = {
+    uid: move $event.fortinet.fctuid,
   }
 }
 
-if fortinet.status? != null {
+if $event.fortinet.status? != null {
   let $statuses = {
     success: 1,
     failed: 2,
   }
-  ocsf.status_id = $statuses[move fortinet.status]? else 0
+  $event.ocsf.status_id = $statuses[move $event.fortinet.status]? else 0
 }

--- a/fortinet/operators/fortigate/ocsf/logs/ips.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/ips.tql
@@ -1,43 +1,48 @@
 ---
 description: "FortiGate IPS logs → OCSF Detection Finding (2004)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.detection_finding"
 
 // IPS events are always new detections.
-ocsf.category_uid = 2
-ocsf.class_uid = 2004
-ocsf.activity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2004
+$event.ocsf.activity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // IPS detections are always alertable.
-ocsf.is_alert = true
+$event.ocsf.is_alert = true
 
-drop fortinet.eventtype
+drop $event.fortinet.eventtype
 
 // `attack` is the signature name; `attackid` is its numeric ID;
 // `incidentserialno` is the unique identifier of this detection instance.
-ocsf.finding_info = {
-  uid: (move fortinet.incidentserialno).string(),
-  title: fortinet.attack,
-  src_url: move fortinet.ref,
+$event.ocsf.finding_info = {
+  uid: (move $event.fortinet.incidentserialno).string(),
+  title: $event.fortinet.attack,
+  src_url: move $event.fortinet.ref,
   analytic: {
     // IPS signatures are rule-based detections.
     type_id: 1,
-    uid: (move fortinet.attackid).string(),
-    name: move fortinet.attack,
+    uid: (move $event.fortinet.attackid).string(),
+    name: move $event.fortinet.attack,
   },
 }
 
 // Network context goes into evidences for Detection Finding.
 // `hostname` is consumed by the network_evidence UDO.
-fortinet::fortigate::ocsf::network_evidence
+fortinet::fortigate::ocsf::network_evidence event=$event
 
 // IPS is a security control: it detected and acted on the traffic.
 // `action` is the IPS response; map to disposition.
-fortinet::fortigate::ocsf::security_control
+fortinet::fortigate::ocsf::security_control event=$event
 
-if fortinet.action? != null {
+if $event.fortinet.action? != null {
   let $dispositions = {
     dropped: 6,
     pass: 1,
@@ -45,8 +50,8 @@ if fortinet.action? != null {
     block: 2,
     alert: 19,
   }
-  ocsf.disposition_id = $dispositions[move fortinet.action]? else 0
+  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
 }
 
 // `crscore`/`crlevel` are the composite UTM risk score and level.
-fortinet::fortigate::ocsf::risk
+fortinet::fortigate::ocsf::risk event=$event

--- a/fortinet/operators/fortigate/ocsf/logs/ssh.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/ssh.tql
@@ -1,5 +1,10 @@
 ---
 description: "FortiGate SSH inspection logs → OCSF SSH Activity (4007)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.ssh_activity"
@@ -11,27 +16,27 @@ let $actions = {
   "blocked": 5,  // Refuse
 }
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4007
-ocsf.activity_id = $actions[fortinet.action?]? else 0
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4007
+$event.ocsf.activity_id = $actions[$event.fortinet.action?]? else 0
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-drop fortinet.eventtype
+drop $event.fortinet.eventtype
 
-fortinet::fortigate::ocsf::network_endpoints
+fortinet::fortigate::ocsf::network_endpoints event=$event
 
 // `login` is the remote username used for the SSH session.
-if fortinet.login? != null {
-  ocsf.dst_endpoint.uid = move fortinet.login
+if $event.fortinet.login? != null {
+  $event.ocsf.dst_endpoint.uid = move $event.fortinet.login
 }
 
-fortinet::fortigate::ocsf::connection_info
-fortinet::fortigate::ocsf::security_control
+fortinet::fortigate::ocsf::connection_info event=$event
+fortinet::fortigate::ocsf::security_control event=$event
 
-if fortinet.action? != null {
+if $event.fortinet.action? != null {
   let $dispositions = {
     blocked: 2,
     allowed: 1,
   }
-  ocsf.disposition_id = $dispositions[move fortinet.action]? else 0
+  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
 }

--- a/fortinet/operators/fortigate/ocsf/logs/ssl.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/ssl.tql
@@ -1,5 +1,10 @@
 ---
 description: "FortiGate SSL inspection logs → OCSF Network Activity (4001)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.network_activity"
@@ -11,26 +16,26 @@ let $activities = {
   "ssl-exempt": 6,     // Traffic
 }
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
-ocsf.activity_id = $activities[move fortinet.eventtype]? else 0
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
+$event.ocsf.activity_id = $activities[move $event.fortinet.eventtype]? else 0
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-fortinet::fortigate::ocsf::network_endpoints
-fortinet::fortigate::ocsf::connection_info
+fortinet::fortigate::ocsf::network_endpoints event=$event
+fortinet::fortigate::ocsf::connection_info event=$event
 
 // `reason` is the specific SSL inspection verdict (e.g. block-cert-invalid).
-if fortinet.reason? != null {
-  ocsf.status_detail = move fortinet.reason
+if $event.fortinet.reason? != null {
+  $event.ocsf.status_detail = move $event.fortinet.reason
 }
 
 // SSL inspection is a security control.
-fortinet::fortigate::ocsf::security_control
+fortinet::fortigate::ocsf::security_control event=$event
 
-if fortinet.action? != null {
+if $event.fortinet.action? != null {
   let $dispositions = {
     blocked: 2,
     exempt: 1,
   }
-  ocsf.disposition_id = $dispositions[move fortinet.action]? else 0
+  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
 }

--- a/fortinet/operators/fortigate/ocsf/logs/traffic.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/traffic.tql
@@ -1,5 +1,10 @@
 ---
 description: "FortiGate traffic logs → OCSF Network Activity (4001)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.network_activity"
@@ -15,110 +20,110 @@ let $actions = {
   drop: 4,          // packet dropped mid-session
 }
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
-ocsf.activity_id = $actions[move fortinet.action]? else 0
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
+$event.ocsf.activity_id = $actions[move $event.fortinet.action]? else 0
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-ocsf.src_endpoint = {
-  ip: move fortinet.srcip,
-  port: move fortinet.srcport,
-  interface_name: move fortinet.srcintf,
-  mac: move fortinet.srcmac?,
+$event.ocsf.src_endpoint = {
+  ip: move $event.fortinet.srcip,
+  port: move $event.fortinet.srcport,
+  interface_name: move $event.fortinet.srcintf,
+  mac: move $event.fortinet.srcmac?,
 }
 
-ocsf.dst_endpoint = {
-  ip: move fortinet.dstip,
-  port: move fortinet.dstport,
-  interface_name: move fortinet.dstintf,
+$event.ocsf.dst_endpoint = {
+  ip: move $event.fortinet.dstip,
+  port: move $event.fortinet.dstport,
+  interface_name: move $event.fortinet.dstintf,
   // `service` is the application-layer protocol name for the destination port.
-  svc_name: move fortinet.service,
+  svc_name: move $event.fortinet.service,
 }
 
 // `srcintfrole`/`dstintfrole` are the network zones of the ingress/egress
 // interfaces (e.g. "lan", "wan", "dmz"). Map to endpoint.zone and derive
 // connection direction from the pairing when possible.
-if fortinet.srcintfrole? != null {
-  ocsf.src_endpoint.zone = fortinet.srcintfrole
+if $event.fortinet.srcintfrole? != null {
+  $event.ocsf.src_endpoint.zone = $event.fortinet.srcintfrole
 }
-if fortinet.dstintfrole? != null {
-  ocsf.dst_endpoint.zone = fortinet.dstintfrole
+if $event.fortinet.dstintfrole? != null {
+  $event.ocsf.dst_endpoint.zone = $event.fortinet.dstintfrole
 }
-ocsf.connection_info = {
-  protocol_num: move fortinet.proto,
-  uid: (move fortinet.sessionid).string(),
+$event.ocsf.connection_info = {
+  protocol_num: move $event.fortinet.proto,
+  uid: (move $event.fortinet.sessionid).string(),
   direction_id: 0,
 }
-if fortinet.srcintfrole? == "lan" and fortinet.dstintfrole? == "wan" {
-  ocsf.connection_info.direction_id = 2  // Outbound
-} else if fortinet.srcintfrole? == "wan" and fortinet.dstintfrole? == "lan" {
-  ocsf.connection_info.direction_id = 1  // Inbound
+if $event.fortinet.srcintfrole? == "lan" and $event.fortinet.dstintfrole? == "wan" {
+  $event.ocsf.connection_info.direction_id = 2  // Outbound
+} else if $event.fortinet.srcintfrole? == "wan" and $event.fortinet.dstintfrole? == "lan" {
+  $event.ocsf.connection_info.direction_id = 1  // Inbound
 }
-drop fortinet.srcintfrole?
-drop fortinet.dstintfrole?
+drop $event.fortinet.srcintfrole?
+drop $event.fortinet.dstintfrole?
 
 // `duration` is the session lifetime in seconds; `ocsf.time` is the end.
-ocsf.traffic = {
-  bytes_in: move fortinet.rcvdbyte,
-  bytes_out: move fortinet.sentbyte,
-  packets_in: move fortinet.rcvdpkt?,
-  packets_out: move fortinet.sentpkt,
-  end_time: ocsf.time,
-  start_time: ocsf.time - (move fortinet.duration?).seconds(),
+$event.ocsf.traffic = {
+  bytes_in: move $event.fortinet.rcvdbyte,
+  bytes_out: move $event.fortinet.sentbyte,
+  packets_in: move $event.fortinet.rcvdpkt?,
+  packets_out: move $event.fortinet.sentpkt,
+  end_time: $event.ocsf.time,
+  start_time: $event.ocsf.time - (move $event.fortinet.duration?).seconds(),
 }
 
 // `trandisp` is the NAT type applied; `transip`/`transport` are the translated
 // address/port. SNAT rewrites the source, DNAT rewrites the destination.
 // transip=0.0.0.0 means no effective translation (e.g. sniffer mode).
-if fortinet.trandisp? == "snat" and fortinet.transip? != 0.0.0.0 {
-  ocsf.src_endpoint.proxy_endpoint = {
-    ip: move fortinet.transip,
-    port: move fortinet.transport,
+if $event.fortinet.trandisp? == "snat" and $event.fortinet.transip? != 0.0.0.0 {
+  $event.ocsf.src_endpoint.proxy_endpoint = {
+    ip: move $event.fortinet.transip,
+    port: move $event.fortinet.transport,
   }
-} else if fortinet.trandisp? == "dnat" and fortinet.transip? != 0.0.0.0 {
-  ocsf.dst_endpoint.proxy_endpoint = {
-    ip: move fortinet.transip,
-    port: move fortinet.transport,
+} else if $event.fortinet.trandisp? == "dnat" and $event.fortinet.transip? != 0.0.0.0 {
+  $event.ocsf.dst_endpoint.proxy_endpoint = {
+    ip: move $event.fortinet.transip,
+    port: move $event.fortinet.transport,
   }
 }
-drop fortinet.trandisp?
-drop fortinet.transip?
-drop fortinet.transport?
+drop $event.fortinet.trandisp?
+drop $event.fortinet.transip?
+drop $event.fortinet.transport?
 
 // `app` is the application identified by deep packet inspection.
-if fortinet.app? != null {
-  ocsf.app_name = move fortinet.app
+if $event.fortinet.app? != null {
+  $event.ocsf.app_name = move $event.fortinet.app
 }
 
 // `osname` is the source device OS as fingerprinted by FortiGate.
-if fortinet.osname? != null {
-  ocsf.src_endpoint.os = {
-    name: move fortinet.osname,
+if $event.fortinet.osname? != null {
+  $event.ocsf.src_endpoint.os = {
+    name: move $event.fortinet.osname,
   }
 }
 
 // Traffic logs always reflect a firewall policy decision.
-ocsf.metadata.profiles = ocsf.metadata.profiles.add("security_control")
+$event.ocsf.metadata.profiles = $event.ocsf.metadata.profiles.add("security_control")
 
 // Firewall policy that matched the session.
 // `poluuid` is the policy UUID (absent in local/multicast/sniffer logs);
 // `policyid` is its numeric ID; `policytype` is the policy table
 // (e.g., "policy", "local-in-policy", "multicast-policy", "sniffer").
-ocsf.firewall_rule = {
-  uid: move fortinet.poluuid?,
-  name: (move fortinet.policyid).string(),
-  type: move fortinet.policytype,
+$event.ocsf.firewall_rule = {
+  uid: move $event.fortinet.poluuid?,
+  name: (move $event.fortinet.policyid).string(),
+  type: move $event.fortinet.policytype,
 }
 
 // `utmaction` is the outcome of the UTM/IPS engine, distinct from `action`
 // which reflects how the TCP/UDP session itself ended.
-if fortinet.utmaction? != null {
+if $event.fortinet.utmaction? != null {
   let $dispositions = {
     allow: 1,
     block: 2,
   }
-  ocsf.disposition_id = $dispositions[move fortinet.utmaction]? else 0
+  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.utmaction]? else 0
 }
 
 // `crscore`/`crlevel` are the composite UTM risk score and level.
-fortinet::fortigate::ocsf::risk
+fortinet::fortigate::ocsf::risk event=$event

--- a/fortinet/operators/fortigate/ocsf/logs/virus.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/virus.tql
@@ -1,51 +1,56 @@
 ---
 description: "FortiGate antivirus logs → OCSF Detection Finding (2004)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.detection_finding"
 
-ocsf.category_uid = 2
-ocsf.class_uid = 2004
-ocsf.activity_id = 1  // Create
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2004
+$event.ocsf.activity_id = 1  // Create
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-ocsf.is_alert = true
+$event.ocsf.is_alert = true
 
-drop fortinet.eventtype
+drop $event.fortinet.eventtype
 
 // `virus` is the malware name; `virusid` is the signature ID;
 // `dtype` is the detection type (e.g. "Virus", "Botnet").
-ocsf.malware = [{
-  name: move fortinet.virus,
-  uid: (move fortinet.virusid).string(),
+$event.ocsf.malware = [{
+  name: move $event.fortinet.virus,
+  uid: (move $event.fortinet.virusid).string(),
   // `dtype` maps to classification: "Virus" → 19.
   classification_ids: [19],
   provider: "FortiGate",
 }]
 
-ocsf.finding_info = {
-  uid: ocsf.malware[0].uid,
-  title: ocsf.malware[0].name,
-  src_url: move fortinet.ref,
+$event.ocsf.finding_info = {
+  uid: $event.ocsf.malware[0].uid,
+  title: $event.ocsf.malware[0].name,
+  src_url: move $event.fortinet.ref,
   analytic: {
     type_id: 1,  // Rule
-    name: ocsf.malware[0].name,
+    name: $event.ocsf.malware[0].name,
   },
 }
 
 // Network context goes into evidences for Detection Finding.
-fortinet::fortigate::ocsf::network_evidence
+fortinet::fortigate::ocsf::network_evidence event=$event
 
-fortinet::fortigate::ocsf::security_control
+fortinet::fortigate::ocsf::security_control event=$event
 
-if fortinet.action? != null {
+if $event.fortinet.action? != null {
   let $dispositions = {
     blocked: 2,
     allowed: 1,
     monitored: 17,
   }
-  ocsf.disposition_id = $dispositions[move fortinet.action]? else 0
+  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
 }
 
 // `crscore`/`crlevel` are the composite UTM risk score and level.
-fortinet::fortigate::ocsf::risk
+fortinet::fortigate::ocsf::risk event=$event

--- a/fortinet/operators/fortigate/ocsf/logs/vpn.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/vpn.tql
@@ -1,5 +1,10 @@
 ---
 description: "FortiGate VPN event logs → OCSF Tunnel Activity (4014)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.tunnel_activity"
@@ -13,60 +18,60 @@ let $actions = {
   delete: 2,
 }
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4014
-ocsf.activity_id = $actions[move fortinet.action]? else 0
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4014
+$event.ocsf.activity_id = $actions[move $event.fortinet.action]? else 0
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // `remip`/`remport` is the remote peer; `locip`/`locport` is the local end.
-ocsf.src_endpoint = {
-  ip: move fortinet.locip,
-  port: move fortinet.locport,
-  interface_name: move fortinet.outintf?,
+$event.ocsf.src_endpoint = {
+  ip: move $event.fortinet.locip,
+  port: move $event.fortinet.locport,
+  interface_name: move $event.fortinet.outintf?,
 }
 
-ocsf.dst_endpoint = {
-  ip: move fortinet.remip,
-  port: move fortinet.remport,
+$event.ocsf.dst_endpoint = {
+  ip: move $event.fortinet.remip,
+  port: move $event.fortinet.remport,
 }
 
 // `vpntunnel` is the configured tunnel name.
-if fortinet.vpntunnel? != null {
-  ocsf.tunnel_interface = {
-    name: move fortinet.vpntunnel,
+if $event.fortinet.vpntunnel? != null {
+  $event.ocsf.tunnel_interface = {
+    name: move $event.fortinet.vpntunnel,
   }
 }
 
 // `mode` is the IKE exchange mode (main, aggressive).
 // `dir` is the negotiation direction (inbound, outbound).
-ocsf.connection_info = {
+$event.ocsf.connection_info = {
   direction_id: 0,
 }
-if fortinet.dir? == "outbound" {
-  ocsf.connection_info.direction_id = 2
-} else if fortinet.dir? == "inbound" {
-  ocsf.connection_info.direction_id = 1
+if $event.fortinet.dir? == "outbound" {
+  $event.ocsf.connection_info.direction_id = 2
+} else if $event.fortinet.dir? == "inbound" {
+  $event.ocsf.connection_info.direction_id = 1
 }
-drop fortinet.dir?
+drop $event.fortinet.dir?
 
 // `status`/`result` reflect negotiation outcome.
-if fortinet.status? != null {
+if $event.fortinet.status? != null {
   let $statuses = {
     success: 1,
     failed: 2,
   }
-  ocsf.status_id = $statuses[move fortinet.status]? else 0
+  $event.ocsf.status_id = $statuses[move $event.fortinet.status]? else 0
 }
-drop fortinet.result?
+drop $event.fortinet.result?
 
 // IPsec-specific context: protocol is IKE (UDP 500).
-ocsf.protocol_name = "IPSec"
+$event.ocsf.protocol_name = "IPSec"
 
 // `user`/`group`/`xauthuser`/`xauthgroup` are already null after cleaning
 // (N/A → null); only populate if actually set.
-if fortinet.user? != null {
-  ocsf.user = { name: move fortinet.user }
+if $event.fortinet.user? != null {
+  $event.ocsf.user = { name: move $event.fortinet.user }
 }
-drop fortinet.group?
-drop fortinet.xauthuser?
-drop fortinet.xauthgroup?
+drop $event.fortinet.group?
+drop $event.fortinet.xauthuser?
+drop $event.fortinet.xauthgroup?

--- a/fortinet/operators/fortigate/ocsf/logs/wad.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/wad.tql
@@ -1,49 +1,54 @@
 ---
 description: "FortiGate WAD SSL alert logs → OCSF Network Activity (4001)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.network_activity"
 
 // SSL fatal alerts terminate the connection.
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
-ocsf.activity_id = 3  // Reset
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
+$event.ocsf.activity_id = 3  // Reset
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // `desc` is the human-readable reason for the SSL alert.
-if fortinet.desc? != null {
-  ocsf.status_detail = move fortinet.desc
+if $event.fortinet.desc? != null {
+  $event.ocsf.status_detail = move $event.fortinet.desc
 }
 
 // Only map endpoints when srcip is a real address.
-if fortinet.srcip? != null and fortinet.srcip != 0.0.0.0 {
-  ocsf.src_endpoint = {
-    ip: move fortinet.srcip,
-    port: move fortinet.srcport,
+if $event.fortinet.srcip? != null and $event.fortinet.srcip != 0.0.0.0 {
+  $event.ocsf.src_endpoint = {
+    ip: move $event.fortinet.srcip,
+    port: move $event.fortinet.srcport,
   }
 } else {
-  drop fortinet.srcip?
-  drop fortinet.srcport?
+  drop $event.fortinet.srcip?
+  drop $event.fortinet.srcport?
 }
 
-ocsf.dst_endpoint = {
-  ip: move fortinet.dstip,
-  port: move fortinet.dstport,
+$event.ocsf.dst_endpoint = {
+  ip: move $event.fortinet.dstip,
+  port: move $event.fortinet.dstport,
 }
 
 // `session_id` may be a hex string (e.g. "5f88ddd1") or integer 0.
 // Coerce to string before comparing to avoid type mismatch.
-if fortinet.session_id? != null and (fortinet.session_id).string() != "0" {
-  ocsf.connection_info = {
+if $event.fortinet.session_id? != null and ($event.fortinet.session_id).string() != "0" {
+  $event.ocsf.connection_info = {
     direction_id: 0,
-    uid: (move fortinet.session_id).string(),
+    uid: (move $event.fortinet.session_id).string(),
   }
 } else {
-  drop fortinet.session_id?
+  drop $event.fortinet.session_id?
 }
 
 // SSL inspection is a security control.
 // `action` (send/receive) describes alert direction; consumed here.
-drop fortinet.action?
-fortinet::fortigate::ocsf::security_control
-ocsf.disposition_id = 2  // Blocked: fatal alert terminates the connection
+drop $event.fortinet.action?
+fortinet::fortigate::ocsf::security_control event=$event
+$event.ocsf.disposition_id = 2  // Blocked: fatal alert terminates the connection

--- a/fortinet/operators/fortigate/ocsf/logs/webfilter.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/webfilter.tql
@@ -1,47 +1,52 @@
 ---
 description: "FortiGate web filter logs → OCSF HTTP Activity (4002)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.http_activity"
 
 // Web filter logs report a URL access attempt; the HTTP method is unknown.
-ocsf.category_uid = 4
-ocsf.class_uid = 4002
-ocsf.activity_id = 0  // Unknown: FortiGate doesn't log the HTTP verb here
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4002
+$event.ocsf.activity_id = 0  // Unknown: FortiGate doesn't log the HTTP verb here
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-drop fortinet.eventtype
+drop $event.fortinet.eventtype
 
-fortinet::fortigate::ocsf::network_endpoints
+fortinet::fortigate::ocsf::network_endpoints event=$event
 // `hostname` is the virtual host name of the requested site.
-ocsf.dst_endpoint.hostname = move fortinet.hostname
+$event.ocsf.dst_endpoint.hostname = move $event.fortinet.hostname
 
-fortinet::fortigate::ocsf::connection_info
+fortinet::fortigate::ocsf::connection_info event=$event
 
 // `url` is the path; `hostname` (already mapped above) is the host.
-ocsf.http_request = {
+$event.ocsf.http_request = {
   url: {
-    hostname: ocsf.dst_endpoint.hostname,
-    path: move fortinet.url,
+    hostname: $event.ocsf.dst_endpoint.hostname,
+    path: move $event.fortinet.url,
   },
 }
 
-ocsf.traffic = {
-  bytes_in: move fortinet.rcvdbyte,
-  bytes_out: move fortinet.sentbyte,
+$event.ocsf.traffic = {
+  bytes_in: move $event.fortinet.rcvdbyte,
+  bytes_out: move $event.fortinet.sentbyte,
 }
 
 // Web filter is a security control: it evaluated and acted on the request.
-fortinet::fortigate::ocsf::security_control
+fortinet::fortigate::ocsf::security_control event=$event
 
-if fortinet.action? != null {
+if $event.fortinet.action? != null {
   let $dispositions = {
     blocked: 2,
     allowed: 1,
     monitored: 17,
   }
-  ocsf.disposition_id = $dispositions[move fortinet.action]? else 0
+  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
 }
 
 // `crscore`/`crlevel` are the composite UTM risk score and level.
-fortinet::fortigate::ocsf::risk
+fortinet::fortigate::ocsf::risk event=$event

--- a/fortinet/operators/fortigate/ocsf/logs/wireless.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/wireless.tql
@@ -1,38 +1,43 @@
 ---
 description: "FortiGate wireless event logs → OCSF Detection Finding (2004) or Base Event"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // Rogue-AP events carry a `bssid` (the rogue AP's MAC address); routine
 // wireless telemetry (DHCP, handshakes, traffic stats) does not. Use bssid
 // presence as the structural discriminator rather than enumerating action
 // values, which can expand across firmware versions.
-if fortinet.bssid? != null {
+if $event.fortinet.bssid? != null {
   @name = "ocsf.detection_finding"
 
-  ocsf.category_uid = 2
-  ocsf.class_uid = 2004
-  ocsf.activity_id = 1  // Create
-  ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+  $event.ocsf.category_uid = 2
+  $event.ocsf.class_uid = 2004
+  $event.ocsf.activity_id = 1  // Create
+  $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-  ocsf.is_alert = true
+  $event.ocsf.is_alert = true
 
   // `ssid` is the rogue AP name; `bssid` is its MAC (unique identifier).
-  ocsf.finding_info = {
-    uid: move fortinet.bssid,
-    title: f"Rogue AP: {move fortinet.ssid}",
+  $event.ocsf.finding_info = {
+    uid: move $event.fortinet.bssid,
+    title: f"Rogue AP: {move $event.fortinet.ssid}",
     analytic: {
       type_id: 1,  // Rule
-      name: move fortinet.action,
+      name: move $event.fortinet.action,
     },
   }
 
   // `snclosest` is the FortiAP serial number that detected the rogue AP.
-  if fortinet.snclosest? != null {
-    ocsf.device = {
-      uid: move fortinet.snclosest,
-      zone: ocsf.device.zone,
+  if $event.fortinet.snclosest? != null {
+    $event.ocsf.device = {
+      uid: move $event.fortinet.snclosest,
+      zone: $event.ocsf.device.zone,
     }
   }
 } else {
-  fortinet::fortigate::ocsf::base
+  fortinet::fortigate::ocsf::base event=$event
 }

--- a/fortinet/operators/fortigate/ocsf/map.tql
+++ b/fortinet/operators/fortigate/ocsf/map.tql
@@ -1,71 +1,67 @@
 ---
 description: FortiGate → OCSF
 args:
-  positional:
-    - name: log
-      description: The field containing the Fortigate log as string.
+  named:
+    - name: event
+      description: The field that holds the event to map.
       type: field
+      default: this
 ---
 
-ocsf = {}
-
-ocsf.raw_data = $log
-ocsf.raw_data_size = $log.length_bytes()
-
-fortinet = $log.parse_kv()
+$event = {...$event, fortinet: $event, ocsf: {}}
 
 // Normalize FortiGate sentinel strings to null.
-replace what="N/A", with=null
-replace what="none", with=null
-replace what="undefined", with=null
+replace $event.fortinet, what="N/A", with=null
+replace $event.fortinet, what="none", with=null
+replace $event.fortinet, what="undefined", with=null
 
-ocsf.metadata = {
+$event.ocsf.metadata = {
   log_format: "kv",
-  log_level: move fortinet.level,
-  log_name: move fortinet.subtype,
-  original_time: f"{(move fortinet.date).format_time("%Y-%m-%d")} {move fortinet.time}",
-  original_event_uid: (move fortinet.logid).string(),
+  log_level: move $event.fortinet.level,
+  log_name: move $event.fortinet.subtype,
+  original_time: f"{(move $event.fortinet.date).format_time("%Y-%m-%d")} {move $event.fortinet.time}",
+  original_event_uid: (move $event.fortinet.logid).string(),
   processed_time: now(),
   product: {
     name: "FortiGate",
     vendor_name: "Fortinet",
   },
   profiles: ["host"],
-  type: move fortinet.type?,
+  type: move $event.fortinet.type?,
   version: "1.8.0",
 }
 
-if fortinet.msg? != null {
-  ocsf.message = move fortinet.msg
+if $event.fortinet.msg? != null {
+  $event.ocsf.message = move $event.fortinet.msg
 }
 
-if fortinet.eventtime? != null {
-  ocsf.time = move fortinet.eventtime
+if $event.fortinet.eventtime? != null {
+  $event.ocsf.time = move $event.fortinet.eventtime
   // FortiGate eventtime is seconds (10-digit) or nanoseconds (19-digit).
   // Values below 1e13 are seconds; above are nanoseconds.
-  ocsf.time = ocsf.time.seconds() if ocsf.time < 10T else ocsf.time.nanoseconds()
-  ocsf.time = ocsf.time.from_epoch()
+  $event.ocsf.time = $event.ocsf.time.seconds() if $event.ocsf.time < 10T else $event.ocsf.time.nanoseconds()
+  $event.ocsf.time = $event.ocsf.time.from_epoch()
 } else {
-  ocsf.time = ocsf.metadata.original_time.parse_time("%Y-%m-%d %H:%M:%S")
+  $event.ocsf.time = $event.ocsf.metadata.original_time.parse_time("%Y-%m-%d %H:%M:%S")
 }
 
-if fortinet.logdesc? != null  {
-  ocsf.status_detail = move fortinet.logdesc
+if $event.fortinet.logdesc? != null  {
+  $event.ocsf.status_detail = move $event.fortinet.logdesc
 }
 
 // `severity` is present on some UTM logs; `level` appears on all logs and is
 // already captured in metadata.log_level. Use severity first, fall back to
 // level so events without an explicit severity are not silently downgraded to
 // Informational.
-if fortinet.severity? != null {
+if $event.fortinet.severity? != null {
   let $severities = {
     low: 2,
     medium: 3,
     high: 4,
     critical: 5,
   }
-  ocsf.severity_id = $severities[move fortinet.severity]
-} else if ocsf.metadata.log_level? != null {
+  $event.ocsf.severity_id = $severities[move $event.fortinet.severity]
+} else if $event.ocsf.metadata.log_level? != null {
   let $levels = {
     debug: 1,
     information: 1,
@@ -76,72 +72,72 @@ if fortinet.severity? != null {
     critical: 5,
     emergency: 6,
   }
-  ocsf.severity_id = $levels[ocsf.metadata.log_level]? else 1
+  $event.ocsf.severity_id = $levels[$event.ocsf.metadata.log_level]? else 1
 } else {
-  ocsf.severity_id = 1
+  $event.ocsf.severity_id = 1
 }
 
 // Host profile
-if fortinet.vd? != null {
-  ocsf.device.zone = move fortinet.vd
+if $event.fortinet.vd? != null {
+  $event.ocsf.device.zone = move $event.fortinet.vd
 }
 
 // Specific event type mappings
-if ocsf.metadata.type == "utm" {
-  if ocsf.metadata.log_name == "dns" {
-    fortinet::fortigate::ocsf::logs::dns
-  } else if ocsf.metadata.log_name == "ips" {
-    fortinet::fortigate::ocsf::logs::ips
-  } else if ocsf.metadata.log_name == "webfilter" {
-    fortinet::fortigate::ocsf::logs::webfilter
-  } else if ocsf.metadata.log_name == "anomaly" {
-    fortinet::fortigate::ocsf::logs::anomaly
-  } else if ocsf.metadata.log_name == "virus" {
-    fortinet::fortigate::ocsf::logs::virus
-  } else if ocsf.metadata.log_name == "ssh" {
-    fortinet::fortigate::ocsf::logs::ssh
-  } else if ocsf.metadata.log_name == "ssl" {
-    fortinet::fortigate::ocsf::logs::ssl
-  } else if ocsf.metadata.log_name == "emailfilter" {
-    fortinet::fortigate::ocsf::logs::emailfilter
-  } else if ocsf.metadata.log_name == "app-ctrl" {
-    fortinet::fortigate::ocsf::logs::app_ctrl
-  } else if ocsf.metadata.log_name == "dlp" {
-    fortinet::fortigate::ocsf::logs::dlp
-  } else if ocsf.metadata.log_name == "cifs" {
-    fortinet::fortigate::ocsf::logs::cifs
+if $event.ocsf.metadata.type == "utm" {
+  if $event.ocsf.metadata.log_name == "dns" {
+    fortinet::fortigate::ocsf::logs::dns event=$event
+  } else if $event.ocsf.metadata.log_name == "ips" {
+    fortinet::fortigate::ocsf::logs::ips event=$event
+  } else if $event.ocsf.metadata.log_name == "webfilter" {
+    fortinet::fortigate::ocsf::logs::webfilter event=$event
+  } else if $event.ocsf.metadata.log_name == "anomaly" {
+    fortinet::fortigate::ocsf::logs::anomaly event=$event
+  } else if $event.ocsf.metadata.log_name == "virus" {
+    fortinet::fortigate::ocsf::logs::virus event=$event
+  } else if $event.ocsf.metadata.log_name == "ssh" {
+    fortinet::fortigate::ocsf::logs::ssh event=$event
+  } else if $event.ocsf.metadata.log_name == "ssl" {
+    fortinet::fortigate::ocsf::logs::ssl event=$event
+  } else if $event.ocsf.metadata.log_name == "emailfilter" {
+    fortinet::fortigate::ocsf::logs::emailfilter event=$event
+  } else if $event.ocsf.metadata.log_name == "app-ctrl" {
+    fortinet::fortigate::ocsf::logs::app_ctrl event=$event
+  } else if $event.ocsf.metadata.log_name == "dlp" {
+    fortinet::fortigate::ocsf::logs::dlp event=$event
+  } else if $event.ocsf.metadata.log_name == "cifs" {
+    fortinet::fortigate::ocsf::logs::cifs event=$event
   } else {
     // Unknown UTM subtype: emit as Base Event so ocsf::derive does not drop
     // the record for a missing class_uid.
-    fortinet::fortigate::ocsf::base
+    fortinet::fortigate::ocsf::base event=$event
   }
-} else if ocsf.metadata.type == "traffic" {
-  fortinet::fortigate::ocsf::logs::traffic
-} else if ocsf.metadata.type == "event" {
-  if ocsf.metadata.log_name == "user" {
-    fortinet::fortigate::ocsf::logs::authentication
-  } else if ocsf.metadata.log_name == "system" {
+} else if $event.ocsf.metadata.type == "traffic" {
+  fortinet::fortigate::ocsf::logs::traffic event=$event
+} else if $event.ocsf.metadata.type == "event" {
+  if $event.ocsf.metadata.log_name == "user" {
+    fortinet::fortigate::ocsf::logs::authentication event=$event
+  } else if $event.ocsf.metadata.log_name == "system" {
     // Only admin login/logout events map to Authentication; subtype="system"
     // also covers startup, config changes, and performance stats which should
     // fall through to Base Event.
-    if fortinet.action? == "login" or fortinet.action? == "logout" {
-      fortinet::fortigate::ocsf::logs::authentication
+    if $event.fortinet.action? == "login" or $event.fortinet.action? == "logout" {
+      fortinet::fortigate::ocsf::logs::authentication event=$event
     } else {
-      fortinet::fortigate::ocsf::base
+      fortinet::fortigate::ocsf::base event=$event
     }
-  } else if ocsf.metadata.log_name == "vpn" {
-    fortinet::fortigate::ocsf::logs::vpn
-  } else if ocsf.metadata.log_name == "endpoint" {
-    fortinet::fortigate::ocsf::logs::endpoint
-  } else if ocsf.metadata.log_name == "wad" {
-    fortinet::fortigate::ocsf::logs::wad
-  } else if ocsf.metadata.log_name == "wireless" {
-    fortinet::fortigate::ocsf::logs::wireless
+  } else if $event.ocsf.metadata.log_name == "vpn" {
+    fortinet::fortigate::ocsf::logs::vpn event=$event
+  } else if $event.ocsf.metadata.log_name == "endpoint" {
+    fortinet::fortigate::ocsf::logs::endpoint event=$event
+  } else if $event.ocsf.metadata.log_name == "wad" {
+    fortinet::fortigate::ocsf::logs::wad event=$event
+  } else if $event.ocsf.metadata.log_name == "wireless" {
+    fortinet::fortigate::ocsf::logs::wireless event=$event
   } else {
-    fortinet::fortigate::ocsf::base
+    fortinet::fortigate::ocsf::base event=$event
   }
 } else {
-  fortinet::fortigate::ocsf::base
+  fortinet::fortigate::ocsf::base event=$event
 }
 
-this = {...ocsf, unmapped: fortinet}
+$event = {...$event.ocsf, unmapped: $event.fortinet}

--- a/fortinet/operators/fortigate/ocsf/network_endpoints.tql
+++ b/fortinet/operators/fortigate/ocsf/network_endpoints.tql
@@ -4,29 +4,34 @@ description: >-
   Sets ip, port, interface_name, and zone (from intfrole) on both endpoints.
   Conditionally sets dst_endpoint.svc_name from `service` if present.
   Callers may extend endpoints further (e.g. hostname, mac, login).
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-ocsf.src_endpoint = {
-  ip: move fortinet.srcip,
-  port: move fortinet.srcport?,
-  interface_name: move fortinet.srcintf,
+$event.ocsf.src_endpoint = {
+  ip: move $event.fortinet.srcip,
+  port: move $event.fortinet.srcport?,
+  interface_name: move $event.fortinet.srcintf,
 }
-if fortinet.srcintfrole? != null {
-  ocsf.src_endpoint.zone = fortinet.srcintfrole
+if $event.fortinet.srcintfrole? != null {
+  $event.ocsf.src_endpoint.zone = $event.fortinet.srcintfrole
 }
-drop fortinet.srcintfrole?
+drop $event.fortinet.srcintfrole?
 
-ocsf.dst_endpoint = {
-  ip: move fortinet.dstip,
-  port: move fortinet.dstport?,
-  interface_name: move fortinet.dstintf?,
+$event.ocsf.dst_endpoint = {
+  ip: move $event.fortinet.dstip,
+  port: move $event.fortinet.dstport?,
+  interface_name: move $event.fortinet.dstintf?,
 }
-if fortinet.dstintfrole? != null {
-  ocsf.dst_endpoint.zone = fortinet.dstintfrole
+if $event.fortinet.dstintfrole? != null {
+  $event.ocsf.dst_endpoint.zone = $event.fortinet.dstintfrole
 }
-drop fortinet.dstintfrole?
+drop $event.fortinet.dstintfrole?
 
 // `service` is the application-layer protocol name for the destination port.
-if fortinet.service? != null {
-  ocsf.dst_endpoint.svc_name = move fortinet.service
+if $event.fortinet.service? != null {
+  $event.ocsf.dst_endpoint.svc_name = move $event.fortinet.service
 }

--- a/fortinet/operators/fortigate/ocsf/network_evidence.tql
+++ b/fortinet/operators/fortigate/ocsf/network_evidence.tql
@@ -3,33 +3,38 @@ description: >-
   Map FortiGate network fields into ocsf.evidences for Detection Finding.
   Puts src_endpoint, dst_endpoint, and connection_info inside the evidence
   artifact where Detection Finding can carry them.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-fortinet::fortigate::ocsf::network_endpoints
+fortinet::fortigate::ocsf::network_endpoints event=$event
 
 // `hostname` is consumed here before packing; parse_kv may parse
 // IP-shaped hostname values as ip_t so coerce to string.
-if fortinet.hostname? != null {
-  ocsf.dst_endpoint.hostname = (move fortinet.hostname).string()
+if $event.fortinet.hostname? != null {
+  $event.ocsf.dst_endpoint.hostname = (move $event.fortinet.hostname).string()
 }
 
 // `direction` in Detection Finding logs (IPS, virus, DLP) describes the
 // inspected packet's orientation relative to the UTM engine, not the network
 // session direction. Dropping it here prevents it from inverting direction_id
 // for sessions whose actual direction can be inferred from intfroles.
-drop fortinet.direction?
-fortinet::fortigate::ocsf::connection_info
+drop $event.fortinet.direction?
+fortinet::fortigate::ocsf::connection_info event=$event
 
 // Only emit evidences when at least one endpoint IP is present; an all-null
 // evidence record is unhelpful and drop_null_fields does not recurse into lists.
-if ocsf.src_endpoint.ip? != null or ocsf.dst_endpoint.ip? != null {
-  ocsf.evidences = [{
-    src_endpoint: move ocsf.src_endpoint,
-    dst_endpoint: move ocsf.dst_endpoint,
-    connection_info: move ocsf.connection_info,
+if $event.ocsf.src_endpoint.ip? != null or $event.ocsf.dst_endpoint.ip? != null {
+  $event.ocsf.evidences = [{
+    src_endpoint: move $event.ocsf.src_endpoint,
+    dst_endpoint: move $event.ocsf.dst_endpoint,
+    connection_info: move $event.ocsf.connection_info,
   }]
 } else {
-  drop ocsf.src_endpoint?
-  drop ocsf.dst_endpoint?
-  drop ocsf.connection_info?
+  drop $event.ocsf.src_endpoint?
+  drop $event.ocsf.dst_endpoint?
+  drop $event.ocsf.connection_info?
 }

--- a/fortinet/operators/fortigate/ocsf/risk.tql
+++ b/fortinet/operators/fortigate/ocsf/risk.tql
@@ -3,17 +3,22 @@ description: >-
   FortiGate UTM composite risk fields → OCSF risk_score and
   risk_level_id. `crscore` is the numeric risk score; `crlevel` is its
   normalized label (low/medium/high/critical).
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-if fortinet.crscore? != null {
-  ocsf.risk_score = move fortinet.crscore
+if $event.fortinet.crscore? != null {
+  $event.ocsf.risk_score = move $event.fortinet.crscore
 }
-if fortinet.crlevel? != null {
+if $event.fortinet.crlevel? != null {
   let $levels = {
     low: 1,
     medium: 2,
     high: 3,
     critical: 4,
   }
-  ocsf.risk_level_id = $levels[move fortinet.crlevel]? else 99
+  $event.ocsf.risk_level_id = $levels[move $event.fortinet.crlevel]? else 99
 }

--- a/fortinet/operators/fortigate/ocsf/security_control.tql
+++ b/fortinet/operators/fortigate/ocsf/security_control.tql
@@ -5,18 +5,23 @@ description: >-
   policy.name (coerced to string for numeric profile IDs), and maps
   `policyid` → firewall_rule.uid. Callers may extend firewall_rule further
   (e.g. with policytype or poluuid).
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-ocsf.metadata.profiles = ocsf.metadata.profiles.add("security_control")
+$event.ocsf.metadata.profiles = $event.ocsf.metadata.profiles.add("security_control")
 
-if fortinet.profile? != null {
-  ocsf.policy = {
-    name: (move fortinet.profile).string(),
+if $event.fortinet.profile? != null {
+  $event.ocsf.policy = {
+    name: (move $event.fortinet.profile).string(),
   }
 }
 
-if fortinet.policyid? != null {
-  ocsf.firewall_rule = {
-    uid: (move fortinet.policyid).string(),
+if $event.fortinet.policyid? != null {
+  $event.ocsf.firewall_rule = {
+    uid: (move $event.fortinet.policyid).string(),
   }
 }

--- a/fortinet/tests/fortigate/ocsf/map.tql
+++ b/fortinet/tests/fortigate/ocsf/map.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/*.txt" {
   read_lines
 }
-fortinet::fortigate::ocsf::map line
+fortinet = line.parse_kv()
+fortinet::fortigate::ocsf::map event=fortinet
+fortinet.raw_data = move line
+fortinet.raw_data_size = fortinet.raw_data.length_bytes()
+this = fortinet
 ocsf::derive
 ocsf::cast
 drop metadata.processed_time

--- a/foxio/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/foxio/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,22 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:18.011303Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+```

--- a/foxio/operators/ocsf/map.tql
+++ b/foxio/operators/ocsf/map.tql
@@ -1,86 +1,92 @@
 ---
 description: FoxIO JA4+ fingerprints -> OCSF OSINT Inventory Info
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {foxio: this}
+$event = {...$event, foxio: $event, ocsf: {}}
 
-fingerprint = [
+$event.fingerprint = [
   {
     field: "ja4_fingerprint",
     type: "JA4",
-    value: foxio.ja4_fingerprint?,
+    value: $event.foxio.ja4_fingerprint?,
   },
   {
     field: "ja4h_fingerprint",
     type: "JA4HTTP",
-    value: foxio.ja4h_fingerprint?,
+    value: $event.foxio.ja4h_fingerprint?,
   },
   {
     field: "ja4s_fingerprint",
     type: "JA4Server",
-    value: foxio.ja4s_fingerprint?,
+    value: $event.foxio.ja4s_fingerprint?,
   },
   {
     field: "ja4t_fingerprint",
     type: "JA4TCP",
-    value: foxio.ja4t_fingerprint?,
+    value: $event.foxio.ja4t_fingerprint?,
   },
   {
     field: "ja4ts_fingerprint",
     type: "JA4TCPServer",
-    value: foxio.ja4ts_fingerprint?,
+    value: $event.foxio.ja4ts_fingerprint?,
   },
   {
     field: "ja4tscan_fingerprint",
     type: "JA4TCPScan",
-    value: foxio.ja4tscan_fingerprint?,
+    value: $event.foxio.ja4tscan_fingerprint?,
   },
   {
     field: "ja4x_fingerprint",
     type: "JA4X509",
-    value: foxio.ja4x_fingerprint?,
+    value: $event.foxio.ja4x_fingerprint?,
   },
 ]
-unroll fingerprint
-where fingerprint.value != null
+unroll $event.fingerprint
+where $event.fingerprint.value != null
 
-labels = [
-  foxio.application?,
-  foxio.os?,
-  foxio.device?,
-  foxio.library?,
-  foxio.user_agent?,
+$event.labels = [
+  $event.foxio.application?,
+  $event.foxio.os?,
+  $event.foxio.device?,
+  $event.foxio.library?,
+  $event.foxio.user_agent?,
 ].where(x => x != null)
 
-osint = {}
-osint.category = move fingerprint.type
-osint.confidence_id = 0
-osint.labels = labels if labels.length() > 0 else null
-osint.name = move fingerprint.field
-osint.src_url = "https://ja4db.com/"
-osint.type_id = 4
-osint.value = move fingerprint.value
-osint.vendor_name = "FoxIO"
+$event.osint = {}
+$event.osint.category = move $event.fingerprint.type
+$event.osint.confidence_id = 0
+$event.osint.labels = $event.labels if $event.labels.length() > 0 else null
+$event.osint.name = move $event.fingerprint.field
+$event.osint.src_url = "https://ja4db.com/"
+$event.osint.type_id = 4
+$event.osint.value = move $event.fingerprint.value
+$event.osint.vendor_name = "FoxIO"
 
-ocsf = {}
-ocsf.activity_id = 2
-ocsf.actor = {
+$event.ocsf = {}
+$event.ocsf.activity_id = 2
+$event.ocsf.actor = {
   app_name: "Tenzir",
 }
-ocsf.category_uid = 5
-ocsf.class_uid = 5021
-ocsf.metadata = {
+$event.ocsf.category_uid = 5
+$event.ocsf.class_uid = 5021
+$event.ocsf.metadata = {
   product: {
     name: "JA4+ Database",
     vendor_name: "FoxIO",
   },
   version: "1.8.0",
 }
-ocsf.osint = [move osint]
-ocsf.severity_id = 1
-ocsf.time = now()
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.osint = [move $event.osint]
+$event.ocsf.severity_id = 1
+$event.ocsf.time = now()
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-drop labels
-this = {...ocsf, unmapped: foxio}
+drop $event.labels
+$event = {...$event.ocsf, unmapped: $event.foxio}
 @name = "ocsf.osint_inventory_info"

--- a/misp/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/misp/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,22 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:18.719629Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+```

--- a/misp/operators/event/ocsf/map.tql
+++ b/misp/operators/event/ocsf/map.tql
@@ -1,5 +1,11 @@
 ---
 description: MISP Event → OCSF OSINT Inventory Info (5021)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
 let $threat_level = {
@@ -39,18 +45,17 @@ let $type_ids = {
   vulnerability: 10,
   link: 5,
 }
-this = {misp: this}
-ocsf = {}
+$event = {...$event, misp: $event, ocsf: {}}
 // ------ OCSF Inventory Info --------
 // Classification
-ocsf.activity_id = 2
-ocsf.category_uid = 5
-ocsf.class_uid = 5021
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-ocsf.severity_id = $threat_level[move misp.threat_level_id]? else 1
+$event.ocsf.activity_id = 2
+$event.ocsf.category_uid = 5
+$event.ocsf.class_uid = 5021
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+$event.ocsf.severity_id = $threat_level[move $event.misp.threat_level_id]? else 1
 // Context
-ocsf.actor = {
+$event.ocsf.actor = {
   app_name: "Tenzir",
   process: {
     name: "MISP",
@@ -58,52 +63,52 @@ ocsf.actor = {
   user: {
     // Creator org of the MISP event.
     org: {
-      name: move misp.Orgc.name?,
-      uid: move misp.Orgc.uuid?,
+      name: move $event.misp.Orgc.name?,
+      uid: move $event.misp.Orgc.uuid?,
     }
   }
 }
-if misp.Org? != null {
+if $event.misp.Org? != null {
   // Org currently owning the MISP event.
-  ocsf.actor.process.user = {
+  $event.ocsf.actor.process.user = {
     org: {
-      name: move misp.Org.name?,
-      uid: move misp.Org.uuid?,
+      name: move $event.misp.Org.name?,
+      uid: move $event.misp.Org.uuid?,
     },
   }
 }
-ocsf.metadata = {
+$event.ocsf.metadata = {
   product: {
     name: "MISP",
     vendor_name: "CIRCL",
   },
-  uid: move misp.uuid,
+  uid: move $event.misp.uuid,
   version: "1.8.0",
 }
-ocsf.time = from_epoch(int(move misp.timestamp) * 1s)
-drop misp.date // implied in the timestamp
+$event.ocsf.time = from_epoch(int(move $event.misp.timestamp) * 1s)
+drop $event.misp.date // implied in the timestamp
 // Primary
-ocsf.message = move misp.info
-ocsf.osint = misp.Attribute.map(x => {
+$event.ocsf.message = move $event.misp.info
+$event.ocsf.osint = $event.misp.Attribute.map(x => {
   category: x.category,
   created_time: from_epoch(int(x.timestamp) * 1s),
   creator: {
-    org: ocsf.actor.user.org, // Orgc
+    org: $event.ocsf.actor.user.org, // Orgc
   },
   desc: x.comment,
   external_uid: x.uuid,
-  severity_id: ocsf.severity_id,
+  severity_id: $event.ocsf.severity_id,
   // TODO: Figure out how to assign `null` if no tlp tag in the source.
-  tlp: misp.Tag?.where(x => x.name.starts_with("tlp:"))[0]?.name?.slice(begin=4).to_upper(),
+  tlp: $event.misp.Tag?.where(x => x.name.starts_with("tlp:"))[0]?.name?.slice(begin=4).to_upper(),
   type_id: $type_ids[x.type]? else 99,
   type: x.type if $type_ids[x.type]? == null else null,
   value: x.value,
 })
-ocsf.status_id = $analysis_status[move misp.analysis]? else 0
-drop misp.Attribute?
+$event.ocsf.status_id = $analysis_status[move $event.misp.analysis]? else 0
+drop $event.misp.Attribute?
 // TODO: consider mapping the Galaxy in the future. For now, we drop
 // it because it is incredibly bulky.
-drop misp.Galaxy?
+drop $event.misp.Galaxy?
 // ------ Finalize --------
-this = {...ocsf, unmapped: misp}
+$event = {...$event.ocsf, unmapped: $event.misp}
 @name = "ocsf.osint_inventory_info"

--- a/okta/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/okta/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,22 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:19.553916Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+```

--- a/okta/operators/ocsf/base.tql
+++ b/okta/operators/ocsf/base.tql
@@ -1,17 +1,22 @@
 ---
 description: "Okta → OCSF Base Event (0)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 0
-ocsf.category_uid = 0
-ocsf.class_uid = 0
-ocsf.severity_id = 0
-ocsf.type_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.category_uid = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.severity_id = 0
+$event.ocsf.type_uid = 0
 
-okta._actor = move ocsf.actor?
-okta._http_request = move ocsf.http_request?
-okta._src_endpoint = move ocsf.src_endpoint?
+$event.okta._actor = move $event.ocsf.actor?
+$event.okta._http_request = move $event.ocsf.http_request?
+$event.okta._src_endpoint = move $event.ocsf.src_endpoint?
 
 @name = "ocsf.base_event"

--- a/okta/operators/ocsf/event/account_change.tql
+++ b/okta/operators/ocsf/event/account_change.tql
@@ -1,5 +1,10 @@
 ---
 description: "Okta → OCSF Account Change (3001)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // --- OCSF: classification attributes ----------
@@ -33,30 +38,30 @@ let $activity_map = {
   "user.mfa.factor.update": 99,
   "user.mfa.factor.reset_all": 99,
 }
-ocsf.activity_id = $activity_map[ocsf.metadata.event_code]? else 99
-ocsf.category_uid = 3
-ocsf.class_uid = 3001
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = $activity_map[$event.ocsf.metadata.event_code]? else 99
+$event.ocsf.category_uid = 3
+$event.ocsf.class_uid = 3001
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 let $status_map = {
   SUCCESS: 1,
   FAILURE: 2,
 }
-ocsf.status_id = $status_map[okta.outcome.result?]? else 0
-ocsf.status_detail = move okta.outcome.reason?
-drop okta.outcome?
+$event.ocsf.status_id = $status_map[$event.okta.outcome.result?]? else 0
+$event.ocsf.status_detail = move $event.okta.outcome.reason?
+drop $event.okta.outcome?
 
 // --- OCSF: target user from target[] ----------
 
-if okta.target? != null {
-  ocsf.user = okta.target.where(t => t.type == "User").map(t => {
+if $event.okta.target? != null {
+  $event.ocsf.user = $event.okta.target.where(t => t.type == "User").map(t => {
     uid: t.id,
     name: t.alternateId?.split("@")[0]?,
     full_name: string(t.displayName?),
     email_addr: t.alternateId,
     type_id: 1,
   })[0]?
-  ocsf.user.groups = okta.target.where(t => t.type == "UserGroup").map(t => {
+  $event.ocsf.user.groups = $event.okta.target.where(t => t.type == "UserGroup").map(t => {
     uid: t.id,
     name: t.displayName,
   })

--- a/okta/operators/ocsf/event/api_activity.tql
+++ b/okta/operators/ocsf/event/api_activity.tql
@@ -1,5 +1,10 @@
 ---
 description: "Okta → OCSF API Activity (6003)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // --- OCSF: classification attributes ----------
@@ -24,32 +29,32 @@ let $activity_map = {
   "system.log_stream.lifecycle.update": 3,
   "system.log_stream.lifecycle.delete": 4,
 }
-ocsf.activity_id = $activity_map[ocsf.metadata.event_code]? else 99
-ocsf.category_uid = 6
-ocsf.class_uid = 6003
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = $activity_map[$event.ocsf.metadata.event_code]? else 99
+$event.ocsf.category_uid = 6
+$event.ocsf.class_uid = 6003
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 let $status_map = {
   SUCCESS: 1,
   FAILURE: 2,
 }
-ocsf.status_id = $status_map[okta.outcome.result?]? else 0
-ocsf.status_detail = move okta.outcome.reason?
-drop okta.outcome?
+$event.ocsf.status_id = $status_map[$event.okta.outcome.result?]? else 0
+$event.ocsf.status_detail = move $event.okta.outcome.reason?
+drop $event.okta.outcome?
 
-ocsf.api = {
+$event.ocsf.api = {
   request: {
-    uid: ocsf.http_request.uid?,
+    uid: $event.ocsf.http_request.uid?,
   },
 }
-if ocsf.metadata.event_code == "system.api_token.create" {
-  ocsf.api.operation = "PUT"
+if $event.ocsf.metadata.event_code == "system.api_token.create" {
+  $event.ocsf.api.operation = "PUT"
 }
 
 // --- OCSF: resources from target[] ------------
 
-if okta.target? != null {
-  ocsf.resources = okta.target.where(t => t.type == "access_token" or t.type == "Token" or t.type == "id_token" or t.type == "refresh_token").map(t => {
+if $event.okta.target? != null {
+  $event.ocsf.resources = $event.okta.target.where(t => t.type == "access_token" or t.type == "Token" or t.type == "id_token" or t.type == "refresh_token").map(t => {
     uid: t.id,
     name: t.displayName,
     type: t.type,

--- a/okta/operators/ocsf/event/authentication.tql
+++ b/okta/operators/ocsf/event/authentication.tql
@@ -1,5 +1,10 @@
 ---
 description: "Okta → OCSF Authentication (3002)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // --- OCSF: classification attributes ----------
@@ -24,10 +29,10 @@ let $activity_map = {
   "app.oauth2.authorize.code": 1,
   "system.push.send_factor_verify_push": 6,
 }
-ocsf.activity_id = $activity_map[ocsf.metadata.event_code]? else 0
-ocsf.category_uid = 3
-ocsf.class_uid = 3002
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = $activity_map[$event.ocsf.metadata.event_code]? else 0
+$event.ocsf.category_uid = 3
+$event.ocsf.class_uid = 3002
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // Status with security control profile.
 let $status_map = {
@@ -37,63 +42,63 @@ let $status_map = {
   DENY: 2,
   CHALLENGE: 99,
 }
-if ocsf.metadata.event_code == "application.policy.sign_on.deny_access" {
-  ocsf.status_id = 2
+if $event.ocsf.metadata.event_code == "application.policy.sign_on.deny_access" {
+  $event.ocsf.status_id = 2
 } else {
-  ocsf.status_id = $status_map[okta.outcome.result?]? else 0
+  $event.ocsf.status_id = $status_map[$event.okta.outcome.result?]? else 0
 }
-if okta.outcome.result == "SUCCESS" or okta.outcome.result == "ALLOW" {
-  ocsf.action_id = 1
-  ocsf.disposition_id = 1
-} else if okta.outcome.result == "FAILURE" or okta.outcome.result == "DENY" {
-  ocsf.action_id = 2
-  if ocsf.metadata.event_code == "app.generic.unauth_app_access_attempt" {
-    ocsf.disposition_id = 26
-  } else if string(okta.debugContext.debugData.threatSuspected?) == "true" {
-    ocsf.disposition_id = 2
+if $event.okta.outcome.result == "SUCCESS" or $event.okta.outcome.result == "ALLOW" {
+  $event.ocsf.action_id = 1
+  $event.ocsf.disposition_id = 1
+} else if $event.okta.outcome.result == "FAILURE" or $event.okta.outcome.result == "DENY" {
+  $event.ocsf.action_id = 2
+  if $event.ocsf.metadata.event_code == "app.generic.unauth_app_access_attempt" {
+    $event.ocsf.disposition_id = 26
+  } else if string($event.okta.debugContext.debugData.threatSuspected?) == "true" {
+    $event.ocsf.disposition_id = 2
   } else {
-    ocsf.disposition_id = 2
+    $event.ocsf.disposition_id = 2
   }
-} else if okta.outcome.result == "CHALLENGE" {
-  ocsf.action_id = 99
-  ocsf.disposition_id = 16
+} else if $event.okta.outcome.result == "CHALLENGE" {
+  $event.ocsf.action_id = 99
+  $event.ocsf.disposition_id = 16
 } else {
-  ocsf.action_id = 0
-  ocsf.disposition_id = 0
+  $event.ocsf.action_id = 0
+  $event.ocsf.disposition_id = 0
 }
-ocsf.status_detail = move okta.outcome.reason?
-drop okta.outcome?
+$event.ocsf.status_detail = move $event.okta.outcome.reason?
+drop $event.okta.outcome?
 
 // Auth protocol.
 let $auth_protocol_map = {
   "OpenID Connect": 4,
   "SAML 2.0": 5,
 }
-if okta.debugContext.debugData.signOnMode? != null {
-  ocsf.auth_protocol_id = $auth_protocol_map[okta.debugContext.debugData.signOnMode]? else 99
-  drop okta.debugContext.debugData.signOnMode
-} else if ocsf.metadata.event_code == "user.authentication.auth_via_radius" {
-  ocsf.auth_protocol_id = 10
+if $event.okta.debugContext.debugData.signOnMode? != null {
+  $event.ocsf.auth_protocol_id = $auth_protocol_map[$event.okta.debugContext.debugData.signOnMode]? else 99
+  drop $event.okta.debugContext.debugData.signOnMode
+} else if $event.ocsf.metadata.event_code == "user.authentication.auth_via_radius" {
+  $event.ocsf.auth_protocol_id = 10
 }
 
-ocsf.metadata.profiles = ["cloud", "security_control"]
+$event.ocsf.metadata.profiles = ["cloud", "security_control"]
 
-ocsf.session = {
-  uid: move okta.authenticationContext.externalSessionId?,
+$event.ocsf.session = {
+  uid: move $event.okta.authenticationContext.externalSessionId?,
 }
 
 // --- OCSF: risk & alert ----------------------
 
-ocsf.risk_details = move okta.debugContext.debugData.behaviors?
-ocsf.is_alert = false
-if string(okta.debugContext.debugData.threatSuspected?) == "true" or okta.debugContext.debugData.threatDetections? != null {
-  ocsf.is_alert = true
+$event.ocsf.risk_details = move $event.okta.debugContext.debugData.behaviors?
+$event.ocsf.is_alert = false
+if string($event.okta.debugContext.debugData.threatSuspected?) == "true" or $event.okta.debugContext.debugData.threatDetections? != null {
+  $event.ocsf.is_alert = true
 }
 
 // --- OCSF: target user from target[] ----------
 
-if okta.target? != null {
-  ocsf.user = okta.target.where(t => t.type == "User" or t.type == "AppUser").map(t => {
+if $event.okta.target? != null {
+  $event.ocsf.user = $event.okta.target.where(t => t.type == "User" or t.type == "AppUser").map(t => {
     uid: t.id,
     name: t.alternateId?.split("@")[0]?,
     full_name: string(t.displayName?),

--- a/okta/operators/ocsf/event/detection_finding.tql
+++ b/okta/operators/ocsf/event/detection_finding.tql
@@ -1,37 +1,42 @@
 ---
 description: "Okta → OCSF Detection Finding (2004)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 1
-ocsf.category_uid = 2
-ocsf.class_uid = 2004
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 1
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2004
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 let $status_map = {
   SUCCESS: 1,
   FAILURE: 2,
   DENY: 2,
 }
-ocsf.status_id = $status_map[okta.outcome.result?]? else 0
-ocsf.status_detail = move okta.outcome.reason?
-drop okta.outcome?
+$event.ocsf.status_id = $status_map[$event.okta.outcome.result?]? else 0
+$event.ocsf.status_detail = move $event.okta.outcome.reason?
+drop $event.okta.outcome?
 
 // --- OCSF: finding_info -----------------------
 
-ocsf.finding_info = {
-  title: ocsf.metadata.event_code,
-  uid: ocsf.metadata.loggers[0].event_uid?,
-  desc: ocsf.message,
+$event.ocsf.finding_info = {
+  title: $event.ocsf.metadata.event_code,
+  uid: $event.ocsf.metadata.loggers[0].event_uid?,
+  desc: $event.ocsf.message,
 }
 
 // --- OCSF: evidences[] -----------------------
 
-ocsf.evidences = [{
-  actor: move ocsf.actor?,
-  src_endpoint: move ocsf.src_endpoint?,
-  http_request: move ocsf.http_request?,
-  data: okta.debugContext.debugData?,
+$event.ocsf.evidences = [{
+  actor: move $event.ocsf.actor?,
+  src_endpoint: move $event.ocsf.src_endpoint?,
+  http_request: move $event.ocsf.http_request?,
+  data: $event.okta.debugContext.debugData?,
 }]
 @name = "ocsf.detection_finding"

--- a/okta/operators/ocsf/event/entity_management.tql
+++ b/okta/operators/ocsf/event/entity_management.tql
@@ -1,5 +1,10 @@
 ---
 description: "Okta → OCSF Entity Management (3004)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // --- OCSF: classification attributes ----------
@@ -55,64 +60,64 @@ let $activity_map = {
   "security.trusted_origin.create": 1,
   "security.trusted_origin.activate": 10,
 }
-ocsf.activity_id = $activity_map[ocsf.metadata.event_code]? else 99
-ocsf.category_uid = 3
-ocsf.class_uid = 3004
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = $activity_map[$event.ocsf.metadata.event_code]? else 99
+$event.ocsf.category_uid = 3
+$event.ocsf.class_uid = 3004
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 let $status_map = {
   SUCCESS: 1,
   FAILURE: 2,
 }
-ocsf.status_id = $status_map[okta.outcome.result?]? else 0
-ocsf.status_detail = move okta.outcome.reason?
-drop okta.outcome?
+$event.ocsf.status_id = $status_map[$event.okta.outcome.result?]? else 0
+$event.ocsf.status_detail = move $event.okta.outcome.reason?
+drop $event.okta.outcome?
 
 // --- OCSF: entity from target[] ---------------
 
 // Route entity extraction by event type prefix since target[] contains
 // different object types depending on the Okta event category.
-if okta.target? != null {
-  if ocsf.metadata.event_code.starts_with("policy.") {
-    ocsf.entity = okta.target.where(t => t.type == "PolicyEntity").map(t => {
+if $event.okta.target? != null {
+  if $event.ocsf.metadata.event_code.starts_with("policy.") {
+    $event.ocsf.entity = $event.okta.target.where(t => t.type == "PolicyEntity").map(t => {
       uid: t.id,
       name: t.displayName,
     })[0]?
-    ocsf.entity.type_id = 5
-    ocsf.entity.policy = {
-      desc: move okta.debugContext.debugData.policyType?,
+    $event.ocsf.entity.type_id = 5
+    $event.ocsf.entity.policy = {
+      desc: move $event.okta.debugContext.debugData.policyType?,
     }
-  } else if ocsf.metadata.event_code.starts_with("application.") {
-    ocsf.entity = okta.target.where(t => t.type == "AppInstance" or t.type == "AppUser").map(t => {
+  } else if $event.ocsf.metadata.event_code.starts_with("application.") {
+    $event.ocsf.entity = $event.okta.target.where(t => t.type == "AppInstance" or t.type == "AppUser").map(t => {
       uid: t.id,
       name: t.displayName,
     })[0]?
-    ocsf.entity.type_id = 6
-  } else if ocsf.metadata.event_code.starts_with("device.") {
-    ocsf.entity = okta.target.where(t => t.type == "UDDevice").map(t => {
+    $event.ocsf.entity.type_id = 6
+  } else if $event.ocsf.metadata.event_code.starts_with("device.") {
+    $event.ocsf.entity = $event.okta.target.where(t => t.type == "UDDevice").map(t => {
       uid: t.id,
       name: t.displayName,
     })[0]?
-    ocsf.entity.type_id = 1
-  } else if ocsf.metadata.event_code.starts_with("zone.") {
-    ocsf.entity = okta.target.where(t => t.type == "NetworkZoneEntity").map(t => {
+    $event.ocsf.entity.type_id = 1
+  } else if $event.ocsf.metadata.event_code.starts_with("zone.") {
+    $event.ocsf.entity = $event.okta.target.where(t => t.type == "NetworkZoneEntity").map(t => {
       uid: t.id,
       name: t.displayName,
     })[0]?
-    ocsf.entity.type_id = 9
-    ocsf.entity.data = move okta.debugContext.debugData.zoneData?
-  } else if ocsf.metadata.event_code.starts_with("directory.") {
-    ocsf.entity = okta.target.where(t => t.type == "AppUser").map(t => {
+    $event.ocsf.entity.type_id = 9
+    $event.ocsf.entity.data = move $event.okta.debugContext.debugData.zoneData?
+  } else if $event.ocsf.metadata.event_code.starts_with("directory.") {
+    $event.ocsf.entity = $event.okta.target.where(t => t.type == "AppUser").map(t => {
       uid: t.id,
       name: t.displayName,
     })[0]?
-    ocsf.entity.type_id = 99
-  } else if ocsf.metadata.event_code.starts_with("security.trusted_origin.") {
-    ocsf.entity = okta.target.where(t => t.type == "TrustedOrigin").map(t => {
+    $event.ocsf.entity.type_id = 99
+  } else if $event.ocsf.metadata.event_code.starts_with("security.trusted_origin.") {
+    $event.ocsf.entity = $event.okta.target.where(t => t.type == "TrustedOrigin").map(t => {
       uid: t.id,
       name: t.displayName,
     })[0]?
-    ocsf.entity.type_id = 7
+    $event.ocsf.entity.type_id = 7
   }
 }
 

--- a/okta/operators/ocsf/event/group_management.tql
+++ b/okta/operators/ocsf/event/group_management.tql
@@ -1,5 +1,10 @@
 ---
 description: "Okta → OCSF Group Management (3006)"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // --- OCSF: classification attributes ----------
@@ -15,28 +20,28 @@ let $activity_map = {
   "group.application_assignment.update": 99,
   "group.user_membership.rule.add_exclusion": 99,
 }
-ocsf.activity_id = $activity_map[ocsf.metadata.event_code]? else 99
-ocsf.category_uid = 3
-ocsf.class_uid = 3006
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = $activity_map[$event.ocsf.metadata.event_code]? else 99
+$event.ocsf.category_uid = 3
+$event.ocsf.class_uid = 3006
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 let $status_map = {
   SUCCESS: 1,
   FAILURE: 2,
 }
-ocsf.status_id = $status_map[okta.outcome.result?]? else 0
-ocsf.status_detail = move okta.outcome.reason?
-drop okta.outcome?
+$event.ocsf.status_id = $status_map[$event.okta.outcome.result?]? else 0
+$event.ocsf.status_detail = move $event.okta.outcome.reason?
+drop $event.okta.outcome?
 
 // --- OCSF: group and user from target[] -------
 
-if okta.target? != null {
-  ocsf.group = okta.target.where(t => t.type == "UserGroup").map(t => {
+if $event.okta.target? != null {
+  $event.ocsf.group = $event.okta.target.where(t => t.type == "UserGroup").map(t => {
     uid: t.id,
     name: t.displayName,
   })[0]?
-  ocsf.group.privileges = move okta.debugContext.debugData.privilegeGranted?
-  ocsf.user = okta.target.where(t => t.type == "User").map(t => {
+  $event.ocsf.group.privileges = move $event.okta.debugContext.debugData.privilegeGranted?
+  $event.ocsf.user = $event.okta.target.where(t => t.type == "User").map(t => {
     uid: t.id,
     name: t.alternateId?.split("@")[0]?,
     full_name: string(t.displayName?),

--- a/okta/operators/ocsf/map.tql
+++ b/okta/operators/ocsf/map.tql
@@ -1,9 +1,14 @@
 ---
 description: Okta → OCSF
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {okta: this}
-ocsf = {}
+$event = {...$event, okta: $event, ocsf: {}}
 
 // Raw System Log input must pass through okta::read before OCSF mapping.
 
@@ -12,39 +17,39 @@ let $severity_map = {
   MEDIUM: 3,
   LOW: 2,
 }
-ocsf.severity_id = $severity_map[okta.debugContext.debugData.risk?]? else 1
-drop okta.debugContext.debugData.risk?
+$event.ocsf.severity_id = $severity_map[$event.okta.debugContext.debugData.risk?]? else 1
+drop $event.okta.debugContext.debugData.risk?
 
-ocsf.time = time(move okta.published)
-ocsf.message = move okta.displayMessage
+$event.ocsf.time = time(move $event.okta.published)
+$event.ocsf.message = move $event.okta.displayMessage
 
-ocsf.metadata = {
-  event_code: move okta.eventType,
+$event.ocsf.metadata = {
+  event_code: move $event.okta.eventType,
   log_provider: "Okta",
   product: {
     name: "Okta",
     vendor_name: "Okta",
-    version: move okta.version?,
+    version: move $event.okta.version?,
   },
   profiles: ["cloud"],
   version: "1.8.0",
-  loggers: [{event_uid: move okta.uuid?}],
+  loggers: [{event_uid: move $event.okta.uuid?}],
 }
 
-ocsf.http_request = {
-  uid: move okta.debugContext.debugData.requestId?,
+$event.ocsf.http_request = {
+  uid: move $event.okta.debugContext.debugData.requestId?,
   url: {
-    path: move okta.debugContext.debugData.url?,
-    hostname: move okta.debugContext.debugData.authnRequestId? else move okta.debugContext.debugData.origin?,
+    path: move $event.okta.debugContext.debugData.url?,
+    hostname: move $event.okta.debugContext.debugData.authnRequestId? else move $event.okta.debugContext.debugData.origin?,
   },
 }
-if okta.client.userAgent? != null {
-  ocsf.http_request.user_agent = move okta.client.userAgent.rawUserAgent?
+if $event.okta.client.userAgent? != null {
+  $event.ocsf.http_request.user_agent = move $event.okta.client.userAgent.rawUserAgent?
 }
 
-ocsf.cloud = {
-  provider: "AWS" if okta.source?.contains("aws.partner") else "Other",
-  region: move okta.region?,
+$event.ocsf.cloud = {
+  provider: "AWS" if $event.okta.source?.contains("aws.partner") else "Other",
+  region: move $event.okta.region?,
 }
 
 let $actor_type_id = {
@@ -52,48 +57,48 @@ let $actor_type_id = {
   SystemPrincipal: 2,
 }
 
-ocsf.actor = {
+$event.ocsf.actor = {
   user: {
-    uid: move okta.actor.id?,
-    name: okta.actor.alternateId?.split("@")[0]?,
-    domain: okta.actor.alternateId?.split("@")[1]?,
-    full_name: string(move okta.actor.displayName?),
-    email_addr: move okta.actor.alternateId?,
-    type_id: $actor_type_id[okta.actor.type?]? else 99,
+    uid: move $event.okta.actor.id?,
+    name: $event.okta.actor.alternateId?.split("@")[0]?,
+    domain: $event.okta.actor.alternateId?.split("@")[1]?,
+    full_name: string(move $event.okta.actor.displayName?),
+    email_addr: move $event.okta.actor.alternateId?,
+    type_id: $actor_type_id[$event.okta.actor.type?]? else 99,
   },
   session: {
-    uid: okta.authenticationContext.externalSessionId?,
-    uid_alt: move okta.authenticationContext.rootSessionId?,
+    uid: $event.okta.authenticationContext.externalSessionId?,
+    uid_alt: move $event.okta.authenticationContext.rootSessionId?,
   },
 }
-drop okta.actor?
+drop $event.okta.actor?
 
 let $device_type_map = {
   Computer: "Desktop",
   Mobile: "Mobile",
 }
 
-ocsf.src_endpoint = {
-  ip: move okta.client.ipAddress?,
-  uid: move okta.client.id?,
-  type: $device_type_map[move okta.client.device?]?,
-  domain: move okta.securityContext.domain?,
+$event.ocsf.src_endpoint = {
+  ip: move $event.okta.client.ipAddress?,
+  uid: move $event.okta.client.id?,
+  type: $device_type_map[move $event.okta.client.device?]?,
+  domain: move $event.okta.securityContext.domain?,
   autonomous_system: {
-    number: move okta.securityContext.asNumber?,
+    number: move $event.okta.securityContext.asNumber?,
   },
   owner: {
     org: {
-      name: move okta.securityContext.asOrg?,
+      name: move $event.okta.securityContext.asOrg?,
     },
   },
 }
-ocsf.src_endpoint.location.isp = move okta.securityContext.isp?
-if okta.client.geographicalContext? != null {
-  ocsf.src_endpoint.location.city = move okta.client.geographicalContext.city?
-  ocsf.src_endpoint.location.country = move okta.client.geographicalContext.country?
-  ocsf.src_endpoint.location.postal_code = move okta.client.geographicalContext.postalCode?
-  ocsf.src_endpoint.location.lat = move okta.client.geographicalContext.geolocation?.lat?
-  ocsf.src_endpoint.location.long = move okta.client.geographicalContext.geolocation?.lon?
+$event.ocsf.src_endpoint.location.isp = move $event.okta.securityContext.isp?
+if $event.okta.client.geographicalContext? != null {
+  $event.ocsf.src_endpoint.location.city = move $event.okta.client.geographicalContext.city?
+  $event.ocsf.src_endpoint.location.country = move $event.okta.client.geographicalContext.country?
+  $event.ocsf.src_endpoint.location.postal_code = move $event.okta.client.geographicalContext.postalCode?
+  $event.ocsf.src_endpoint.location.lat = move $event.okta.client.geographicalContext.geolocation?.lat?
+  $event.ocsf.src_endpoint.location.long = move $event.okta.client.geographicalContext.geolocation?.lon?
 }
 
 // Okta reports "Mac OS X (iPhone)" for iPhones, so check for mobile OS
@@ -107,76 +112,76 @@ let $os_type_map = {
   Linux: {name: "Linux", type_id: 200},
   ChromeOS: {name: "ChromeOS", type: "ChromeOS", type_id: 99},
 }
-if okta.client.userAgent?.os? != null {
-  if okta.client.userAgent.os.contains("iPhone") or okta.client.userAgent.os == "iOS" { ocsf.src_endpoint.os = $os_type_map["iOS"] }
-  else if okta.client.userAgent.os.contains("iPad") or okta.client.userAgent.os == "iPadOS" { ocsf.src_endpoint.os = $os_type_map["iPadOS"] }
-  else if okta.client.userAgent.os.contains("Android") { ocsf.src_endpoint.os = $os_type_map["Android"] }
-  else if okta.client.userAgent.os.contains("Windows") { ocsf.src_endpoint.os = $os_type_map["Windows"] }
-  else if okta.client.userAgent.os.contains("Mac") { ocsf.src_endpoint.os = $os_type_map["macOS"] }
-  else if okta.client.userAgent.os.contains("Linux") or okta.client.userAgent.os.contains("Ubuntu") { ocsf.src_endpoint.os = $os_type_map["Linux"] }
-  else if okta.client.userAgent.os.contains("ChromeOS") or okta.client.userAgent.os.contains("Chrome OS") or okta.client.userAgent.os.contains("CrOS") { ocsf.src_endpoint.os = $os_type_map["ChromeOS"] }
+if $event.okta.client.userAgent?.os? != null {
+  if $event.okta.client.userAgent.os.contains("iPhone") or $event.okta.client.userAgent.os == "iOS" { $event.ocsf.src_endpoint.os = $os_type_map["iOS"] }
+  else if $event.okta.client.userAgent.os.contains("iPad") or $event.okta.client.userAgent.os == "iPadOS" { $event.ocsf.src_endpoint.os = $os_type_map["iPadOS"] }
+  else if $event.okta.client.userAgent.os.contains("Android") { $event.ocsf.src_endpoint.os = $os_type_map["Android"] }
+  else if $event.okta.client.userAgent.os.contains("Windows") { $event.ocsf.src_endpoint.os = $os_type_map["Windows"] }
+  else if $event.okta.client.userAgent.os.contains("Mac") { $event.ocsf.src_endpoint.os = $os_type_map["macOS"] }
+  else if $event.okta.client.userAgent.os.contains("Linux") or $event.okta.client.userAgent.os.contains("Ubuntu") { $event.ocsf.src_endpoint.os = $os_type_map["Linux"] }
+  else if $event.okta.client.userAgent.os.contains("ChromeOS") or $event.okta.client.userAgent.os.contains("Chrome OS") or $event.okta.client.userAgent.os.contains("CrOS") { $event.ocsf.src_endpoint.os = $os_type_map["ChromeOS"] }
 }
 
-match ocsf.metadata.event_code {
-  _ if ocsf.metadata.event_code.starts_with("user.session.") or
-       ocsf.metadata.event_code.starts_with("user.authentication.") or
-       ocsf.metadata.event_code == "policy.evaluate_sign_on" or
-       ocsf.metadata.event_code == "system.push.send_factor_verify_push" or
-       ocsf.metadata.event_code == "application.policy.sign_on.deny_access" or
-       ocsf.metadata.event_code.starts_with("app.generic.unauth_app_access_attempt") or
-       ocsf.metadata.event_code.starts_with("app.oauth2.authorize") => {
-    okta::ocsf::event::authentication
+match $event.ocsf.metadata.event_code {
+  _ if $event.ocsf.metadata.event_code.starts_with("user.session.") or
+       $event.ocsf.metadata.event_code.starts_with("user.authentication.") or
+       $event.ocsf.metadata.event_code == "policy.evaluate_sign_on" or
+       $event.ocsf.metadata.event_code == "system.push.send_factor_verify_push" or
+       $event.ocsf.metadata.event_code == "application.policy.sign_on.deny_access" or
+       $event.ocsf.metadata.event_code.starts_with("app.generic.unauth_app_access_attempt") or
+       $event.ocsf.metadata.event_code.starts_with("app.oauth2.authorize") => {
+    okta::ocsf::event::authentication event=$event
   }
   "user.account.report_suspicious_activity_by_enduser" => {
-    okta::ocsf::event::detection_finding
+    okta::ocsf::event::detection_finding event=$event
   }
-  _ if ocsf.metadata.event_code.starts_with("user.lifecycle.") or
-       ocsf.metadata.event_code.starts_with("user.account.") or
-       ocsf.metadata.event_code.starts_with("user.mfa.factor.") => {
-    okta::ocsf::event::account_change
+  _ if $event.ocsf.metadata.event_code.starts_with("user.lifecycle.") or
+       $event.ocsf.metadata.event_code.starts_with("user.account.") or
+       $event.ocsf.metadata.event_code.starts_with("user.mfa.factor.") => {
+    okta::ocsf::event::account_change event=$event
   }
-  _ if ocsf.metadata.event_code.starts_with("group.") => {
-    okta::ocsf::event::group_management
+  _ if $event.ocsf.metadata.event_code.starts_with("group.") => {
+    okta::ocsf::event::group_management event=$event
   }
   "security.threat.detected" |
   "user.mfa.attempt_bypass" |
   "security.protected_action.attempt" => {
-    okta::ocsf::event::detection_finding
+    okta::ocsf::event::detection_finding event=$event
   }
-  _ if ocsf.metadata.event_code.starts_with("system.api_token.") or
-       ocsf.metadata.event_code.starts_with("app.oauth2.token.") or
-       ocsf.metadata.event_code.starts_with("app.oauth2.client.") or
-       ocsf.metadata.event_code.starts_with("app.oauth2.credentials.") or
-       ocsf.metadata.event_code == "application.configuration.read_client_secret" or
-       ocsf.metadata.event_code.starts_with("system.idp.lifecycle.") or
-       ocsf.metadata.event_code.starts_with("system.log_stream.") or
-       ocsf.metadata.event_code.starts_with("workflows.") => {
-    okta::ocsf::event::api_activity
+  _ if $event.ocsf.metadata.event_code.starts_with("system.api_token.") or
+       $event.ocsf.metadata.event_code.starts_with("app.oauth2.token.") or
+       $event.ocsf.metadata.event_code.starts_with("app.oauth2.client.") or
+       $event.ocsf.metadata.event_code.starts_with("app.oauth2.credentials.") or
+       $event.ocsf.metadata.event_code == "application.configuration.read_client_secret" or
+       $event.ocsf.metadata.event_code.starts_with("system.idp.lifecycle.") or
+       $event.ocsf.metadata.event_code.starts_with("system.log_stream.") or
+       $event.ocsf.metadata.event_code.starts_with("workflows.") => {
+    okta::ocsf::event::api_activity event=$event
   }
-  _ if ocsf.metadata.event_code.starts_with("application.") or
-       ocsf.metadata.event_code.starts_with("policy.") or
-       ocsf.metadata.event_code.starts_with("zone.") or
-       ocsf.metadata.event_code.starts_with("device.") or
-       ocsf.metadata.event_code.starts_with("directory.") or
-       ocsf.metadata.event_code.starts_with("security.trusted_origin.") => {
-    okta::ocsf::event::entity_management
+  _ if $event.ocsf.metadata.event_code.starts_with("application.") or
+       $event.ocsf.metadata.event_code.starts_with("policy.") or
+       $event.ocsf.metadata.event_code.starts_with("zone.") or
+       $event.ocsf.metadata.event_code.starts_with("device.") or
+       $event.ocsf.metadata.event_code.starts_with("directory.") or
+       $event.ocsf.metadata.event_code.starts_with("security.trusted_origin.") => {
+    okta::ocsf::event::entity_management event=$event
   }
   _ => {
-    okta::ocsf::base
+    okta::ocsf::base event=$event
   }
 }
 
-drop okta.severity?
-drop okta.legacyEventType?
-if okta.debugContext? != null {
-  drop okta.debugContext.debugData.threatSuspected?
-  drop okta.debugContext.debugData.responseTime?
+drop $event.okta.severity?
+drop $event.okta.legacyEventType?
+if $event.okta.debugContext? != null {
+  drop $event.okta.debugContext.debugData.threatSuspected?
+  drop $event.okta.debugContext.debugData.responseTime?
 }
-drop okta.target?
-drop okta.client?
-drop okta.securityContext?
-drop okta.request?
-drop okta.transaction?
-drop okta.authenticationContext?
+drop $event.okta.target?
+drop $event.okta.client?
+drop $event.okta.securityContext?
+drop $event.okta.request?
+drop $event.okta.transaction?
+drop $event.okta.authenticationContext?
 
-this = {...ocsf, unmapped: okta}
+$event = {...$event.ocsf, unmapped: $event.okta}

--- a/sophos/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/sophos/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,22 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:20.370947Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+```

--- a/sophos/operators/ocsf/base.tql
+++ b/sophos/operators/ocsf/base.tql
@@ -1,12 +1,17 @@
 ---
 description: Sophos → OCSF Base Event (0)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.base_event"
 
-ocsf.category_uid = 0
-ocsf.class_uid = 0
-ocsf.activity_id = 0
-ocsf.type_uid = 0
-ocsf.severity_id = 0
-ocsf.time = now()
+$event.ocsf.category_uid = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.type_uid = 0
+$event.ocsf.severity_id = 0
+$event.ocsf.time = now()

--- a/sophos/operators/ocsf/events/alert.tql
+++ b/sophos/operators/ocsf/events/alert.tql
@@ -1,24 +1,29 @@
 ---
 description: Sophos Alert → OCSF Detection Finding (2004)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.detection_finding"
 
-ocsf.metadata.product.name = "Sophos Endpoint"
-ocsf.metadata.log_name = "alerts"
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.product.name = "Sophos Endpoint"
+$event.ocsf.metadata.log_name = "alerts"
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 2
-ocsf.class_uid = 2004
-ocsf.activity_id = 1  // Create
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-ocsf.time = now()
-if sophos.raisedAt? != null {
-  ocsf.time = time(move sophos.raisedAt)
-} else if sophos.when? != null {
-  ocsf.time = time(move sophos.when)
-} else if sophos.created_at? != null {
-  ocsf.time = time(move sophos.created_at)
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2004
+$event.ocsf.activity_id = 1  // Create
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+$event.ocsf.time = now()
+if $event.sophos.raisedAt? != null {
+  $event.ocsf.time = time(move $event.sophos.raisedAt)
+} else if $event.sophos.when? != null {
+  $event.ocsf.time = time(move $event.sophos.when)
+} else if $event.sophos.created_at? != null {
+  $event.ocsf.time = time(move $event.sophos.created_at)
 }
 
 let $statuses = {
@@ -28,64 +33,64 @@ let $statuses = {
   resolved: 4,
   closed: 4,
 }
-ocsf.status_id = 1
-if sophos.status? != null {
-  ocsf.status_id = $statuses[move sophos.status]? else 1
+$event.ocsf.status_id = 1
+if $event.sophos.status? != null {
+  $event.ocsf.status_id = $statuses[move $event.sophos.status]? else 1
 }
 
-ocsf.finding_info = {
-  uid: ocsf.metadata.original_event_uid,
-  uid_alt: move sophos.event_service_event_id?,
-  title: sophos.threat? else sophos.type?,
-  desc: move sophos.description?,
-  created_time: time(move sophos.created_at?),
-  first_seen_time: ocsf.time,
-  modified_time: time(move sophos.updatedAt?),
+$event.ocsf.finding_info = {
+  uid: $event.ocsf.metadata.original_event_uid,
+  uid_alt: move $event.sophos.event_service_event_id?,
+  title: $event.sophos.threat? else $event.sophos.type?,
+  desc: move $event.sophos.description?,
+  created_time: time(move $event.sophos.created_at?),
+  first_seen_time: $event.ocsf.time,
+  modified_time: time(move $event.sophos.updatedAt?),
   product: {
-    name: move sophos.product?,
+    name: move $event.sophos.product?,
     vendor_name: "Sophos",
   },
-  types: [move sophos.category?],
+  types: [move $event.sophos.category?],
 }
 
-ocsf.device = {
-  uid: sophos.data?.endpoint_id? else sophos.managedAgent?.id?,
-  name: sophos.location? else sophos.managedAgent?.name?,
-  hostname: sophos.location? else sophos.managedAgent?.name?,
+$event.ocsf.device = {
+  uid: $event.sophos.data?.endpoint_id? else $event.sophos.managedAgent?.id?,
+  name: $event.sophos.location? else $event.sophos.managedAgent?.name?,
+  hostname: $event.sophos.location? else $event.sophos.managedAgent?.name?,
   type_id: 2,
-  ip: sophos.data?.source_info?.ip?,
+  ip: $event.sophos.data?.source_info?.ip?,
 }
 
-ocsf.evidences = [{
-  uid: ocsf.finding_info.uid_alt,
-  device: ocsf.device?,
+$event.ocsf.evidences = [{
+  uid: $event.ocsf.finding_info.uid_alt,
+  device: $event.ocsf.device?,
   actor: {
     user: {
-      uid: move sophos.person?.id?,
-      name: sophos.source?.split("\\")[-1]? else sophos.person?.name?.split("\\")[-1]?,
-      domain: sophos.source?.split("\\")[0]? else sophos.person?.name?.split("\\")[0]?,
-      full_name: sophos.source? else sophos.person?.name?,
+      uid: move $event.sophos.person?.id?,
+      name: $event.sophos.source?.split("\\")[-1]? else $event.sophos.person?.name?.split("\\")[-1]?,
+      domain: $event.sophos.source?.split("\\")[0]? else $event.sophos.person?.name?.split("\\")[0]?,
+      full_name: $event.sophos.source? else $event.sophos.person?.name?,
       type_id: 1,
     },
   },
   file: {
-    path: move sophos.data?.app_path?,
-    name: sophos.data?.app_path?.split("\\")[-1]?,
+    path: move $event.sophos.data?.app_path?,
+    name: $event.sophos.data?.app_path?.split("\\")[-1]?,
     hashes: [{
       algorithm_id: 3,
-      value: move sophos.data?.app_sha256?,
+      value: move $event.sophos.data?.app_sha256?,
     }],
   },
   src_endpoint: {
-    ip: sophos.data?.source_info?.ip?,
+    ip: $event.sophos.data?.source_info?.ip?,
   },
 }]
 
-ocsf.resources = [{
-  uid: ocsf.device.uid,
-  name: ocsf.device.hostname,
+$event.ocsf.resources = [{
+  uid: $event.ocsf.device.uid,
+  name: $event.ocsf.device.hostname,
   type: "Device",
   role_id: 3,
 }]
 
-ocsf.is_alert = true
+$event.ocsf.is_alert = true

--- a/sophos/operators/ocsf/events/common_alert.tql
+++ b/sophos/operators/ocsf/events/common_alert.tql
@@ -1,22 +1,27 @@
 ---
 description: Sophos Common Alert → OCSF Detection Finding (2004)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.detection_finding"
 
-ocsf.metadata.product.name = "Sophos Endpoint"
-ocsf.metadata.log_name = "common/alerts"
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.product.name = "Sophos Endpoint"
+$event.ocsf.metadata.log_name = "common/alerts"
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 2
-ocsf.class_uid = 2004
-ocsf.activity_id = 1  // Create
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-ocsf.time = now()
-if sophos.raisedAt? != null {
-  ocsf.time = time(move sophos.raisedAt)
-} else if sophos.updatedAt? != null {
-  ocsf.time = time(move sophos.updatedAt)
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2004
+$event.ocsf.activity_id = 1  // Create
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+$event.ocsf.time = now()
+if $event.sophos.raisedAt? != null {
+  $event.ocsf.time = time(move $event.sophos.raisedAt)
+} else if $event.sophos.updatedAt? != null {
+  $event.ocsf.time = time(move $event.sophos.updatedAt)
 }
 
 let $statuses = {
@@ -26,51 +31,51 @@ let $statuses = {
   resolved: 4,
   closed: 4,
 }
-ocsf.status_id = 1
-if sophos.status? != null {
-  ocsf.status_id = $statuses[move sophos.status]? else 1
+$event.ocsf.status_id = 1
+if $event.sophos.status? != null {
+  $event.ocsf.status_id = $statuses[move $event.sophos.status]? else 1
 }
 
-ocsf.finding_info = {
-  uid: ocsf.metadata.original_event_uid,
-  uid_alt: move sophos.groupKey?,
-  title: sophos.type? else sophos.category?,
-  desc: move sophos.description?,
-  created_time: ocsf.time,
-  modified_time: time(move sophos.updatedAt?),
-  last_seen_time: time(move sophos.lastCorrelatedAt?),
+$event.ocsf.finding_info = {
+  uid: $event.ocsf.metadata.original_event_uid,
+  uid_alt: move $event.sophos.groupKey?,
+  title: $event.sophos.type? else $event.sophos.category?,
+  desc: move $event.sophos.description?,
+  created_time: $event.ocsf.time,
+  modified_time: time(move $event.sophos.updatedAt?),
+  last_seen_time: time(move $event.sophos.lastCorrelatedAt?),
   product: {
-    name: move sophos.product?,
+    name: move $event.sophos.product?,
     vendor_name: "Sophos",
   },
-  types: [move sophos.category?],
+  types: [move $event.sophos.category?],
 }
 
-ocsf.device = {
-  uid: sophos.managedAgent?.id?,
-  name: sophos.managedAgent?.name?,
-  hostname: sophos.managedAgent?.name?,
+$event.ocsf.device = {
+  uid: $event.sophos.managedAgent?.id?,
+  name: $event.sophos.managedAgent?.name?,
+  hostname: $event.sophos.managedAgent?.name?,
   type_id: 2,
 }
 
-ocsf.evidences = [{
-  device: ocsf.device?,
+$event.ocsf.evidences = [{
+  device: $event.ocsf.device?,
   actor: {
     user: {
-      uid: move sophos.person?.id?,
-      name: sophos.person?.name?.split("\\")[-1]?,
-      domain: sophos.person?.name?.split("\\")[0]?,
-      full_name: move sophos.person?.name?,
+      uid: move $event.sophos.person?.id?,
+      name: $event.sophos.person?.name?.split("\\")[-1]?,
+      domain: $event.sophos.person?.name?.split("\\")[0]?,
+      full_name: move $event.sophos.person?.name?,
       type_id: 1,
     },
   },
 }]
 
-ocsf.resources = [{
-  uid: ocsf.device.uid,
-  name: ocsf.device.hostname,
+$event.ocsf.resources = [{
+  uid: $event.ocsf.device.uid,
+  name: $event.ocsf.device.hostname,
   type: "Device",
   role_id: 3,
 }]
 
-ocsf.is_alert = true
+$event.ocsf.is_alert = true

--- a/sophos/operators/ocsf/events/detection.tql
+++ b/sophos/operators/ocsf/events/detection.tql
@@ -1,71 +1,76 @@
 ---
 description: Sophos Detection → OCSF Detection Finding (2004)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.detection_finding"
 
-ocsf.metadata.product.name = "Sophos XDR"
-ocsf.metadata.log_name = "detections"
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.product.name = "Sophos XDR"
+$event.ocsf.metadata.log_name = "detections"
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 2
-ocsf.class_uid = 2004
-ocsf.activity_id = 1  // Create
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-ocsf.time = time(move sophos.time)
-ocsf.severity_id = int(sophos.severity)
-ocsf.risk_level_id = int(sophos.severity) - 1
-ocsf.confidence_score = int(sophos.intelixFileReputation[0].reputationScore?)
-ocsf.status_id = 3 if sophos.suppressed else 1
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2004
+$event.ocsf.activity_id = 1  // Create
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+$event.ocsf.time = time(move $event.sophos.time)
+$event.ocsf.severity_id = int($event.sophos.severity)
+$event.ocsf.risk_level_id = int($event.sophos.severity) - 1
+$event.ocsf.confidence_score = int($event.sophos.intelixFileReputation[0].reputationScore?)
+$event.ocsf.status_id = 3 if $event.sophos.suppressed else 1
 
-ocsf.finding_info = {
-  uid: ocsf.metadata.original_event_uid,
-  title: sophos.rawData?.detection_name? else sophos.detectionRule? else sophos.type?,
-  desc: move sophos.ruleDescription?,
-  created_time: time(move sophos.sensorGeneratedAt?),
+$event.ocsf.finding_info = {
+  uid: $event.ocsf.metadata.original_event_uid,
+  title: $event.sophos.rawData?.detection_name? else $event.sophos.detectionRule? else $event.sophos.type?,
+  desc: move $event.sophos.ruleDescription?,
+  created_time: time(move $event.sophos.sensorGeneratedAt?),
   product: {
-    name: move sophos.sensor.source?,
-    version: move sophos.sensor.version?,
-    uid: move sophos.sensor.id?,
+    name: move $event.sophos.sensor.source?,
+    version: move $event.sophos.sensor.version?,
+    uid: move $event.sophos.sensor.id?,
     vendor_name: "Sophos",
   },
-  types: [move sophos.attackType?, move sophos.detectionAttack?],
+  types: [move $event.sophos.attackType?, move $event.sophos.detectionAttack?],
 }
 
-ocsf.device = {
-  uid: sophos.device?.id? else sophos.rawData?.customer_id?,
-  name: sophos.device?.entity? else sophos.rawData?.meta_hostname?,
-  hostname: sophos.device?.entity? else sophos.rawData?.meta_hostname?,
+$event.ocsf.device = {
+  uid: $event.sophos.device?.id? else $event.sophos.rawData?.customer_id?,
+  name: $event.sophos.device?.entity? else $event.sophos.rawData?.meta_hostname?,
+  hostname: $event.sophos.device?.entity? else $event.sophos.rawData?.meta_hostname?,
   type_id: 2,
 }
 
-ocsf.evidences = [{
-  device: ocsf.device?,
+$event.ocsf.evidences = [{
+  device: $event.ocsf.device?,
   actor: {
     user: {
-      name: move sophos.rawData?.meta_username?,
+      name: move $event.sophos.rawData?.meta_username?,
       type_id: 1,
     },
   },
   process: {
-    name: move sophos.rawData?.process_name?,
-    cmd_line: move sophos.rawData?.process_cmd_line?,
+    name: move $event.sophos.rawData?.process_name?,
+    cmd_line: move $event.sophos.rawData?.process_cmd_line?,
     file: {
-      path: move sophos.rawData?.process_path?,
-      name: sophos.rawData?.process_path?.split("\\")[-1]?,
+      path: move $event.sophos.rawData?.process_path?,
+      name: $event.sophos.rawData?.process_path?.split("\\")[-1]?,
       hashes: [{
         algorithm_id: 3,
-        value: move sophos.rawData?.process_sha256?,
+        value: move $event.sophos.rawData?.process_sha256?,
       }],
     },
   },
 }]
 
-ocsf.resources = [{
-  uid: ocsf.device.uid,
-  name: ocsf.device.hostname,
+$event.ocsf.resources = [{
+  uid: $event.ocsf.device.uid,
+  name: $event.ocsf.device.hostname,
   type: "Device",
   role_id: 3,
 }]
 
-ocsf.is_alert = true
+$event.ocsf.is_alert = true

--- a/sophos/operators/ocsf/events/endpoint.tql
+++ b/sophos/operators/ocsf/events/endpoint.tql
@@ -1,22 +1,27 @@
 ---
 description: Sophos Endpoint → OCSF Device Inventory Info (5001)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.inventory_info"
 
-ocsf.metadata.product.name = "Sophos Endpoint"
-ocsf.metadata.log_name = "endpoints"
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.product.name = "Sophos Endpoint"
+$event.ocsf.metadata.log_name = "endpoints"
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 5
-ocsf.class_uid = 5001
-ocsf.activity_id = 2  // Collect
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-ocsf.time = now()
-if sophos.lastSeenAt? != null {
-  ocsf.time = time(move sophos.lastSeenAt)
-} else if sophos.registeredAt? != null {
-  ocsf.time = time(move sophos.registeredAt)
+$event.ocsf.category_uid = 5
+$event.ocsf.class_uid = 5001
+$event.ocsf.activity_id = 2  // Collect
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+$event.ocsf.time = now()
+if $event.sophos.lastSeenAt? != null {
+  $event.ocsf.time = time(move $event.sophos.lastSeenAt)
+} else if $event.sophos.registeredAt? != null {
+  $event.ocsf.time = time(move $event.sophos.registeredAt)
 }
 
 let $os_type_ids = {
@@ -29,35 +34,35 @@ let $device_type_ids = {
   server: 1,
 }
 
-ocsf.device = {
-  uid: ocsf.metadata.original_event_uid,
-  name: sophos.hostname?,
-  hostname: sophos.hostname?,
-  type_id: $device_type_ids[sophos.type]? else 0,
-  ip: sophos.ipv4Addresses[0]?,
+$event.ocsf.device = {
+  uid: $event.ocsf.metadata.original_event_uid,
+  name: $event.sophos.hostname?,
+  hostname: $event.sophos.hostname?,
+  type_id: $device_type_ids[$event.sophos.type]? else 0,
+  ip: $event.sophos.ipv4Addresses[0]?,
   os: {
-    name: move sophos.os.name?,
-    type_id: $os_type_ids[sophos.os.platform]? else 0,
-    build: string(move sophos.os.build?),
+    name: move $event.sophos.os.name?,
+    type_id: $os_type_ids[$event.sophos.os.platform]? else 0,
+    build: string(move $event.sophos.os.build?),
   },
   hw_info: {
-    serial_number: move sophos.serialNumber?,
+    serial_number: move $event.sophos.serialNumber?,
   },
   owner: {
-    uid: move sophos.associatedPerson.id?,
-    name: sophos.associatedPerson.name?.split("\\")[-1]?,
-    domain: sophos.associatedPerson.name?.split("\\")[0]?,
-    full_name: move sophos.associatedPerson.name?,
+    uid: move $event.sophos.associatedPerson.id?,
+    name: $event.sophos.associatedPerson.name?.split("\\")[-1]?,
+    domain: $event.sophos.associatedPerson.name?.split("\\")[0]?,
+    full_name: move $event.sophos.associatedPerson.name?,
     type_id: 1,
   },
   groups: [{
-    uid: move sophos.group.id?,
-    name: move sophos.group.name?,
+    uid: move $event.sophos.group.id?,
+    name: move $event.sophos.group.name?,
   }],
-  first_seen_time: time(move sophos.registeredAt?),
-  last_seen_time: ocsf.time,
+  first_seen_time: time(move $event.sophos.registeredAt?),
+  last_seen_time: $event.ocsf.time,
   is_managed: true,
-  is_trusted: move sophos.tamperProtectionEnabled?,
+  is_trusted: move $event.sophos.tamperProtectionEnabled?,
 }
 
-ocsf.status_detail = move sophos.health.overall?
+$event.ocsf.status_detail = move $event.sophos.health.overall?

--- a/sophos/operators/ocsf/events/file_remediation_activity.tql
+++ b/sophos/operators/ocsf/events/file_remediation_activity.tql
@@ -1,47 +1,52 @@
 ---
 description: Sophos Cleanup Event → OCSF File Remediation Activity (7002)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.file_remediation_activity"
 
-ocsf.metadata.product.name = "Sophos Endpoint"
-ocsf.metadata.log_name = "siem/events"
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.product.name = "Sophos Endpoint"
+$event.ocsf.metadata.log_name = "siem/events"
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 7
-ocsf.class_uid = 7002
-ocsf.activity_id = 2  // Evict
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-ocsf.time = now()
-if sophos.when? != null {
-  ocsf.time = time(move sophos.when)
-} else if sophos.created_at? != null {
-  ocsf.time = time(move sophos.created_at)
+$event.ocsf.category_uid = 7
+$event.ocsf.class_uid = 7002
+$event.ocsf.activity_id = 2  // Evict
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+$event.ocsf.time = now()
+if $event.sophos.when? != null {
+  $event.ocsf.time = time(move $event.sophos.when)
+} else if $event.sophos.created_at? != null {
+  $event.ocsf.time = time(move $event.sophos.created_at)
 }
 
-ocsf.command_uid = ocsf.metadata.original_event_uid
-ocsf.status_detail = sophos.core_remedy_items.items[0].result?
+$event.ocsf.command_uid = $event.ocsf.metadata.original_event_uid
+$event.ocsf.status_detail = $event.sophos.core_remedy_items.items[0].result?
 
-ocsf.device = {
-  uid: sophos.endpoint_id?,
-  name: sophos.location?,
-  hostname: sophos.location?,
+$event.ocsf.device = {
+  uid: $event.sophos.endpoint_id?,
+  name: $event.sophos.location?,
+  hostname: $event.sophos.location?,
   type_id: 2,
-  ip: sophos.source_info?.ip?,
+  ip: $event.sophos.source_info?.ip?,
 }
 
-ocsf.actor = {
+$event.ocsf.actor = {
   user: {
-    uid: move sophos.user_id?,
-    name: sophos.source?.split("\\")[-1]?,
-    domain: sophos.source?.split("\\")[0]?,
-    full_name: move sophos.source?,
+    uid: move $event.sophos.user_id?,
+    name: $event.sophos.source?.split("\\")[-1]?,
+    domain: $event.sophos.source?.split("\\")[0]?,
+    full_name: move $event.sophos.source?,
     type_id: 1,
   },
 }
 
-ocsf.file = {
-  path: sophos.core_remedy_items.items[0].descriptor?,
-  name: sophos.core_remedy_items.items[0].descriptor?.split("\\")[-1]?,
-  is_deleted: ocsf.status_detail == "DELETED",
+$event.ocsf.file = {
+  path: $event.sophos.core_remedy_items.items[0].descriptor?,
+  name: $event.sophos.core_remedy_items.items[0].descriptor?.split("\\")[-1]?,
+  is_deleted: $event.ocsf.status_detail == "DELETED",
 }

--- a/sophos/operators/ocsf/events/siem_detection.tql
+++ b/sophos/operators/ocsf/events/siem_detection.tql
@@ -1,69 +1,74 @@
 ---
 description: Sophos SIEM Event → OCSF Detection Finding (2004)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.detection_finding"
 
-ocsf.metadata.product.name = "Sophos Endpoint"
-ocsf.metadata.log_name = "siem/events"
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.product.name = "Sophos Endpoint"
+$event.ocsf.metadata.log_name = "siem/events"
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 2
-ocsf.class_uid = 2004
-ocsf.activity_id = 1  // Create
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-ocsf.time = now()
-if sophos.when? != null {
-  ocsf.time = time(move sophos.when)
-} else if sophos.created_at? != null {
-  ocsf.time = time(move sophos.created_at)
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2004
+$event.ocsf.activity_id = 1  // Create
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+$event.ocsf.time = now()
+if $event.sophos.when? != null {
+  $event.ocsf.time = time(move $event.sophos.when)
+} else if $event.sophos.created_at? != null {
+  $event.ocsf.time = time(move $event.sophos.created_at)
 }
-ocsf.status_id = 1
+$event.ocsf.status_id = 1
 
-ocsf.finding_info = {
-  uid: ocsf.metadata.original_event_uid,
-  title: sophos.threat? else sophos.name? else sophos.type?,
-  desc: move sophos.name?,
-  created_time: time(move sophos.created_at?),
+$event.ocsf.finding_info = {
+  uid: $event.ocsf.metadata.original_event_uid,
+  title: $event.sophos.threat? else $event.sophos.name? else $event.sophos.type?,
+  desc: move $event.sophos.name?,
+  created_time: time(move $event.sophos.created_at?),
   product: {
-    name: move sophos.origin?,
+    name: move $event.sophos.origin?,
     vendor_name: "Sophos",
   },
-  types: [move sophos.group?],
+  types: [move $event.sophos.group?],
 }
 
-ocsf.device = {
-  uid: sophos.endpoint_id?,
-  name: sophos.location?,
-  hostname: sophos.location?,
+$event.ocsf.device = {
+  uid: $event.sophos.endpoint_id?,
+  name: $event.sophos.location?,
+  hostname: $event.sophos.location?,
   type_id: 2,
-  ip: sophos.source_info?.ip?,
+  ip: $event.sophos.source_info?.ip?,
 }
 
-ocsf.evidences = [{
-  device: ocsf.device?,
+$event.ocsf.evidences = [{
+  device: $event.ocsf.device?,
   actor: {
     user: {
-      uid: move sophos.user_id?,
-      name: sophos.source?.split("\\")[-1]?,
-      domain: sophos.source?.split("\\")[0]?,
-      full_name: move sophos.source?,
+      uid: move $event.sophos.user_id?,
+      name: $event.sophos.source?.split("\\")[-1]?,
+      domain: $event.sophos.source?.split("\\")[0]?,
+      full_name: move $event.sophos.source?,
       type_id: 1,
     },
   },
   src_endpoint: {
-    ip: sophos.source_info?.ip?,
+    ip: $event.sophos.source_info?.ip?,
   },
   data: {
-    file_sha256: move sophos.appSha256?,
+    file_sha256: move $event.sophos.appSha256?,
   },
 }]
 
-ocsf.resources = [{
-  uid: ocsf.device.uid,
-  name: ocsf.device.hostname,
+$event.ocsf.resources = [{
+  uid: $event.ocsf.device.uid,
+  name: $event.ocsf.device.hostname,
   type: "Device",
   role_id: 3,
 }]
 
-ocsf.is_alert = true
+$event.ocsf.is_alert = true

--- a/sophos/operators/ocsf/events/web_resource_access_activity.tql
+++ b/sophos/operators/ocsf/events/web_resource_access_activity.tql
@@ -1,50 +1,55 @@
 ---
 description: Sophos Web Filtering Event → OCSF Web Resource Access Activity (6004)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.web_resource_access_activity"
 
-ocsf.metadata.product.name = "Sophos Endpoint"
-ocsf.metadata.log_name = "siem/events"
-ocsf.metadata.profiles = ["host", "security_control"]
+$event.ocsf.metadata.product.name = "Sophos Endpoint"
+$event.ocsf.metadata.log_name = "siem/events"
+$event.ocsf.metadata.profiles = ["host", "security_control"]
 
-ocsf.category_uid = 6
-ocsf.class_uid = 6004
-ocsf.activity_id = 2  // Access Deny
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-ocsf.status_id = 2
-ocsf.time = now()
-if sophos.when? != null {
-  ocsf.time = time(move sophos.when)
-} else if sophos.created_at? != null {
-  ocsf.time = time(move sophos.created_at)
+$event.ocsf.category_uid = 6
+$event.ocsf.class_uid = 6004
+$event.ocsf.activity_id = 2  // Access Deny
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+$event.ocsf.status_id = 2
+$event.ocsf.time = now()
+if $event.sophos.when? != null {
+  $event.ocsf.time = time(move $event.sophos.when)
+} else if $event.sophos.created_at? != null {
+  $event.ocsf.time = time(move $event.sophos.created_at)
 }
 
-ocsf.message = move sophos.name?
-ocsf.status_detail = move sophos.threat?
+$event.ocsf.message = move $event.sophos.name?
+$event.ocsf.status_detail = move $event.sophos.threat?
 
-ocsf.src_endpoint = {
-  ip: sophos.source_info?.ip?,
-  name: move sophos.location?,
-  hostname: sophos.location?,
+$event.ocsf.src_endpoint = {
+  ip: $event.sophos.source_info?.ip?,
+  name: move $event.sophos.location?,
+  hostname: $event.sophos.location?,
 }
 
-ocsf.actor = {
+$event.ocsf.actor = {
   user: {
-    uid: move sophos.user_id?,
-    name: sophos.source?.split("\\")[-1]?,
-    domain: sophos.source?.split("\\")[0]?,
-    full_name: move sophos.source?,
+    uid: move $event.sophos.user_id?,
+    name: $event.sophos.source?.split("\\")[-1]?,
+    domain: $event.sophos.source?.split("\\")[0]?,
+    full_name: move $event.sophos.source?,
     type_id: 1,
   },
 }
 
-ocsf.http_request = {
-  uid: ocsf.metadata.original_event_uid,
+$event.ocsf.http_request = {
+  uid: $event.ocsf.metadata.original_event_uid,
 }
 
-ocsf.web_resources = [{
-  uid: ocsf.metadata.original_event_uid,
-  name: ocsf.status_detail,
+$event.ocsf.web_resources = [{
+  uid: $event.ocsf.metadata.original_event_uid,
+  name: $event.ocsf.status_detail,
   type: "category",
 }]

--- a/sophos/operators/ocsf/map.tql
+++ b/sophos/operators/ocsf/map.tql
@@ -1,11 +1,16 @@
 ---
 description: Sophos → OCSF
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {sophos: this}
-ocsf = {}
+$event = {...$event, sophos: $event, ocsf: {}}
 
-ocsf.metadata = {
+$event.ocsf.metadata = {
   product: {
     vendor_name: "Sophos",
     feature: {
@@ -15,17 +20,17 @@ ocsf.metadata = {
   version: "1.8.0",
 }
 
-if sophos.customer_id? != null {
-  ocsf.metadata.tenant_uid = move sophos.customer_id
+if $event.sophos.customer_id? != null {
+  $event.ocsf.metadata.tenant_uid = move $event.sophos.customer_id
 }
-if sophos.tenant?.id? != null {
-  ocsf.metadata.tenant_uid = move sophos.tenant.id
+if $event.sophos.tenant?.id? != null {
+  $event.ocsf.metadata.tenant_uid = move $event.sophos.tenant.id
 }
-if sophos.id? != null {
-  ocsf.metadata.original_event_uid = move sophos.id
+if $event.sophos.id? != null {
+  $event.ocsf.metadata.original_event_uid = move $event.sophos.id
 }
-if sophos.data? != null and sophos.data.correlation_id? != null {
-  ocsf.metadata.correlation_uid = move sophos.data.correlation_id
+if $event.sophos.data? != null and $event.sophos.data.correlation_id? != null {
+  $event.ocsf.metadata.correlation_uid = move $event.sophos.data.correlation_id
 }
 
 let $severities = {
@@ -36,47 +41,47 @@ let $severities = {
   high: 4,
   critical: 5,
 }
-ocsf.severity_id = 1
-if sophos.severity? != null {
-  ocsf.severity_id = $severities[sophos.severity]? else 1
+$event.ocsf.severity_id = 1
+if $event.sophos.severity? != null {
+  $event.ocsf.severity_id = $severities[$event.sophos.severity]? else 1
 }
 
 match @name {
   "sophos.endpoint" => {
-    sophos::ocsf::events::endpoint
+    sophos::ocsf::events::endpoint event=$event
   }
   "sophos.detection" => {
-    sophos::ocsf::events::detection
+    sophos::ocsf::events::detection event=$event
   }
   "sophos.common.alert" => {
-    sophos::ocsf::events::common_alert
+    sophos::ocsf::events::common_alert event=$event
   }
   "sophos.alert" => {
-    sophos::ocsf::events::alert
+    sophos::ocsf::events::alert event=$event
   }
   "sophos.event" => {
-    match sophos.type {
+    match $event.sophos.type {
       "Event::Endpoint::CoreDetection" |
       "Event::Endpoint::CorePuaDetection" |
       "Event::Endpoint::CorePuaRemoteDetection" |
       "Event::Endpoint::HmpaExploitPrevented" => {
-        sophos::ocsf::events::siem_detection
+        sophos::ocsf::events::siem_detection event=$event
       }
       "Event::Endpoint::CoreClean" |
       "Event::Endpoint::CorePuaClean" => {
-        sophos::ocsf::events::file_remediation_activity
+        sophos::ocsf::events::file_remediation_activity event=$event
       }
       "Event::Endpoint::WebFilteringBlocked" => {
-        sophos::ocsf::events::web_resource_access_activity
+        sophos::ocsf::events::web_resource_access_activity event=$event
       }
       _ => {
-        sophos::ocsf::base
+        sophos::ocsf::base event=$event
       }
     }
   }
   _ => {
-    sophos::ocsf::base
+    sophos::ocsf::base event=$event
   }
 }
 
-this = {...ocsf, unmapped: sophos}
+$event = {...$event.ocsf, unmapped: $event.sophos}

--- a/splunk/changelog/unreleased/event-scoped-cim-and-ocsf-mapping-operators.md
+++ b/splunk/changelog/unreleased/event-scoped-cim-and-ocsf-mapping-operators.md
@@ -1,0 +1,24 @@
+---
+title: Event-scoped CIM and OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:24.616664Z
+---
+
+Splunk CIM and OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+The canonical OCSF-to-CIM mapper remains `splunk::cim::ocsf::map`, and the CIM-to-OCSF mapper remains `splunk::ocsf::cim::map`.
+
+Before:
+
+```tql
+splunk::cim::ocsf::map
+```
+
+After:
+
+```tql
+splunk::cim::ocsf::map event=ocsf_event
+```

--- a/splunk/operators/cim/map.tql
+++ b/splunk/operators/cim/map.tql
@@ -1,5 +1,11 @@
 ---
 description: Splunk → CIM
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-splunk::cim::ocsf::map
+splunk::cim::ocsf::map event=$event

--- a/splunk/operators/cim/ocsf/account_change.tql
+++ b/splunk/operators/cim/ocsf/account_change.tql
@@ -1,59 +1,64 @@
 ---
 description: OCSF Account Change (3001) → Splunk CIM Change Account Management
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 3001
+assert $event.ocsf.class_uid == 3001
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["change", "account"]
+$event.cim.tag = ["change", "account"]
 
 // --- CIM: occurrence and action attributes ----
 
-cim._time = time
-cim.action = activity_name?.to_lower().replace(" ", "_") else "unknown"
-cim.change_type = "AAA"
-cim.status = status?.to_lower()
-match status_id? {
+$event.cim._time = $event.ocsf.time
+$event.cim.action = $event.ocsf.activity_name?.to_lower().replace(" ", "_") else "unknown"
+$event.cim.change_type = "AAA"
+$event.cim.status = $event.ocsf.status?.to_lower()
+match $event.ocsf.status_id? {
   1 => {
-    cim.status = "success"
+    $event.cim.status = "success"
   }
   2 => {
-    cim.status = "failure"
+    $event.cim.status = "failure"
   }
   _ => {}
 }
-cim.result = status_detail? else status?
-cim.result_id = status_code? else status_id?.string()
+$event.cim.result = $event.ocsf.status_detail? else $event.ocsf.status?
+$event.cim.result_id = $event.ocsf.status_code? else $event.ocsf.status_id?.string()
 
 // --- CIM: object attributes -------------------
 
-cim.object = user_result?.name? else user?.name? else user_result?.uid? else user?.uid?
-cim.object_id = user_result?.uid? else user?.uid?
-cim.object_category = "user"
-cim.object_attrs = [...user_result?.changes?.map(c => c.name)]
+$event.cim.object = $event.ocsf.user_result?.name? else $event.ocsf.user?.name? else $event.ocsf.user_result?.uid? else $event.ocsf.user?.uid?
+$event.cim.object_id = $event.ocsf.user_result?.uid? else $event.ocsf.user?.uid?
+$event.cim.object_category = "user"
+$event.cim.object_attrs = [...$event.ocsf.user_result?.changes?.map(c => c.name)]
 
 // --- CIM: endpoint attributes -----------------
 
-cim.src = actor?.process?.device?.hostname? else actor?.process?.device?.ip? else actor?.process?.device?.name?
-cim.dest = device?.hostname? else device?.ip? else device?.name?
-cim.dvc = device?.hostname? else device?.ip? else device?.name?
+$event.cim.src = $event.ocsf.actor?.process?.device?.hostname? else $event.ocsf.actor?.process?.device?.ip? else $event.ocsf.actor?.process?.device?.name?
+$event.cim.dest = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
+$event.cim.dvc = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
 
 // --- CIM: user and product attributes ---------
 
-cim.user = user_result?.name? else user?.name? else user_result?.uid? else user?.uid?
-cim.user_name = user_result?.name? else user?.name?
-cim.user_type = user_result?.type? else user?.type?
-cim.src_user = actor?.user?.name? else actor?.user?.uid?
-cim.src_user_name = actor?.user?.name?
-cim.src_user_type = actor?.user?.type?
-cim.user_agent = http_request?.user_agent?
-cim.vendor_account = cloud?.account?.uid?
-cim.vendor_region = cloud?.region?
-splunk::cim::ocsf::helpers::product
+$event.cim.user = $event.ocsf.user_result?.name? else $event.ocsf.user?.name? else $event.ocsf.user_result?.uid? else $event.ocsf.user?.uid?
+$event.cim.user_name = $event.ocsf.user_result?.name? else $event.ocsf.user?.name?
+$event.cim.user_type = $event.ocsf.user_result?.type? else $event.ocsf.user?.type?
+$event.cim.src_user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+$event.cim.src_user_name = $event.ocsf.actor?.user?.name?
+$event.cim.src_user_type = $event.ocsf.actor?.user?.type?
+$event.cim.user_agent = $event.ocsf.http_request?.user_agent?
+$event.cim.vendor_account = $event.ocsf.cloud?.account?.uid?
+$event.cim.vendor_region = $event.ocsf.cloud?.region?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/alerts_finding.tql
+++ b/splunk/operators/cim/ocsf/alerts_finding.tql
@@ -1,51 +1,56 @@
 ---
 description: OCSF Finding → Splunk CIM Alerts
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid in [2001, 2004, 2006]
+assert $event.ocsf.class_uid in [2001, 2004, 2006]
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["alert"]
+$event.cim.tag = ["alert"]
 
 // --- CIM: occurrence attributes ---------------
 
-cim._time = time
-cim.type = "alert" if is_alert? == true else "event"
-cim.app = metadata.product.name?
+$event.cim._time = $event.ocsf.time
+$event.cim.type = "alert" if $event.ocsf.is_alert? == true else "event"
+$event.cim.app = $event.ocsf.metadata.product.name?
 
 // --- CIM: finding attributes ------------------
 
-cim.id = finding_info?.uid? else finding?.uid? else metadata.original_event_uid?
-cim.description = finding_info?.desc? else finding?.desc? else message?
-cim.signature = finding_info?.title? else finding?.title? else type_name? else class_name?
-cim.signature_id = finding_info?.uid? else finding?.uid? else metadata.event_code? else type_uid?.string()
-cim.subject = cim.signature
-cim.mitre_technique_id = [...(
-  finding_info?.attacks?.map(a => a.technique?.uid?) else
-  attacks?.map(a => a.technique?.uid?)
+$event.cim.id = $event.ocsf.finding_info?.uid? else $event.ocsf.finding?.uid? else $event.ocsf.metadata.original_event_uid?
+$event.cim.description = $event.ocsf.finding_info?.desc? else $event.ocsf.finding?.desc? else $event.ocsf.message?
+$event.cim.signature = $event.ocsf.finding_info?.title? else $event.ocsf.finding?.title? else $event.ocsf.type_name? else $event.ocsf.class_name?
+$event.cim.signature_id = $event.ocsf.finding_info?.uid? else $event.ocsf.finding?.uid? else $event.ocsf.metadata.event_code? else $event.ocsf.type_uid?.string()
+$event.cim.subject = $event.cim.signature
+$event.cim.mitre_technique_id = [...(
+  $event.ocsf.finding_info?.attacks?.map(a => a.technique?.uid?) else
+  $event.ocsf.attacks?.map(a => a.technique?.uid?)
 )]
-splunk::cim::ocsf::helpers::severity
+splunk::cim::ocsf::helpers::severity event=$event
 
 // --- CIM: source and destination attributes ---
 
-cim.src = src_endpoint?.hostname? else src_endpoint?.ip? else src_endpoint?.name? else
-          actor?.process?.device?.hostname? else actor?.process?.device?.ip? else actor?.process?.device?.name?
-cim.src_type = src_endpoint?.type? else actor?.process?.device?.type?
-cim.dest = dst_endpoint?.hostname? else dst_endpoint?.ip? else dst_endpoint?.name? else
-           device?.hostname? else device?.ip? else device?.name? else
-           resource?.name? else resources?[0]?.name? else resources?[0]?.hostname? else resources?[0]?.ip?
-cim.dest_type = dst_endpoint?.type? else device?.type?
+$event.cim.src = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.ip? else $event.ocsf.src_endpoint?.name? else
+          $event.ocsf.actor?.process?.device?.hostname? else $event.ocsf.actor?.process?.device?.ip? else $event.ocsf.actor?.process?.device?.name?
+$event.cim.src_type = $event.ocsf.src_endpoint?.type? else $event.ocsf.actor?.process?.device?.type?
+$event.cim.dest = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.ip? else $event.ocsf.dst_endpoint?.name? else
+           $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name? else
+           $event.ocsf.resource?.name? else $event.ocsf.resources?[0]?.name? else $event.ocsf.resources?[0]?.hostname? else $event.ocsf.resources?[0]?.ip?
+$event.cim.dest_type = $event.ocsf.dst_endpoint?.type? else $event.ocsf.device?.type?
 
 // --- CIM: user and cloud attributes -----------
 
-cim.user = actor?.user?.name? else actor?.user?.uid? else user?.name? else user?.uid?
-cim.user_name = actor?.user?.name? else user?.name?
-cim.vendor_account = cloud?.account?.uid?
-cim.vendor_region = cloud?.region?
+$event.cim.user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid? else $event.ocsf.user?.name? else $event.ocsf.user?.uid?
+$event.cim.user_name = $event.ocsf.actor?.user?.name? else $event.ocsf.user?.name?
+$event.cim.vendor_account = $event.ocsf.cloud?.account?.uid?
+$event.cim.vendor_region = $event.ocsf.cloud?.region?
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/api_activity.tql
+++ b/splunk/operators/cim/ocsf/api_activity.tql
@@ -1,49 +1,54 @@
 ---
 description: OCSF API Activity (6003) → Splunk CIM Data Access
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 6003
+assert $event.ocsf.class_uid == 6003
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["data", "access"]
+$event.cim.tag = ["data", "access"]
 
 // --- CIM: occurrence and action attributes ----
 
-cim._time = time
-cim.action = activity_name?.to_lower().replace(" ", "_") else "unknown"
-cim.app = actor?.app_name? else api?.service?.name? else api?.name? else metadata.product.name?
+$event.cim._time = $event.ocsf.time
+$event.cim.action = $event.ocsf.activity_name?.to_lower().replace(" ", "_") else "unknown"
+$event.cim.app = $event.ocsf.actor?.app_name? else $event.ocsf.api?.service?.name? else $event.ocsf.api?.name? else $event.ocsf.metadata.product.name?
 
 // --- CIM: object attributes -------------------
 
-cim.object = api?.operation? else api?.name? else resources?[0]?.name?
-cim.object_id = api?.uid? else resources?[0]?.uid?
-cim.object_category = "api"
-cim.object_path = http_request?.url?.path? else resources?[0]?.path?
-cim.signature = type_name? else class_name?
-cim.signature_id = metadata.event_code? else type_uid?.string()
+$event.cim.object = $event.ocsf.api?.operation? else $event.ocsf.api?.name? else $event.ocsf.resources?[0]?.name?
+$event.cim.object_id = $event.ocsf.api?.uid? else $event.ocsf.resources?[0]?.uid?
+$event.cim.object_category = "api"
+$event.cim.object_path = $event.ocsf.http_request?.url?.path? else $event.ocsf.resources?[0]?.path?
+$event.cim.signature = $event.ocsf.type_name? else $event.ocsf.class_name?
+$event.cim.signature_id = $event.ocsf.metadata.event_code? else $event.ocsf.type_uid?.string()
 
 // --- CIM: endpoint attributes -----------------
 
-cim.src = src_endpoint?.hostname? else src_endpoint?.ip? else src_endpoint?.name?
-cim.dest = dst_endpoint?.hostname? else dst_endpoint?.ip? else dst_endpoint?.name?
-cim.dest_url = http_request?.url?.url_string?
-cim.dvc = device?.hostname? else device?.ip? else device?.name?
+$event.cim.src = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.ip? else $event.ocsf.src_endpoint?.name?
+$event.cim.dest = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.ip? else $event.ocsf.dst_endpoint?.name?
+$event.cim.dest_url = $event.ocsf.http_request?.url?.url_string?
+$event.cim.dvc = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
 
 // --- CIM: user and request attributes ---------
 
-cim.user = actor?.user?.name? else actor?.user?.uid?
-cim.user_id = actor?.user?.uid?
-cim.user_name = actor?.user?.name?
-cim.user_role = actor?.user?.type?
-cim.user_type = actor?.user?.type?
-cim.user_agent = http_request?.user_agent?
-cim.vendor_account = cloud?.account?.uid?
-cim.vendor_region = cloud?.region?
-splunk::cim::ocsf::helpers::product
+$event.cim.user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+$event.cim.user_id = $event.ocsf.actor?.user?.uid?
+$event.cim.user_name = $event.ocsf.actor?.user?.name?
+$event.cim.user_role = $event.ocsf.actor?.user?.type?
+$event.cim.user_type = $event.ocsf.actor?.user?.type?
+$event.cim.user_agent = $event.ocsf.http_request?.user_agent?
+$event.cim.vendor_account = $event.ocsf.cloud?.account?.uid?
+$event.cim.vendor_region = $event.ocsf.cloud?.region?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/authentication.tql
+++ b/splunk/operators/cim/ocsf/authentication.tql
@@ -1,72 +1,77 @@
 ---
 description: OCSF Authentication (3002) → Splunk CIM Authentication
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 3002
+assert $event.ocsf.class_uid == 3002
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["authentication"]
+$event.cim.tag = ["authentication"]
 
 // --- CIM: occurrence attributes ---------------
 
-cim._time = time
-if duration? != null {
-  cim.duration = duration.milliseconds().count_seconds()
+$event.cim._time = $event.ocsf.time
+if $event.ocsf.duration? != null {
+  $event.cim.duration = $event.ocsf.duration.milliseconds().count_seconds()
 }
 
 // --- CIM: result attributes -------------------
 
-cim.action = status?.to_lower() else "unknown"
-match status_id? {
+$event.cim.action = $event.ocsf.status?.to_lower() else "unknown"
+match $event.ocsf.status_id? {
   0 => {
-    cim.action = "unknown"
+    $event.cim.action = "unknown"
   }
   1 => {
-    cim.action = "success"
+    $event.cim.action = "success"
   }
   2 => {
-    cim.action = "failure"
+    $event.cim.action = "failure"
   }
   _ => {}
 }
-cim.result = cim.action
-cim.reason = status_detail? else message?
-cim.reason_id = status_code?
+$event.cim.result = $event.cim.action
+$event.cim.reason = $event.ocsf.status_detail? else $event.ocsf.message?
+$event.cim.reason_id = $event.ocsf.status_code?
 
 // --- CIM: authentication attributes -----------
 
-cim.app = actor?.app_name? else service?.name? else metadata.product.name?
-cim.authentication_method = auth_protocol? else auth_protocol_id?.string()
-cim.authentication_service = service?.name? else service?.uid?
-cim.session_id = session?.uid? else actor?.session?.uid?
-cim.signature = type_name? else class_name?
-cim.signature_id = metadata.event_code? else type_uid?.string()
+$event.cim.app = $event.ocsf.actor?.app_name? else $event.ocsf.service?.name? else $event.ocsf.metadata.product.name?
+$event.cim.authentication_method = $event.ocsf.auth_protocol? else $event.ocsf.auth_protocol_id?.string()
+$event.cim.authentication_service = $event.ocsf.service?.name? else $event.ocsf.service?.uid?
+$event.cim.session_id = $event.ocsf.session?.uid? else $event.ocsf.actor?.session?.uid?
+$event.cim.signature = $event.ocsf.type_name? else $event.ocsf.class_name?
+$event.cim.signature_id = $event.ocsf.metadata.event_code? else $event.ocsf.type_uid?.string()
 
 // --- CIM: endpoint attributes -----------------
 
-cim.src = src_endpoint?.hostname? else src_endpoint?.ip? else src_endpoint?.name?
-cim.dest = dst_endpoint?.hostname? else dst_endpoint?.ip? else dst_endpoint?.name?
+$event.cim.src = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.ip? else $event.ocsf.src_endpoint?.name?
+$event.cim.dest = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.ip? else $event.ocsf.dst_endpoint?.name?
 
 // --- CIM: user and process attributes ---------
 
-cim.user = user?.name? else user?.uid?
-cim.user_id = user?.uid?
-cim.user_role = user?.type?
-cim.user_type = user?.type?
-cim.src_user = actor?.user?.name? else actor?.user?.uid?
-cim.src_user_id = actor?.user?.uid?
-cim.src_user_role = actor?.user?.type?
-cim.src_user_type = actor?.user?.type?
-cim.process = actor?.process?.cmd_line? else actor?.process?.path? else actor?.process?.name?
-cim.user_agent = http_request?.user_agent?
+$event.cim.user = $event.ocsf.user?.name? else $event.ocsf.user?.uid?
+$event.cim.user_id = $event.ocsf.user?.uid?
+$event.cim.user_role = $event.ocsf.user?.type?
+$event.cim.user_type = $event.ocsf.user?.type?
+$event.cim.src_user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+$event.cim.src_user_id = $event.ocsf.actor?.user?.uid?
+$event.cim.src_user_role = $event.ocsf.actor?.user?.type?
+$event.cim.src_user_type = $event.ocsf.actor?.user?.type?
+$event.cim.process = $event.ocsf.actor?.process?.cmd_line? else $event.ocsf.actor?.process?.path? else $event.ocsf.actor?.process?.name?
+$event.cim.user_agent = $event.ocsf.http_request?.user_agent?
 
 // --- CIM: cloud attributes --------------------
 
-cim.vendor_account = cloud?.account?.uid?
+$event.cim.vendor_account = $event.ocsf.cloud?.account?.uid?
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/datastore_activity.tql
+++ b/splunk/operators/cim/ocsf/datastore_activity.tql
@@ -1,43 +1,48 @@
 ---
 description: OCSF Datastore Activity (6005) → Splunk CIM Databases Database Query
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 6005
+assert $event.ocsf.class_uid == 6005
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["database"]
+$event.cim.tag = ["database"]
 
 // --- CIM: occurrence attributes ---------------
 
-cim._time = time
-if duration? != null {
-  cim.duration = duration.milliseconds().count_seconds()
+$event.cim._time = $event.ocsf.time
+if $event.ocsf.duration? != null {
+  $event.cim.duration = $event.ocsf.duration.milliseconds().count_seconds()
 }
 
 // --- CIM: database query attributes -----------
 
-cim.object = table?.name? else database?.name? else databucket?.name?
-cim.query = query_info?.query_string? else query_info?.query?
-cim.query_id = query_info?.uid?
-cim.query_time = query_info?.query_time?
-cim.records_affected = query_info?.record_count?
-if query_info?.duration? != null {
-  cim.response_time = query_info.duration.milliseconds().count_seconds()
+$event.cim.object = $event.ocsf.table?.name? else $event.ocsf.database?.name? else $event.ocsf.databucket?.name?
+$event.cim.query = $event.ocsf.query_info?.query_string? else $event.ocsf.query_info?.query?
+$event.cim.query_id = $event.ocsf.query_info?.uid?
+$event.cim.query_time = $event.ocsf.query_info?.query_time?
+$event.cim.records_affected = $event.ocsf.query_info?.record_count?
+if $event.ocsf.query_info?.duration? != null {
+  $event.cim.response_time = $event.ocsf.query_info.duration.milliseconds().count_seconds()
 }
 
 // --- CIM: endpoint attributes -----------------
 
-cim.src = src_endpoint?.hostname? else src_endpoint?.ip? else src_endpoint?.name?
-cim.dest = dst_endpoint?.hostname? else dst_endpoint?.ip? else dst_endpoint?.name? else database?.name?
+$event.cim.src = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.ip? else $event.ocsf.src_endpoint?.name?
+$event.cim.dest = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.ip? else $event.ocsf.dst_endpoint?.name? else $event.ocsf.database?.name?
 
 // --- CIM: user and product attributes ---------
 
-cim.user = actor?.user?.name? else actor?.user?.uid?
-splunk::cim::ocsf::helpers::product
+$event.cim.user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/dns_activity.tql
+++ b/splunk/operators/cim/ocsf/dns_activity.tql
@@ -1,168 +1,173 @@
 ---
 description: OCSF DNS Activity (4003) → Splunk CIM Network Resolution DNS
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 4003
+assert $event.ocsf.class_uid == 4003
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["network", "resolution", "dns"]
+$event.cim.tag = ["network", "resolution", "dns"]
 
 // --- CIM: occurrence attributes ---------------
 
-cim._time = time
-if duration? != null {
-  cim.duration = duration.milliseconds().count_seconds()
+$event.cim._time = $event.ocsf.time
+if $event.ocsf.duration? != null {
+  $event.cim.duration = $event.ocsf.duration.milliseconds().count_seconds()
 }
-cim.name = type_name? else class_name? else "DNS Activity"
+$event.cim.name = $event.ocsf.type_name? else $event.ocsf.class_name? else "DNS Activity"
 
-if query_time? != null and response_time? != null {
-  cim.response_time = (response_time - query_time).count_seconds()
+if $event.ocsf.query_time? != null and $event.ocsf.response_time? != null {
+  $event.cim.response_time = ($event.ocsf.response_time - $event.ocsf.query_time).count_seconds()
 }
 
 // --- CIM: primary DNS attributes --------------
 
-cim.query = query?.hostname?
-cim.query_count = 1 if query? != null else 0
-cim.query_type = query?.opcode?
-match query?.opcode_id? {
+$event.cim.query = $event.ocsf.query?.hostname?
+$event.cim.query_count = 1 if $event.ocsf.query? != null else 0
+$event.cim.query_type = $event.ocsf.query?.opcode?
+match $event.ocsf.query?.opcode_id? {
   0 => {
-    cim.query_type = "Query"
+    $event.cim.query_type = "Query"
   }
   1 => {
-    cim.query_type = "IQuery"
+    $event.cim.query_type = "IQuery"
   }
   2 => {
-    cim.query_type = "Status"
+    $event.cim.query_type = "Status"
   }
   4 => {
-    cim.query_type = "Notify"
+    $event.cim.query_type = "Notify"
   }
   5 => {
-    cim.query_type = "Update"
+    $event.cim.query_type = "Update"
   }
   _ => {}
 }
-cim.record_type = query?.type?
-cim.transaction_id = query?.packet_uid? else answers?[0]?.packet_uid?
+$event.cim.record_type = $event.ocsf.query?.type?
+$event.cim.transaction_id = $event.ocsf.query?.packet_uid? else $event.ocsf.answers?[0]?.packet_uid?
 
-cim.answer = [...answers?.map(a => a.rdata)]
-cim.answer_count = cim.answer.length()
-cim.ttl = [...answers?.map(a => a.ttl?)]
+$event.cim.answer = [...$event.ocsf.answers?.map(a => a.rdata)]
+$event.cim.answer_count = $event.cim.answer.length()
+$event.cim.ttl = [...$event.ocsf.answers?.map(a => a.ttl?)]
 
-cim.reply_code_id = rcode_id?
-cim.reply_code = rcode?
-match rcode_id? {
+$event.cim.reply_code_id = $event.ocsf.rcode_id?
+$event.cim.reply_code = $event.ocsf.rcode?
+match $event.ocsf.rcode_id? {
   0 => {
-    cim.reply_code = "No Error"
+    $event.cim.reply_code = "No Error"
   }
   1 => {
-    cim.reply_code = "Format Error"
+    $event.cim.reply_code = "Format Error"
   }
   2 => {
-    cim.reply_code = "Server Failure"
+    $event.cim.reply_code = "Server Failure"
   }
   3 => {
-    cim.reply_code = "Non-Existent Domain"
+    $event.cim.reply_code = "Non-Existent Domain"
   }
   4 => {
-    cim.reply_code = "Not Implemented"
+    $event.cim.reply_code = "Not Implemented"
   }
   5 => {
-    cim.reply_code = "Query Refused"
+    $event.cim.reply_code = "Query Refused"
   }
   6 => {
-    cim.reply_code = "Name Exists when it should not"
+    $event.cim.reply_code = "Name Exists when it should not"
   }
   7 => {
-    cim.reply_code = "RR Set Exists when it should not"
+    $event.cim.reply_code = "RR Set Exists when it should not"
   }
   8 => {
-    cim.reply_code = "RR Set that should exist does not"
+    $event.cim.reply_code = "RR Set that should exist does not"
   }
   9 => {
-    cim.reply_code = "Server Not Authoritative for zone"
+    $event.cim.reply_code = "Server Not Authoritative for zone"
   }
   10 => {
-    cim.reply_code = "Name not contained in zone"
+    $event.cim.reply_code = "Name not contained in zone"
   }
   11 => {
-    cim.reply_code = "DSO-TYPE Not Implemented"
+    $event.cim.reply_code = "DSO-TYPE Not Implemented"
   }
   16 => {
-    cim.reply_code = rcode? else "TSIG Signature Failure or Bad OPT Version"
+    $event.cim.reply_code = $event.ocsf.rcode? else "TSIG Signature Failure or Bad OPT Version"
   }
   17 => {
-    cim.reply_code = "Key not recognized"
+    $event.cim.reply_code = "Key not recognized"
   }
   18 => {
-    cim.reply_code = "Signature out of time window"
+    $event.cim.reply_code = "Signature out of time window"
   }
   19 => {
-    cim.reply_code = "Bad TKEY Mode"
+    $event.cim.reply_code = "Bad TKEY Mode"
   }
   20 => {
-    cim.reply_code = "Duplicate key name"
+    $event.cim.reply_code = "Duplicate key name"
   }
   21 => {
-    cim.reply_code = "Algorithm not supported"
+    $event.cim.reply_code = "Algorithm not supported"
   }
   22 => {
-    cim.reply_code = "Bad Truncation"
+    $event.cim.reply_code = "Bad Truncation"
   }
   23 => {
-    cim.reply_code = "Bad/missing Server Cookie"
+    $event.cim.reply_code = "Bad/missing Server Cookie"
   }
   24 => {
-    cim.reply_code = "Unassigned"
+    $event.cim.reply_code = "Unassigned"
   }
   25 => {
-    cim.reply_code = "Reserved"
+    $event.cim.reply_code = "Reserved"
   }
   _ => {}
 }
 
-match activity_id {
+match $event.ocsf.activity_id {
   1 => {
-    cim.message_type = "Query"
+    $event.cim.message_type = "Query"
   }
   2 => {
-    cim.message_type = "Response"
+    $event.cim.message_type = "Response"
   }
   _ => {
-    cim.message_type = activity_name? else "unknown"
+    $event.cim.message_type = $event.ocsf.activity_name? else "unknown"
   }
 }
 
 // --- CIM: endpoint attributes -----------------
 
-cim.src = src_endpoint?.hostname? else src_endpoint?.ip? else src_endpoint?.name?
-cim.src_ip = src_endpoint?.ip?
-cim.src_port = src_endpoint?.port?
+$event.cim.src = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.ip? else $event.ocsf.src_endpoint?.name?
+$event.cim.src_ip = $event.ocsf.src_endpoint?.ip?
+$event.cim.src_port = $event.ocsf.src_endpoint?.port?
 
-cim.dest = dst_endpoint?.hostname? else dst_endpoint?.ip? else dst_endpoint?.name?
-cim.dest_ip = dst_endpoint?.ip?
-cim.dest_port = dst_endpoint?.port?
+$event.cim.dest = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.ip? else $event.ocsf.dst_endpoint?.name?
+$event.cim.dest_ip = $event.ocsf.dst_endpoint?.ip?
+$event.cim.dest_port = $event.ocsf.dst_endpoint?.port?
 
 // --- CIM: product attributes ------------------
 
-splunk::cim::ocsf::helpers::product
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- CIM: network attributes ------------------
 
-cim.transport = connection_info?.protocol_name?
-if cim.transport == null {
-  match connection_info?.protocol_num? {
+$event.cim.transport = $event.ocsf.connection_info?.protocol_name?
+if $event.cim.transport == null {
+  match $event.ocsf.connection_info?.protocol_num? {
     1 => {
-      cim.transport = "icmp"
+      $event.cim.transport = "icmp"
     }
     6 => {
-      cim.transport = "tcp"
+      $event.cim.transport = "tcp"
     }
     17 => {
-      cim.transport = "udp"
+      $event.cim.transport = "udp"
     }
     _ => {}
   }
@@ -170,4 +175,4 @@ if cim.transport == null {
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/email_activity.tql
+++ b/splunk/operators/cim/ocsf/email_activity.tql
@@ -1,56 +1,61 @@
 ---
 description: OCSF Email Activity (4009) → Splunk CIM Email
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 4009
+assert $event.ocsf.class_uid == 4009
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["email"]
+$event.cim.tag = ["email"]
 
 // --- CIM: occurrence and action attributes ----
 
-cim._time = time
-if duration? != null {
-  cim.duration = duration.milliseconds().count_seconds()
+$event.cim._time = $event.ocsf.time
+if $event.ocsf.duration? != null {
+  $event.cim.duration = $event.ocsf.duration.milliseconds().count_seconds()
 }
-splunk::cim::ocsf::helpers::action
+splunk::cim::ocsf::helpers::action event=$event
 
 // --- CIM: email attributes --------------------
 
-cim.delay = email?.delay?
-cim.internal_message_id = message_trace_uid?
-cim.message_id = email?.message_uid? else email?.uid?
-cim.message_info = message?
-cim.protocol = protocol_name?.to_lower()
-cim.recipient = email?.to? else to?
-cim.recipient_count = cim.recipient.length() if cim.recipient != null else 0
-cim.return_addr = email?.return_path?
-cim.size = email?.size?
-cim.status_code = status_code?
-cim.subject = email?.subject?
-cim.url = [...email?.urls?.map(u => u.url_string)]
-cim.xref = email?.uid?
+$event.cim.delay = $event.ocsf.email?.delay?
+$event.cim.internal_message_id = $event.ocsf.message_trace_uid?
+$event.cim.message_id = $event.ocsf.email?.message_uid? else $event.ocsf.email?.uid?
+$event.cim.message_info = $event.ocsf.message?
+$event.cim.protocol = $event.ocsf.protocol_name?.to_lower()
+$event.cim.recipient = $event.ocsf.email?.to? else $event.ocsf.to?
+$event.cim.recipient_count = $event.cim.recipient.length() if $event.cim.recipient != null else 0
+$event.cim.return_addr = $event.ocsf.email?.return_path?
+$event.cim.size = $event.ocsf.email?.size?
+$event.cim.status_code = $event.ocsf.status_code?
+$event.cim.subject = $event.ocsf.email?.subject?
+$event.cim.url = [...$event.ocsf.email?.urls?.map(u => u.url_string)]
+$event.cim.xref = $event.ocsf.email?.uid?
 
 // --- CIM: attachment attributes ---------------
 
-cim.file_hash = [...email?.files?.map(f => f.hashes?.map(h => h.value))]
-cim.file_name = [...email?.files?.map(f => f.name)]
-cim.file_size = [...email?.files?.map(f => f.size)]
+$event.cim.file_hash = [...$event.ocsf.email?.files?.map(f => f.hashes?.map(h => h.value))]
+$event.cim.file_name = [...$event.ocsf.email?.files?.map(f => f.name)]
+$event.cim.file_size = [...$event.ocsf.email?.files?.map(f => f.size)]
 
 // --- CIM: endpoint attributes -----------------
 
-cim.src = src_endpoint?.hostname? else src_endpoint?.ip? else src_endpoint?.name?
-cim.dest = dst_endpoint?.hostname? else dst_endpoint?.ip? else dst_endpoint?.name?
+$event.cim.src = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.ip? else $event.ocsf.src_endpoint?.name?
+$event.cim.dest = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.ip? else $event.ocsf.dst_endpoint?.name?
 
 // --- CIM: sender and user attributes ----------
 
-cim.src_user = from? else email?.smtp_from? else email?.from? else email?.sender?
-cim.user = actor?.user?.name? else actor?.user?.uid?
-splunk::cim::ocsf::helpers::product
+$event.cim.src_user = $event.ocsf.from? else $event.ocsf.email?.smtp_from? else $event.ocsf.email?.from? else $event.ocsf.email?.sender?
+$event.cim.user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/entity_management.tql
+++ b/splunk/operators/cim/ocsf/entity_management.tql
@@ -1,54 +1,59 @@
 ---
 description: OCSF Entity Management (3004) → Splunk CIM Change
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 3004
+assert $event.ocsf.class_uid == 3004
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["change"]
+$event.cim.tag = ["change"]
 
 // --- CIM: occurrence and action attributes ----
 
-cim._time = time
-cim.action = activity_name?.to_lower().replace(" ", "_") else "unknown"
-cim.change_type = "management"
-cim.command = comment?
-cim.status = status?.to_lower()
-match status_id? {
+$event.cim._time = $event.ocsf.time
+$event.cim.action = $event.ocsf.activity_name?.to_lower().replace(" ", "_") else "unknown"
+$event.cim.change_type = "management"
+$event.cim.command = $event.ocsf.comment?
+$event.cim.status = $event.ocsf.status?.to_lower()
+match $event.ocsf.status_id? {
   1 => {
-    cim.status = "success"
+    $event.cim.status = "success"
   }
   2 => {
-    cim.status = "failure"
+    $event.cim.status = "failure"
   }
   _ => {}
 }
-cim.result = status_detail? else status?
-cim.result_id = status_code? else status_id?.string()
+$event.cim.result = $event.ocsf.status_detail? else $event.ocsf.status?
+$event.cim.result_id = $event.ocsf.status_code? else $event.ocsf.status_id?.string()
 
 // --- CIM: object attributes -------------------
 
-cim.object = entity_result?.name? else entity?.name? else entity_result?.uid? else entity?.uid?
-cim.object_id = entity_result?.uid? else entity?.uid?
-cim.object_category = entity_result?.type? else entity?.type? else class_name?
-cim.object_attrs = [...entity_result?.changes?.map(c => c.name)]
+$event.cim.object = $event.ocsf.entity_result?.name? else $event.ocsf.entity?.name? else $event.ocsf.entity_result?.uid? else $event.ocsf.entity?.uid?
+$event.cim.object_id = $event.ocsf.entity_result?.uid? else $event.ocsf.entity?.uid?
+$event.cim.object_category = $event.ocsf.entity_result?.type? else $event.ocsf.entity?.type? else $event.ocsf.class_name?
+$event.cim.object_attrs = [...$event.ocsf.entity_result?.changes?.map(c => c.name)]
 
 // --- CIM: endpoint and user attributes --------
 
-cim.src = actor?.process?.device?.hostname? else actor?.process?.device?.ip? else actor?.process?.device?.name?
-cim.dest = device?.hostname? else device?.ip? else device?.name?
-cim.dvc = device?.hostname? else device?.ip? else device?.name?
-cim.user = actor?.user?.name? else actor?.user?.uid?
-cim.user_name = actor?.user?.name?
-cim.user_type = actor?.user?.type?
-cim.user_agent = http_request?.user_agent?
-cim.vendor_account = cloud?.account?.uid?
-cim.vendor_region = cloud?.region?
-splunk::cim::ocsf::helpers::product
+$event.cim.src = $event.ocsf.actor?.process?.device?.hostname? else $event.ocsf.actor?.process?.device?.ip? else $event.ocsf.actor?.process?.device?.name?
+$event.cim.dest = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
+$event.cim.dvc = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
+$event.cim.user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+$event.cim.user_name = $event.ocsf.actor?.user?.name?
+$event.cim.user_type = $event.ocsf.actor?.user?.type?
+$event.cim.user_agent = $event.ocsf.http_request?.user_agent?
+$event.cim.vendor_account = $event.ocsf.cloud?.account?.uid?
+$event.cim.vendor_region = $event.ocsf.cloud?.region?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/event_log_activity.tql
+++ b/splunk/operators/cim/ocsf/event_log_activity.tql
@@ -1,51 +1,56 @@
 ---
 description: OCSF Event Log Activity (1008) → Splunk CIM Change Auditing Changes
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 1008
+assert $event.ocsf.class_uid == 1008
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["change", "audit"]
+$event.cim.tag = ["change", "audit"]
 
 // --- CIM: occurrence and action attributes ----
 
-cim._time = time
-cim.action = activity_name?.to_lower().replace(" ", "_") else "unknown"
-cim.change_type = "audit"
-cim.command = log_provider?
-cim.status = status?.to_lower()
-match status_id? {
+$event.cim._time = $event.ocsf.time
+$event.cim.action = $event.ocsf.activity_name?.to_lower().replace(" ", "_") else "unknown"
+$event.cim.change_type = "audit"
+$event.cim.command = $event.ocsf.log_provider?
+$event.cim.status = $event.ocsf.status?.to_lower()
+match $event.ocsf.status_id? {
   1 => {
-    cim.status = "success"
+    $event.cim.status = "success"
   }
   2 => {
-    cim.status = "failure"
+    $event.cim.status = "failure"
   }
   _ => {}
 }
-cim.result = status_detail? else status?
-cim.result_id = status_code? else status_id?.string()
+$event.cim.result = $event.ocsf.status_detail? else $event.ocsf.status?
+$event.cim.result_id = $event.ocsf.status_code? else $event.ocsf.status_id?.string()
 
 // --- CIM: object attributes -------------------
 
-cim.object = log_name? else file?.name?
-cim.object_id = file?.uid?
-cim.object_category = log_type? else log_type_id?.string() else "event_log"
-cim.object_path = file?.path?
+$event.cim.object = $event.ocsf.log_name? else $event.ocsf.file?.name?
+$event.cim.object_id = $event.ocsf.file?.uid?
+$event.cim.object_category = $event.ocsf.log_type? else $event.ocsf.log_type_id?.string() else "event_log"
+$event.cim.object_path = $event.ocsf.file?.path?
 
 // --- CIM: endpoint and user attributes --------
 
-cim.src = src_endpoint?.hostname? else src_endpoint?.ip? else src_endpoint?.name?
-cim.dest = dst_endpoint?.hostname? else dst_endpoint?.ip? else dst_endpoint?.name?
-cim.dvc = device?.hostname? else device?.ip? else device?.name?
-cim.user = actor?.user?.name? else actor?.user?.uid?
-cim.user_name = actor?.user?.name?
-cim.user_type = actor?.user?.type?
-splunk::cim::ocsf::helpers::product
+$event.cim.src = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.ip? else $event.ocsf.src_endpoint?.name?
+$event.cim.dest = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.ip? else $event.ocsf.dst_endpoint?.name?
+$event.cim.dvc = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
+$event.cim.user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+$event.cim.user_name = $event.ocsf.actor?.user?.name?
+$event.cim.user_type = $event.ocsf.actor?.user?.type?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/file_activity.tql
+++ b/splunk/operators/cim/ocsf/file_activity.tql
@@ -1,59 +1,64 @@
 ---
 description: OCSF File System Activity (1001) → Splunk CIM Endpoint Filesystem
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 1001
+assert $event.ocsf.class_uid == 1001
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["endpoint", "filesystem"]
+$event.cim.tag = ["endpoint", "filesystem"]
 
 // --- CIM: occurrence and action attributes ----
 
-cim._time = time
-cim.action = activity_name?.to_lower().replace(" ", "_") else "unknown"
+$event.cim._time = $event.ocsf.time
+$event.cim.action = $event.ocsf.activity_name?.to_lower().replace(" ", "_") else "unknown"
 
 // --- CIM: endpoint attributes -----------------
 
-cim.dest = device?.hostname? else device?.ip? else device?.name?
+$event.cim.dest = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
 
 // --- CIM: file attributes ---------------------
 
-cim.file_access_time = file?.accessed_time?
-cim.file_acl = file?.security_descriptor?
-cim.file_create_time = file?.created_time?
-cim.file_hash = [...file?.hashes?.map(h => h.value)]
-cim.file_modify_time = file?.modified_time?
-cim.file_name = file?.name?
-cim.file_path = file?.path?
-if file?.size? != null {
-  cim.file_size = file.size / 1024
+$event.cim.file_access_time = $event.ocsf.file?.accessed_time?
+$event.cim.file_acl = $event.ocsf.file?.security_descriptor?
+$event.cim.file_create_time = $event.ocsf.file?.created_time?
+$event.cim.file_hash = [...$event.ocsf.file?.hashes?.map(h => h.value)]
+$event.cim.file_modify_time = $event.ocsf.file?.modified_time?
+$event.cim.file_name = $event.ocsf.file?.name?
+$event.cim.file_path = $event.ocsf.file?.path?
+if $event.ocsf.file?.size? != null {
+  $event.cim.file_size = $event.ocsf.file.size / 1024
 }
 
 // --- CIM: process attributes ------------------
 
-cim.process = actor?.process?.cmd_line? else actor?.process?.path? else actor?.process?.name?
-cim.process_exec = actor?.process?.file?.name? else actor?.process?.name?
-cim.process_guid = actor?.process?.uid?
-cim.process_hash = [...actor?.process?.file?.hashes?.map(h => h.value)]
-cim.process_id = actor?.process?.pid?
-cim.process_name = actor?.process?.name? else actor?.process?.file?.name?
-cim.process_path = actor?.process?.path? else actor?.process?.file?.path?
-cim.parent_process = actor?.process?.parent_process?.cmd_line?
-cim.parent_process_exec = actor?.process?.parent_process?.file?.name? else actor?.process?.parent_process?.name?
-cim.parent_process_guid = actor?.process?.parent_process?.uid?
-cim.parent_process_hash = [...actor?.process?.parent_process?.file?.hashes?.map(h => h.value)]
-cim.parent_process_id = actor?.process?.parent_process?.pid?
-cim.parent_process_name = actor?.process?.parent_process?.name? else actor?.process?.parent_process?.file?.name?
-cim.parent_process_path = actor?.process?.parent_process?.path? else actor?.process?.parent_process?.file?.path?
+$event.cim.process = $event.ocsf.actor?.process?.cmd_line? else $event.ocsf.actor?.process?.path? else $event.ocsf.actor?.process?.name?
+$event.cim.process_exec = $event.ocsf.actor?.process?.file?.name? else $event.ocsf.actor?.process?.name?
+$event.cim.process_guid = $event.ocsf.actor?.process?.uid?
+$event.cim.process_hash = [...$event.ocsf.actor?.process?.file?.hashes?.map(h => h.value)]
+$event.cim.process_id = $event.ocsf.actor?.process?.pid?
+$event.cim.process_name = $event.ocsf.actor?.process?.name? else $event.ocsf.actor?.process?.file?.name?
+$event.cim.process_path = $event.ocsf.actor?.process?.path? else $event.ocsf.actor?.process?.file?.path?
+$event.cim.parent_process = $event.ocsf.actor?.process?.parent_process?.cmd_line?
+$event.cim.parent_process_exec = $event.ocsf.actor?.process?.parent_process?.file?.name? else $event.ocsf.actor?.process?.parent_process?.name?
+$event.cim.parent_process_guid = $event.ocsf.actor?.process?.parent_process?.uid?
+$event.cim.parent_process_hash = [...$event.ocsf.actor?.process?.parent_process?.file?.hashes?.map(h => h.value)]
+$event.cim.parent_process_id = $event.ocsf.actor?.process?.parent_process?.pid?
+$event.cim.parent_process_name = $event.ocsf.actor?.process?.parent_process?.name? else $event.ocsf.actor?.process?.parent_process?.file?.name?
+$event.cim.parent_process_path = $event.ocsf.actor?.process?.parent_process?.path? else $event.ocsf.actor?.process?.parent_process?.file?.path?
 
 // --- CIM: user and product attributes ---------
 
-cim.user = actor?.user?.name? else actor?.user?.uid?
-splunk::cim::ocsf::helpers::product
+$event.cim.user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/file_hosting.tql
+++ b/splunk/operators/cim/ocsf/file_hosting.tql
@@ -1,52 +1,57 @@
 ---
 description: OCSF File Hosting Activity (6006) → Splunk CIM Data Access
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 6006
+assert $event.ocsf.class_uid == 6006
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["data", "access"]
+$event.cim.tag = ["data", "access"]
 
 // --- CIM: occurrence and action attributes ----
 
-cim._time = time
-cim.action = activity_name?.to_lower().replace(" ", "_") else "unknown"
-cim.app = actor?.app_name? else metadata.product.name?
+$event.cim._time = $event.ocsf.time
+$event.cim.action = $event.ocsf.activity_name?.to_lower().replace(" ", "_") else "unknown"
+$event.cim.app = $event.ocsf.actor?.app_name? else $event.ocsf.metadata.product.name?
 
 // --- CIM: object attributes -------------------
 
-cim.object = file?.name?
-cim.object_id = file?.uid?
-cim.object_category = file?.type? else "file"
-cim.object_path = file?.path? else file?.uri?
-cim.object_size = file?.size?
-cim.parent_object = share?
-cim.parent_object_category = share_type?
-cim.signature = type_name? else class_name?
-cim.signature_id = metadata.event_code? else type_uid?.string()
+$event.cim.object = $event.ocsf.file?.name?
+$event.cim.object_id = $event.ocsf.file?.uid?
+$event.cim.object_category = $event.ocsf.file?.type? else "file"
+$event.cim.object_path = $event.ocsf.file?.path? else $event.ocsf.file?.uri?
+$event.cim.object_size = $event.ocsf.file?.size?
+$event.cim.parent_object = $event.ocsf.share?
+$event.cim.parent_object_category = $event.ocsf.share_type?
+$event.cim.signature = $event.ocsf.type_name? else $event.ocsf.class_name?
+$event.cim.signature_id = $event.ocsf.metadata.event_code? else $event.ocsf.type_uid?.string()
 
 // --- CIM: endpoint attributes -----------------
 
-cim.src = src_endpoint?.hostname? else src_endpoint?.ip? else src_endpoint?.name?
-cim.dest = dst_endpoint?.hostname? else dst_endpoint?.ip? else dst_endpoint?.name?
-cim.dest_url = http_request?.url?.url_string? else file?.url?.url_string?
-cim.dvc = device?.hostname? else device?.ip? else device?.name?
+$event.cim.src = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.ip? else $event.ocsf.src_endpoint?.name?
+$event.cim.dest = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.ip? else $event.ocsf.dst_endpoint?.name?
+$event.cim.dest_url = $event.ocsf.http_request?.url?.url_string? else $event.ocsf.file?.url?.url_string?
+$event.cim.dvc = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
 
 // --- CIM: user and request attributes ---------
 
-cim.user = actor?.user?.name? else actor?.user?.uid?
-cim.user_id = actor?.user?.uid?
-cim.user_name = actor?.user?.name?
-cim.user_role = actor?.user?.type?
-cim.user_type = actor?.user?.type?
-cim.user_agent = http_request?.user_agent?
-cim.vendor_account = cloud?.account?.uid?
-cim.vendor_region = cloud?.region?
-splunk::cim::ocsf::helpers::product
+$event.cim.user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+$event.cim.user_id = $event.ocsf.actor?.user?.uid?
+$event.cim.user_name = $event.ocsf.actor?.user?.name?
+$event.cim.user_role = $event.ocsf.actor?.user?.type?
+$event.cim.user_type = $event.ocsf.actor?.user?.type?
+$event.cim.user_agent = $event.ocsf.http_request?.user_agent?
+$event.cim.vendor_account = $event.ocsf.cloud?.account?.uid?
+$event.cim.vendor_region = $event.ocsf.cloud?.region?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/group_management.tql
+++ b/splunk/operators/cim/ocsf/group_management.tql
@@ -1,56 +1,61 @@
 ---
 description: OCSF Group Management (3006) → Splunk CIM Change Account Management
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 3006
+assert $event.ocsf.class_uid == 3006
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["change", "account"]
+$event.cim.tag = ["change", "account"]
 
 // --- CIM: occurrence and action attributes ----
 
-cim._time = time
-cim.action = activity_name?.to_lower().replace(" ", "_") else "unknown"
-cim.change_type = "AAA"
-cim.status = status?.to_lower()
-match status_id? {
+$event.cim._time = $event.ocsf.time
+$event.cim.action = $event.ocsf.activity_name?.to_lower().replace(" ", "_") else "unknown"
+$event.cim.change_type = "AAA"
+$event.cim.status = $event.ocsf.status?.to_lower()
+match $event.ocsf.status_id? {
   1 => {
-    cim.status = "success"
+    $event.cim.status = "success"
   }
   2 => {
-    cim.status = "failure"
+    $event.cim.status = "failure"
   }
   _ => {}
 }
-cim.result = status_detail? else status?
-cim.result_id = status_code? else status_id?.string()
+$event.cim.result = $event.ocsf.status_detail? else $event.ocsf.status?
+$event.cim.result_id = $event.ocsf.status_code? else $event.ocsf.status_id?.string()
 
 // --- CIM: object attributes -------------------
 
-cim.object = subgroup?.name? else group?.name? else user?.name? else group?.uid?
-cim.object_id = subgroup?.uid? else group?.uid? else user?.uid?
-cim.object_category = "group"
-cim.object_attrs = privileges?
+$event.cim.object = $event.ocsf.subgroup?.name? else $event.ocsf.group?.name? else $event.ocsf.user?.name? else $event.ocsf.group?.uid?
+$event.cim.object_id = $event.ocsf.subgroup?.uid? else $event.ocsf.group?.uid? else $event.ocsf.user?.uid?
+$event.cim.object_category = "group"
+$event.cim.object_attrs = $event.ocsf.privileges?
 
 // --- CIM: endpoint and user attributes --------
 
-cim.src = actor?.process?.device?.hostname? else actor?.process?.device?.ip? else actor?.process?.device?.name?
-cim.dest = device?.hostname? else device?.ip? else device?.name?
-cim.dvc = device?.hostname? else device?.ip? else device?.name?
-cim.user = user?.name? else user?.uid?
-cim.user_name = user?.name?
-cim.user_type = user?.type?
-cim.src_user = actor?.user?.name? else actor?.user?.uid?
-cim.src_user_name = actor?.user?.name?
-cim.src_user_type = actor?.user?.type?
-cim.user_agent = http_request?.user_agent?
-cim.vendor_account = cloud?.account?.uid?
-cim.vendor_region = cloud?.region?
-splunk::cim::ocsf::helpers::product
+$event.cim.src = $event.ocsf.actor?.process?.device?.hostname? else $event.ocsf.actor?.process?.device?.ip? else $event.ocsf.actor?.process?.device?.name?
+$event.cim.dest = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
+$event.cim.dvc = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
+$event.cim.user = $event.ocsf.user?.name? else $event.ocsf.user?.uid?
+$event.cim.user_name = $event.ocsf.user?.name?
+$event.cim.user_type = $event.ocsf.user?.type?
+$event.cim.src_user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+$event.cim.src_user_name = $event.ocsf.actor?.user?.name?
+$event.cim.src_user_type = $event.ocsf.actor?.user?.type?
+$event.cim.user_agent = $event.ocsf.http_request?.user_agent?
+$event.cim.vendor_account = $event.ocsf.cloud?.account?.uid?
+$event.cim.vendor_region = $event.ocsf.cloud?.region?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/helpers/action.tql
+++ b/splunk/operators/cim/ocsf/helpers/action.tql
@@ -1,62 +1,67 @@
 ---
 description: OCSF action/disposition/activity → Splunk CIM action
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim.action = action?.to_lower().replace(" ", "_") else
-             disposition?.to_lower().replace(" ", "_") else
-             activity_name?.to_lower().replace(" ", "_") else
+$event.cim.action = $event.ocsf.action?.to_lower().replace(" ", "_") else
+             $event.ocsf.disposition?.to_lower().replace(" ", "_") else
+             $event.ocsf.activity_name?.to_lower().replace(" ", "_") else
              "unknown"
 
-match action_id? {
+match $event.ocsf.action_id? {
   0 => {
-    cim.action = "unknown"
+    $event.cim.action = "unknown"
   }
   1 => {
-    cim.action = "allowed"
+    $event.cim.action = "allowed"
   }
   2 => {
-    cim.action = "blocked"
+    $event.cim.action = "blocked"
   }
   3 => {
-    cim.action = "observed"
+    $event.cim.action = "observed"
   }
   4 => {
-    cim.action = "modified"
+    $event.cim.action = "modified"
   }
   _ => {}
 }
 
-if action_id? == null {
-  match disposition_id? {
+if $event.ocsf.action_id? == null {
+  match $event.ocsf.disposition_id? {
     1 => {
-      cim.action = "allowed"
+      $event.cim.action = "allowed"
     }
     2 => {
-      cim.action = "blocked"
+      $event.cim.action = "blocked"
     }
     3 => {
-      cim.action = "quarantined"
+      $event.cim.action = "quarantined"
     }
     4 => {
-      cim.action = "isolated"
+      $event.cim.action = "isolated"
     }
     5 => {
-      cim.action = "deleted"
+      $event.cim.action = "deleted"
     }
     6 => {
-      cim.action = "dropped"
+      $event.cim.action = "dropped"
     }
     15 => {
-      cim.action = "detected"
+      $event.cim.action = "detected"
     }
     16 => {
-      cim.action = "no_action"
+      $event.cim.action = "no_action"
     }
     17 => {
-      cim.action = "logged"
+      $event.cim.action = "logged"
     }
     26 => {
-      cim.action = "blocked"
+      $event.cim.action = "blocked"
     }
     _ => {}
   }

--- a/splunk/operators/cim/ocsf/helpers/product.tql
+++ b/splunk/operators/cim/ocsf/helpers/product.tql
@@ -1,10 +1,15 @@
 ---
 description: OCSF product metadata → Splunk CIM vendor_product
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-product = metadata.product.name?
-vendor = metadata.product.vendor_name?
-cim.vendor_product = product
-if vendor != null {
-  cim.vendor_product = f"{vendor} {product}" if product != null else vendor
+$event.cim.vendor_product = $event.ocsf.metadata.product.name?
+if $event.ocsf.metadata.product.vendor_name? != null {
+  $event.cim.vendor_product = f"{$event.ocsf.metadata.product.vendor_name} {$event.ocsf.metadata.product.name}" if
+                              $event.ocsf.metadata.product.name? != null else
+                              $event.ocsf.metadata.product.vendor_name
 }

--- a/splunk/operators/cim/ocsf/helpers/severity.tql
+++ b/splunk/operators/cim/ocsf/helpers/severity.tql
@@ -1,30 +1,35 @@
 ---
 description: OCSF severity → Splunk CIM severity fields
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim.severity = severity?.to_lower()
-match severity_id? {
+$event.cim.severity = $event.ocsf.severity?.to_lower()
+match $event.ocsf.severity_id? {
   0 => {
-    cim.severity = "unknown"
+    $event.cim.severity = "unknown"
   }
   1 => {
-    cim.severity = "informational"
+    $event.cim.severity = "informational"
   }
   2 => {
-    cim.severity = "low"
+    $event.cim.severity = "low"
   }
   3 => {
-    cim.severity = "medium"
+    $event.cim.severity = "medium"
   }
   4 => {
-    cim.severity = "high"
+    $event.cim.severity = "high"
   }
   5 => {
-    cim.severity = "critical"
+    $event.cim.severity = "critical"
   }
   6 => {
-    cim.severity = "critical"
+    $event.cim.severity = "critical"
   }
   _ => {}
 }
-cim.severity_id = severity_id?.string()
+$event.cim.severity_id = $event.ocsf.severity_id?.string()

--- a/splunk/operators/cim/ocsf/helpers/transport.tql
+++ b/splunk/operators/cim/ocsf/helpers/transport.tql
@@ -1,18 +1,23 @@
 ---
 description: OCSF network protocol metadata → Splunk CIM transport fields
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim.transport = connection_info?.protocol_name?
-if cim.transport == null {
-  match connection_info?.protocol_num? {
+$event.cim.transport = $event.ocsf.connection_info?.protocol_name?
+if $event.cim.transport == null {
+  match $event.ocsf.connection_info?.protocol_num? {
     1 => {
-      cim.transport = "icmp"
+      $event.cim.transport = "icmp"
     }
     6 => {
-      cim.transport = "tcp"
+      $event.cim.transport = "tcp"
     }
     17 => {
-      cim.transport = "udp"
+      $event.cim.transport = "udp"
     }
     _ => {}
   }

--- a/splunk/operators/cim/ocsf/http_activity.tql
+++ b/splunk/operators/cim/ocsf/http_activity.tql
@@ -1,67 +1,72 @@
 ---
 description: OCSF HTTP Activity (4002) → Splunk CIM Web
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 4002
+assert $event.ocsf.class_uid == 4002
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["web"]
+$event.cim.tag = ["web"]
 
 // --- CIM: occurrence attributes ---------------
 
-cim._time = time
-cim.duration = duration?
-cim.response_time = http_response?.latency?
+$event.cim._time = $event.ocsf.time
+$event.cim.duration = $event.ocsf.duration?
+$event.cim.response_time = $event.ocsf.http_response?.latency?
 
 // --- CIM: action and application attributes ---
 
-splunk::cim::ocsf::helpers::action
-cim.app = app_name? else app_protocol_name? else metadata.product.name?
+splunk::cim::ocsf::helpers::action event=$event
+$event.cim.app = $event.ocsf.app_name? else $event.ocsf.app_protocol_name? else $event.ocsf.metadata.product.name?
 
 // --- CIM: traffic attributes ------------------
 
-cim.bytes = traffic?.bytes?
-cim.bytes_in = traffic?.bytes_in? else http_request?.length?
-cim.bytes_out = traffic?.bytes_out? else http_response?.length?
+$event.cim.bytes = $event.ocsf.traffic?.bytes?
+$event.cim.bytes_in = $event.ocsf.traffic?.bytes_in? else $event.ocsf.http_request?.length?
+$event.cim.bytes_out = $event.ocsf.traffic?.bytes_out? else $event.ocsf.http_response?.length?
 
 // --- CIM: HTTP attributes ---------------------
 
-cim.http_content_type = http_response?.content_type?
-cim.http_method = http_request?.http_method?
-cim.http_referrer = http_request?.referrer?
-cim.http_user_agent = http_request?.user_agent?
-cim.status = http_status?.string() else http_response?.code?.string() else status_code?
-cim.uri_path = http_request?.url?.path? else url?.path?
-cim.uri_query = http_request?.url?.query_string? else http_request?.args? else url?.query_string?
-cim.url = http_request?.url?.url_string? else url?.url_string? else file?.url?.url_string?
-cim.url_domain = http_request?.url?.domain? else http_request?.url?.hostname? else
-                 url?.domain? else url?.hostname?
-cim.category = http_request?.url?.categories? else url?.categories?
-if cim.url != null {
-  cim.url_length = cim.url.length_chars()
+$event.cim.http_content_type = $event.ocsf.http_response?.content_type?
+$event.cim.http_method = $event.ocsf.http_request?.http_method?
+$event.cim.http_referrer = $event.ocsf.http_request?.referrer?
+$event.cim.http_user_agent = $event.ocsf.http_request?.user_agent?
+$event.cim.status = $event.ocsf.http_status?.string() else $event.ocsf.http_response?.code?.string() else $event.ocsf.status_code?
+$event.cim.uri_path = $event.ocsf.http_request?.url?.path? else $event.ocsf.url?.path?
+$event.cim.uri_query = $event.ocsf.http_request?.url?.query_string? else $event.ocsf.http_request?.args? else $event.ocsf.url?.query_string?
+$event.cim.url = $event.ocsf.http_request?.url?.url_string? else $event.ocsf.url?.url_string? else $event.ocsf.file?.url?.url_string?
+$event.cim.url_domain = $event.ocsf.http_request?.url?.domain? else $event.ocsf.http_request?.url?.hostname? else
+                 $event.ocsf.url?.domain? else $event.ocsf.url?.hostname?
+$event.cim.category = $event.ocsf.http_request?.url?.categories? else $event.ocsf.url?.categories?
+if $event.cim.url != null {
+  $event.cim.url_length = $event.cim.url.length_chars()
 }
 
 // --- CIM: endpoint attributes -----------------
 
-cim.src = src_endpoint?.hostname? else src_endpoint?.ip? else src_endpoint?.name?
-cim.src_ip = src_endpoint?.ip?
+$event.cim.src = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.ip? else $event.ocsf.src_endpoint?.name?
+$event.cim.src_ip = $event.ocsf.src_endpoint?.ip?
 
-cim.dest = dst_endpoint?.hostname? else dst_endpoint?.ip? else dst_endpoint?.name? else
-           http_request?.url?.hostname? else url?.hostname?
-cim.dest_ip = dst_endpoint?.ip?
-cim.dest_port = dst_endpoint?.port? else http_request?.url?.port? else url?.port?
-if cim.dest == null {
-  cim.dest = cim.url_domain
+$event.cim.dest = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.ip? else $event.ocsf.dst_endpoint?.name? else
+           $event.ocsf.http_request?.url?.hostname? else $event.ocsf.url?.hostname?
+$event.cim.dest_ip = $event.ocsf.dst_endpoint?.ip?
+$event.cim.dest_port = $event.ocsf.dst_endpoint?.port? else $event.ocsf.http_request?.url?.port? else $event.ocsf.url?.port?
+if $event.cim.dest == null {
+  $event.cim.dest = $event.cim.url_domain
 }
 
 // --- CIM: user and product attributes ---------
 
-cim.user = actor?.user?.name? else actor?.user?.uid?
-splunk::cim::ocsf::helpers::product
+$event.cim.user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/map.tql
+++ b/splunk/operators/cim/ocsf/map.tql
@@ -1,76 +1,83 @@
 ---
 description: OCSF → Splunk CIM
+args:
+  named:
+    - name: event
+      description: The field that holds the OCSF event to map.
+      type: field
+      default: this
 ---
+$event = {...$event, ocsf: $event, cim: {}}
 
-match class_uid {
+match $event.ocsf.class_uid {
   0 => {
     // OCSF Base Event has no single CIM data model dual.
   }
   1001 => {
-    splunk::cim::ocsf::file_activity
+    splunk::cim::ocsf::file_activity event=$event
   }
   1007 => {
-    splunk::cim::ocsf::process_activity
+    splunk::cim::ocsf::process_activity event=$event
   }
   1008 => {
-    splunk::cim::ocsf::event_log_activity
+    splunk::cim::ocsf::event_log_activity event=$event
   }
   2001 => {
-    splunk::cim::ocsf::alerts_finding
+    splunk::cim::ocsf::alerts_finding event=$event
   }
   2002 => {
-    splunk::cim::ocsf::vulnerability_finding
+    splunk::cim::ocsf::vulnerability_finding event=$event
   }
   2004 => {
-    splunk::cim::ocsf::alerts_finding
+    splunk::cim::ocsf::alerts_finding event=$event
   }
   2006 => {
-    splunk::cim::ocsf::alerts_finding
+    splunk::cim::ocsf::alerts_finding event=$event
   }
   3001 => {
-    splunk::cim::ocsf::account_change
+    splunk::cim::ocsf::account_change event=$event
   }
   3002 => {
-    splunk::cim::ocsf::authentication
+    splunk::cim::ocsf::authentication event=$event
   }
   3004 => {
-    splunk::cim::ocsf::entity_management
+    splunk::cim::ocsf::entity_management event=$event
   }
   3005 => {
-    splunk::cim::ocsf::user_access
+    splunk::cim::ocsf::user_access event=$event
   }
   3006 => {
-    splunk::cim::ocsf::group_management
+    splunk::cim::ocsf::group_management event=$event
   }
   4001 => {
-    splunk::cim::ocsf::network_activity
+    splunk::cim::ocsf::network_activity event=$event
   }
   4002 => {
-    splunk::cim::ocsf::http_activity
+    splunk::cim::ocsf::http_activity event=$event
   }
   4003 => {
-    splunk::cim::ocsf::dns_activity
+    splunk::cim::ocsf::dns_activity event=$event
   }
   4009 => {
-    splunk::cim::ocsf::email_activity
+    splunk::cim::ocsf::email_activity event=$event
   }
   4014 => {
-    splunk::cim::ocsf::tunnel_activity
+    splunk::cim::ocsf::tunnel_activity event=$event
   }
   6001 => {
-    splunk::cim::ocsf::web_resources_activity
+    splunk::cim::ocsf::web_resources_activity event=$event
   }
   6003 => {
-    splunk::cim::ocsf::api_activity
+    splunk::cim::ocsf::api_activity event=$event
   }
   6004 => {
-    splunk::cim::ocsf::web_resource_access_activity
+    splunk::cim::ocsf::web_resource_access_activity event=$event
   }
   6005 => {
-    splunk::cim::ocsf::datastore_activity
+    splunk::cim::ocsf::datastore_activity event=$event
   }
   6006 => {
-    splunk::cim::ocsf::file_hosting
+    splunk::cim::ocsf::file_hosting event=$event
   }
   _ => {}
 }

--- a/splunk/operators/cim/ocsf/map.tql
+++ b/splunk/operators/cim/ocsf/map.tql
@@ -81,3 +81,8 @@ match $event.ocsf.class_uid {
   }
   _ => {}
 }
+
+// Preserve pass-through behavior for unsupported OCSF classes.
+if $event.ocsf? != null and $event.cim? != null {
+  $event = $event.ocsf
+}

--- a/splunk/operators/cim/ocsf/network_activity.tql
+++ b/splunk/operators/cim/ocsf/network_activity.tql
@@ -1,78 +1,83 @@
 ---
 description: OCSF Network Activity (4001) → Splunk CIM Network Traffic All Traffic
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 4001
+assert $event.ocsf.class_uid == 4001
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["network", "communicate"]
+$event.cim.tag = ["network", "communicate"]
 
 // --- CIM: occurrence attributes ---------------
 
-cim._time = time
-if duration? != null {
-  cim.duration = duration.milliseconds().count_seconds()
-} else if start_time? != null and end_time? != null {
-  cim.duration = (end_time - start_time).count_seconds()
+$event.cim._time = $event.ocsf.time
+if $event.ocsf.duration? != null {
+  $event.cim.duration = $event.ocsf.duration.milliseconds().count_seconds()
+} else if $event.ocsf.start_time? != null and $event.ocsf.end_time? != null {
+  $event.cim.duration = ($event.ocsf.end_time - $event.ocsf.start_time).count_seconds()
 }
 
 // --- CIM: action and application attributes ---
 
-splunk::cim::ocsf::helpers::action
-cim.app = app_name? else app_protocol_name?
+splunk::cim::ocsf::helpers::action event=$event
+$event.cim.app = $event.ocsf.app_name? else $event.ocsf.app_protocol_name?
 
 // --- CIM: traffic attributes ------------------
 
-cim.bytes = traffic?.bytes?
-cim.bytes_in = traffic?.bytes_in?
-cim.bytes_out = traffic?.bytes_out?
-cim.packets = traffic?.packets?
-cim.packets_in = traffic?.packets_in?
-cim.packets_out = traffic?.packets_out?
-cim.flow_id = connection_info?.community_uid? else connection_info?.uid?
-cim.session_id = connection_info?.session?.uid?
-cim.direction = connection_info?.direction?.to_lower()
-cim.protocol = app_protocol_name? else connection_info?.protocol_name?
-cim.protocol_version = connection_info?.protocol_ver?
-cim.tcp_flag = connection_info?.tcp_flags?
+$event.cim.bytes = $event.ocsf.traffic?.bytes?
+$event.cim.bytes_in = $event.ocsf.traffic?.bytes_in?
+$event.cim.bytes_out = $event.ocsf.traffic?.bytes_out?
+$event.cim.packets = $event.ocsf.traffic?.packets?
+$event.cim.packets_in = $event.ocsf.traffic?.packets_in?
+$event.cim.packets_out = $event.ocsf.traffic?.packets_out?
+$event.cim.flow_id = $event.ocsf.connection_info?.community_uid? else $event.ocsf.connection_info?.uid?
+$event.cim.session_id = $event.ocsf.connection_info?.session?.uid?
+$event.cim.direction = $event.ocsf.connection_info?.direction?.to_lower()
+$event.cim.protocol = $event.ocsf.app_protocol_name? else $event.ocsf.connection_info?.protocol_name?
+$event.cim.protocol_version = $event.ocsf.connection_info?.protocol_ver?
+$event.cim.tcp_flag = $event.ocsf.connection_info?.tcp_flags?
 
 // --- CIM: endpoint attributes -----------------
 
-cim.src = src_endpoint?.hostname? else src_endpoint?.ip? else src_endpoint?.name?
-cim.src_ip = src_endpoint?.ip?
-cim.src_port = src_endpoint?.port?
-cim.src_mac = src_endpoint?.mac?
-cim.src_interface = src_endpoint?.interface_name?
-cim.src_zone = src_endpoint?.network_scope?
-cim.src_translated_ip = src_endpoint?.proxy_endpoint?.ip?
-cim.src_translated_port = src_endpoint?.proxy_endpoint?.port?
+$event.cim.src = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.ip? else $event.ocsf.src_endpoint?.name?
+$event.cim.src_ip = $event.ocsf.src_endpoint?.ip?
+$event.cim.src_port = $event.ocsf.src_endpoint?.port?
+$event.cim.src_mac = $event.ocsf.src_endpoint?.mac?
+$event.cim.src_interface = $event.ocsf.src_endpoint?.interface_name?
+$event.cim.src_zone = $event.ocsf.src_endpoint?.network_scope?
+$event.cim.src_translated_ip = $event.ocsf.src_endpoint?.proxy_endpoint?.ip?
+$event.cim.src_translated_port = $event.ocsf.src_endpoint?.proxy_endpoint?.port?
 
-cim.dest = dst_endpoint?.hostname? else dst_endpoint?.ip? else dst_endpoint?.name?
-cim.dest_ip = dst_endpoint?.ip?
-cim.dest_port = dst_endpoint?.port?
-cim.dest_mac = dst_endpoint?.mac?
-cim.dest_interface = dst_endpoint?.interface_name?
-cim.dest_zone = dst_endpoint?.network_scope?
-cim.dest_translated_ip = dst_endpoint?.proxy_endpoint?.ip?
-cim.dest_translated_port = dst_endpoint?.proxy_endpoint?.port?
+$event.cim.dest = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.ip? else $event.ocsf.dst_endpoint?.name?
+$event.cim.dest_ip = $event.ocsf.dst_endpoint?.ip?
+$event.cim.dest_port = $event.ocsf.dst_endpoint?.port?
+$event.cim.dest_mac = $event.ocsf.dst_endpoint?.mac?
+$event.cim.dest_interface = $event.ocsf.dst_endpoint?.interface_name?
+$event.cim.dest_zone = $event.ocsf.dst_endpoint?.network_scope?
+$event.cim.dest_translated_ip = $event.ocsf.dst_endpoint?.proxy_endpoint?.ip?
+$event.cim.dest_translated_port = $event.ocsf.dst_endpoint?.proxy_endpoint?.port?
 
-cim.dvc = device?.hostname? else device?.ip? else device?.name? else
-          network_observation_point?.hostname? else network_observation_point?.ip? else network_observation_point?.name?
-cim.dvc_ip = device?.ip? else network_observation_point?.ip?
-cim.dvc_mac = device?.mac? else network_observation_point?.mac?
+$event.cim.dvc = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name? else
+          $event.ocsf.network_observation_point?.hostname? else $event.ocsf.network_observation_point?.ip? else $event.ocsf.network_observation_point?.name?
+$event.cim.dvc_ip = $event.ocsf.device?.ip? else $event.ocsf.network_observation_point?.ip?
+$event.cim.dvc_mac = $event.ocsf.device?.mac? else $event.ocsf.network_observation_point?.mac?
 
 // --- CIM: user and product attributes ---------
 
-cim.user = connection_info?.session?.user?.name? else connection_info?.session?.user?.uid?
-splunk::cim::ocsf::helpers::product
+$event.cim.user = $event.ocsf.connection_info?.session?.user?.name? else $event.ocsf.connection_info?.session?.user?.uid?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- CIM: network attributes ------------------
 
-splunk::cim::ocsf::helpers::transport
+splunk::cim::ocsf::helpers::transport event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/process_activity.tql
+++ b/splunk/operators/cim/ocsf/process_activity.tql
@@ -1,52 +1,57 @@
 ---
 description: OCSF Process Activity (1007) → Splunk CIM Endpoint Processes
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 1007
+assert $event.ocsf.class_uid == 1007
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["process", "report"]
+$event.cim.tag = ["process", "report"]
 
 // --- CIM: occurrence and action attributes ----
 
-cim._time = time
-cim.action = activity_name?.to_lower().replace(" ", "_") else "unknown"
+$event.cim._time = $event.ocsf.time
+$event.cim.action = $event.ocsf.activity_name?.to_lower().replace(" ", "_") else "unknown"
 
 // --- CIM: endpoint attributes -----------------
 
-cim.dest = device?.hostname? else device?.ip? else device?.name?
-cim.os = device?.os?.name?
+$event.cim.dest = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
+$event.cim.os = $event.ocsf.device?.os?.name?
 
 // --- CIM: process attributes ------------------
 
-cim.process = process?.cmd_line? else process?.path? else process?.name?
-cim.process_exec = process?.file?.name? else process?.name?
-cim.process_guid = process?.uid? else process?.cpid?.string()
-cim.process_hash = [...process?.file?.hashes?.map(h => h.value)]
-cim.process_id = process?.pid?
-cim.process_integrity_level = process?.integrity?.to_lower()
-cim.process_name = process?.name? else process?.file?.name?
-cim.process_path = process?.path? else process?.file?.path?
-cim.process_current_directory = process?.working_directory?
+$event.cim.process = $event.ocsf.process?.cmd_line? else $event.ocsf.process?.path? else $event.ocsf.process?.name?
+$event.cim.process_exec = $event.ocsf.process?.file?.name? else $event.ocsf.process?.name?
+$event.cim.process_guid = $event.ocsf.process?.uid? else $event.ocsf.process?.cpid?.string()
+$event.cim.process_hash = [...$event.ocsf.process?.file?.hashes?.map(h => h.value)]
+$event.cim.process_id = $event.ocsf.process?.pid?
+$event.cim.process_integrity_level = $event.ocsf.process?.integrity?.to_lower()
+$event.cim.process_name = $event.ocsf.process?.name? else $event.ocsf.process?.file?.name?
+$event.cim.process_path = $event.ocsf.process?.path? else $event.ocsf.process?.file?.path?
+$event.cim.process_current_directory = $event.ocsf.process?.working_directory?
 
-cim.parent_process = process?.parent_process?.cmd_line?
-cim.parent_process_exec = process?.parent_process?.file?.name? else process?.parent_process?.name?
-cim.parent_process_guid = process?.parent_process?.uid?
-cim.parent_process_hash = [...process?.parent_process?.file?.hashes?.map(h => h.value)]
-cim.parent_process_id = process?.parent_process?.pid?
-cim.parent_process_name = process?.parent_process?.name? else process?.parent_process?.file?.name?
-cim.parent_process_path = process?.parent_process?.path? else process?.parent_process?.file?.path?
-cim.parent_user = process?.parent_process?.user?.name?
+$event.cim.parent_process = $event.ocsf.process?.parent_process?.cmd_line?
+$event.cim.parent_process_exec = $event.ocsf.process?.parent_process?.file?.name? else $event.ocsf.process?.parent_process?.name?
+$event.cim.parent_process_guid = $event.ocsf.process?.parent_process?.uid?
+$event.cim.parent_process_hash = [...$event.ocsf.process?.parent_process?.file?.hashes?.map(h => h.value)]
+$event.cim.parent_process_id = $event.ocsf.process?.parent_process?.pid?
+$event.cim.parent_process_name = $event.ocsf.process?.parent_process?.name? else $event.ocsf.process?.parent_process?.file?.name?
+$event.cim.parent_process_path = $event.ocsf.process?.parent_process?.path? else $event.ocsf.process?.parent_process?.file?.path?
+$event.cim.parent_user = $event.ocsf.process?.parent_process?.user?.name?
 
 // --- CIM: user and product attributes ---------
 
-cim.user = process?.user?.name? else process?.user?.uid?
-cim.user_id = process?.user?.uid?
-splunk::cim::ocsf::helpers::product
+$event.cim.user = $event.ocsf.process?.user?.name? else $event.ocsf.process?.user?.uid?
+$event.cim.user_id = $event.ocsf.process?.user?.uid?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/tunnel_activity.tql
+++ b/splunk/operators/cim/ocsf/tunnel_activity.tql
@@ -1,59 +1,64 @@
 ---
 description: OCSF Tunnel Activity (4014) → Splunk CIM Network Sessions VPN
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 4014
+assert $event.ocsf.class_uid == 4014
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["network", "session", "vpn"]
+$event.cim.tag = ["network", "session", "vpn"]
 
 // --- CIM: occurrence and action attributes ----
 
-cim._time = time
-if duration? != null {
-  cim.duration = duration.milliseconds().count_seconds()
+$event.cim._time = $event.ocsf.time
+if $event.ocsf.duration? != null {
+  $event.cim.duration = $event.ocsf.duration.milliseconds().count_seconds()
 }
-cim.action = activity_name?.to_lower().replace(" ", "_") else "unknown"
-match activity_id {
+$event.cim.action = $event.ocsf.activity_name?.to_lower().replace(" ", "_") else "unknown"
+match $event.ocsf.activity_id {
   1 => {
-    cim.action = "started"
+    $event.cim.action = "started"
   }
   2 => {
-    cim.action = "ended"
+    $event.cim.action = "ended"
   }
   3 => {
-    cim.action = "renewed"
+    $event.cim.action = "renewed"
   }
   _ => {}
 }
 
 // --- CIM: session attributes ------------------
 
-cim.signature = tunnel_type? else protocol_name? else type_name?
-cim.signature_id = tunnel_type_id?.string() else type_uid?.string()
+$event.cim.signature = $event.ocsf.tunnel_type? else $event.ocsf.protocol_name? else $event.ocsf.type_name?
+$event.cim.signature_id = $event.ocsf.tunnel_type_id?.string() else $event.ocsf.type_uid?.string()
 
 // --- CIM: endpoint attributes -----------------
 
-cim.src_ip = src_endpoint?.ip?
-cim.src_dns = src_endpoint?.hostname? else src_endpoint?.name?
-cim.src_mac = src_endpoint?.mac?
-cim.src_nt_host = src_endpoint?.hostname? else src_endpoint?.name?
+$event.cim.src_ip = $event.ocsf.src_endpoint?.ip?
+$event.cim.src_dns = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.name?
+$event.cim.src_mac = $event.ocsf.src_endpoint?.mac?
+$event.cim.src_nt_host = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.name?
 
-cim.dest_ip = dst_endpoint?.ip? else tunnel_interface?.ip?
-cim.dest_dns = dst_endpoint?.hostname? else dst_endpoint?.name? else tunnel_interface?.name?
-cim.dest_mac = dst_endpoint?.mac? else tunnel_interface?.mac?
-cim.dest_nt_host = dst_endpoint?.hostname? else dst_endpoint?.name?
+$event.cim.dest_ip = $event.ocsf.dst_endpoint?.ip? else $event.ocsf.tunnel_interface?.ip?
+$event.cim.dest_dns = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.name? else $event.ocsf.tunnel_interface?.name?
+$event.cim.dest_mac = $event.ocsf.dst_endpoint?.mac? else $event.ocsf.tunnel_interface?.mac?
+$event.cim.dest_nt_host = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.name?
 
-cim.dvc = device?.hostname? else device?.ip? else device?.name?
+$event.cim.dvc = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
 
 // --- CIM: user and product attributes ---------
 
-cim.user = user?.name? else user?.uid? else session?.user?.name? else session?.user?.uid?
-splunk::cim::ocsf::helpers::product
+$event.cim.user = $event.ocsf.user?.name? else $event.ocsf.user?.uid? else $event.ocsf.session?.user?.name? else $event.ocsf.session?.user?.uid?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/user_access.tql
+++ b/splunk/operators/cim/ocsf/user_access.tql
@@ -1,56 +1,61 @@
 ---
 description: OCSF User Access Management (3005) → Splunk CIM Change Account Management
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 3005
+assert $event.ocsf.class_uid == 3005
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["change", "account"]
+$event.cim.tag = ["change", "account"]
 
 // --- CIM: occurrence and action attributes ----
 
-cim._time = time
-cim.action = activity_name?.to_lower().replace(" ", "_") else "unknown"
-cim.change_type = "AAA"
-cim.status = status?.to_lower()
-match status_id? {
+$event.cim._time = $event.ocsf.time
+$event.cim.action = $event.ocsf.activity_name?.to_lower().replace(" ", "_") else "unknown"
+$event.cim.change_type = "AAA"
+$event.cim.status = $event.ocsf.status?.to_lower()
+match $event.ocsf.status_id? {
   1 => {
-    cim.status = "success"
+    $event.cim.status = "success"
   }
   2 => {
-    cim.status = "failure"
+    $event.cim.status = "failure"
   }
   _ => {}
 }
-cim.result = status_detail? else status?
-cim.result_id = status_code? else status_id?.string()
+$event.cim.result = $event.ocsf.status_detail? else $event.ocsf.status?
+$event.cim.result_id = $event.ocsf.status_code? else $event.ocsf.status_id?.string()
 
 // --- CIM: object attributes -------------------
 
-cim.object = resource?.name? else resources?[0]?.name? else user?.name? else user?.uid?
-cim.object_id = resource?.uid? else resources?[0]?.uid? else user?.uid?
-cim.object_category = resource?.type? else resources?[0]?.type? else "privilege"
-cim.object_attrs = privileges?
+$event.cim.object = $event.ocsf.resource?.name? else $event.ocsf.resources?[0]?.name? else $event.ocsf.user?.name? else $event.ocsf.user?.uid?
+$event.cim.object_id = $event.ocsf.resource?.uid? else $event.ocsf.resources?[0]?.uid? else $event.ocsf.user?.uid?
+$event.cim.object_category = $event.ocsf.resource?.type? else $event.ocsf.resources?[0]?.type? else "privilege"
+$event.cim.object_attrs = $event.ocsf.privileges?
 
 // --- CIM: endpoint and user attributes --------
 
-cim.src = actor?.process?.device?.hostname? else actor?.process?.device?.ip? else actor?.process?.device?.name?
-cim.dest = device?.hostname? else device?.ip? else device?.name?
-cim.dvc = device?.hostname? else device?.ip? else device?.name?
-cim.user = user?.name? else user?.uid?
-cim.user_name = user?.name?
-cim.user_type = user?.type?
-cim.src_user = actor?.user?.name? else actor?.user?.uid?
-cim.src_user_name = actor?.user?.name?
-cim.src_user_type = actor?.user?.type?
-cim.user_agent = http_request?.user_agent?
-cim.vendor_account = cloud?.account?.uid?
-cim.vendor_region = cloud?.region?
-splunk::cim::ocsf::helpers::product
+$event.cim.src = $event.ocsf.actor?.process?.device?.hostname? else $event.ocsf.actor?.process?.device?.ip? else $event.ocsf.actor?.process?.device?.name?
+$event.cim.dest = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
+$event.cim.dvc = $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
+$event.cim.user = $event.ocsf.user?.name? else $event.ocsf.user?.uid?
+$event.cim.user_name = $event.ocsf.user?.name?
+$event.cim.user_type = $event.ocsf.user?.type?
+$event.cim.src_user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+$event.cim.src_user_name = $event.ocsf.actor?.user?.name?
+$event.cim.src_user_type = $event.ocsf.actor?.user?.type?
+$event.cim.user_agent = $event.ocsf.http_request?.user_agent?
+$event.cim.vendor_account = $event.ocsf.cloud?.account?.uid?
+$event.cim.vendor_region = $event.ocsf.cloud?.region?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/vulnerability_finding.tql
+++ b/splunk/operators/cim/ocsf/vulnerability_finding.tql
@@ -1,41 +1,46 @@
 ---
 description: OCSF Vulnerability Finding (2002) → Splunk CIM Vulnerabilities
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 2002
+assert $event.ocsf.class_uid == 2002
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["vulnerability", "report"]
+$event.cim.tag = ["vulnerability", "report"]
 
 // --- CIM: occurrence attributes ---------------
 
-cim._time = time
+$event.cim._time = $event.ocsf.time
 
 // --- CIM: vulnerability attributes ------------
 
-cim.category = vulnerabilities?[0]?.category? else finding_info?.types?[0]?
-cim.cve = [...vulnerabilities?.map(v => v.cve.uid)]
-cim.cvss = vulnerabilities?[0]?.cve?.cvss?[0]?.base_score?
-cim.signature = vulnerabilities?[0]?.title? else finding_info?.title? else type_name?
-cim.signature_id = vulnerabilities?[0]?.cve?.uid? else finding_info?.uid? else type_uid?.string()
-cim.url = vulnerabilities?[0]?.references?[0]? else finding_info?.src_url?
-cim.xref = [...vulnerabilities?[0]?.references?]
-splunk::cim::ocsf::helpers::severity
+$event.cim.category = $event.ocsf.vulnerabilities?[0]?.category? else $event.ocsf.finding_info?.types?[0]?
+$event.cim.cve = [...$event.ocsf.vulnerabilities?.map(v => v.cve.uid)]
+$event.cim.cvss = $event.ocsf.vulnerabilities?[0]?.cve?.cvss?[0]?.base_score?
+$event.cim.signature = $event.ocsf.vulnerabilities?[0]?.title? else $event.ocsf.finding_info?.title? else $event.ocsf.type_name?
+$event.cim.signature_id = $event.ocsf.vulnerabilities?[0]?.cve?.uid? else $event.ocsf.finding_info?.uid? else $event.ocsf.type_uid?.string()
+$event.cim.url = $event.ocsf.vulnerabilities?[0]?.references?[0]? else $event.ocsf.finding_info?.src_url?
+$event.cim.xref = [...$event.ocsf.vulnerabilities?[0]?.references?]
+splunk::cim::ocsf::helpers::severity event=$event
 
 // --- CIM: endpoint and device attributes ------
 
-cim.dest = resource?.name? else resources?[0]?.name? else
-           device?.hostname? else device?.ip? else device?.name?
-cim.dvc = metadata.product.name?
+$event.cim.dest = $event.ocsf.resource?.name? else $event.ocsf.resources?[0]?.name? else
+           $event.ocsf.device?.hostname? else $event.ocsf.device?.ip? else $event.ocsf.device?.name?
+$event.cim.dvc = $event.ocsf.metadata.product.name?
 
 // --- CIM: user and product attributes ---------
 
-cim.user = actor?.user?.name? else actor?.user?.uid?
-splunk::cim::ocsf::helpers::product
+$event.cim.user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/cim/ocsf/web_resource_access_activity.tql
+++ b/splunk/operators/cim/ocsf/web_resource_access_activity.tql
@@ -1,7 +1,12 @@
 ---
 description: OCSF Web Resource Access Activity (6004) → Splunk CIM Web
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid == 6004
+assert $event.ocsf.class_uid == 6004
 
-splunk::cim::ocsf::web_resources_activity
+splunk::cim::ocsf::web_resources_activity event=$event

--- a/splunk/operators/cim/ocsf/web_resources_activity.tql
+++ b/splunk/operators/cim/ocsf/web_resources_activity.tql
@@ -1,51 +1,56 @@
 ---
 description: OCSF Web Resources Activity (6001/6004) → Splunk CIM Web
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-assert class_uid in [6001, 6004]
+assert $event.ocsf.class_uid in [6001, 6004]
 
-cim = {}
+$event.cim = {}
 
 // --- CIM: data model attributes ---------------
 
-cim.tag = ["web"]
+$event.cim.tag = ["web"]
 
 // --- CIM: occurrence and action attributes ----
 
-cim._time = time
-splunk::cim::ocsf::helpers::action
-cim.app = actor?.app_name? else metadata.product.name?
+$event.cim._time = $event.ocsf.time
+splunk::cim::ocsf::helpers::action event=$event
+$event.cim.app = $event.ocsf.actor?.app_name? else $event.ocsf.metadata.product.name?
 
 // --- CIM: web attributes ----------------------
 
-cim.http_content_type = http_response?.content_type?
-cim.http_method = http_request?.http_method?
-cim.http_referrer = http_request?.referrer?
-cim.http_user_agent = http_request?.user_agent?
-cim.response_time = http_response?.latency?
-cim.status = http_response?.code?.string() else status_code?
-cim.url = http_request?.url?.url_string? else web_resources?[0]?.url_string?
-cim.url_domain = http_request?.url?.domain? else http_request?.url?.hostname? else
-                 web_resources?[0]?.url_string?
-cim.uri_path = http_request?.url?.path?
-cim.uri_query = http_request?.url?.query_string?
-if cim.url != null {
-  cim.url_length = cim.url.length_chars()
+$event.cim.http_content_type = $event.ocsf.http_response?.content_type?
+$event.cim.http_method = $event.ocsf.http_request?.http_method?
+$event.cim.http_referrer = $event.ocsf.http_request?.referrer?
+$event.cim.http_user_agent = $event.ocsf.http_request?.user_agent?
+$event.cim.response_time = $event.ocsf.http_response?.latency?
+$event.cim.status = $event.ocsf.http_response?.code?.string() else $event.ocsf.status_code?
+$event.cim.url = $event.ocsf.http_request?.url?.url_string? else $event.ocsf.web_resources?[0]?.url_string?
+$event.cim.url_domain = $event.ocsf.http_request?.url?.domain? else $event.ocsf.http_request?.url?.hostname? else
+                 $event.ocsf.web_resources?[0]?.url_string?
+$event.cim.uri_path = $event.ocsf.http_request?.url?.path?
+$event.cim.uri_query = $event.ocsf.http_request?.url?.query_string?
+if $event.cim.url != null {
+  $event.cim.url_length = $event.cim.url.length_chars()
 }
 
 // --- CIM: endpoint attributes -----------------
 
-cim.src = src_endpoint?.hostname? else src_endpoint?.ip? else src_endpoint?.name?
-cim.src_ip = src_endpoint?.ip?
-cim.dest = dst_endpoint?.hostname? else dst_endpoint?.ip? else dst_endpoint?.name? else cim.url_domain
-cim.dest_ip = dst_endpoint?.ip?
-cim.dest_port = dst_endpoint?.port? else http_request?.url?.port?
+$event.cim.src = $event.ocsf.src_endpoint?.hostname? else $event.ocsf.src_endpoint?.ip? else $event.ocsf.src_endpoint?.name?
+$event.cim.src_ip = $event.ocsf.src_endpoint?.ip?
+$event.cim.dest = $event.ocsf.dst_endpoint?.hostname? else $event.ocsf.dst_endpoint?.ip? else $event.ocsf.dst_endpoint?.name? else $event.cim.url_domain
+$event.cim.dest_ip = $event.ocsf.dst_endpoint?.ip?
+$event.cim.dest_port = $event.ocsf.dst_endpoint?.port? else $event.ocsf.http_request?.url?.port?
 
 // --- CIM: user and product attributes ---------
 
-cim.user = actor?.user?.name? else actor?.user?.uid?
-splunk::cim::ocsf::helpers::product
+$event.cim.user = $event.ocsf.actor?.user?.name? else $event.ocsf.actor?.user?.uid?
+splunk::cim::ocsf::helpers::product event=$event
 
 // --- Finalize ---------------------------------
 
-this = cim
+$event = $event.cim

--- a/splunk/operators/ocsf/cim/account_change.tql
+++ b/splunk/operators/ocsf/cim/account_change.tql
@@ -1,99 +1,102 @@
 ---
 description: Splunk CIM Change Account Management → OCSF Account Change (3001)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "create" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "enable" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "password_change" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "password_reset" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   "disable" => {
-    ocsf.activity_id = 5
+    $event.ocsf.activity_id = 5
   }
   "delete" => {
-    ocsf.activity_id = 6
+    $event.ocsf.activity_id = 6
   }
   "attach_policy" => {
-    ocsf.activity_id = 7
+    $event.ocsf.activity_id = 7
   }
   "detach_policy" => {
-    ocsf.activity_id = 8
+    $event.ocsf.activity_id = 8
   }
   "lock" => {
-    ocsf.activity_id = 9
+    $event.ocsf.activity_id = 9
   }
   "mfa_factor_enable" => {
-    ocsf.activity_id = 10
+    $event.ocsf.activity_id = 10
   }
   "mfa_factor_disable" => {
-    ocsf.activity_id = 11
+    $event.ocsf.activity_id = 11
   }
   "unlock" => {
-    ocsf.activity_id = 12
+    $event.ocsf.activity_id = 12
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 3
-ocsf.class_uid = 3001
-splunk::ocsf::cim::helpers::common
-splunk::ocsf::cim::helpers::status
+$event.ocsf.category_uid = 3
+$event.ocsf.class_uid = 3001
+splunk::ocsf::cim::helpers::common event=$event
+splunk::ocsf::cim::helpers::status event=$event
 
 // --- OCSF: account attributes -----------------
 
-ocsf.user = {
-  name: move cim.user_name? else move cim.object?,
-  type: move cim.user_type? else move cim.object_category?,
-  uid: move cim.object_id?,
+$event.ocsf.user = {
+  name: move $event.cim.user_name? else move $event.cim.object?,
+  type: move $event.cim.user_type? else move $event.cim.object_category?,
+  uid: move $event.cim.object_id?,
 }
-ocsf.user_result = {
-  name: ocsf.user.name?,
-  type: ocsf.user.type?,
-  uid: ocsf.user.uid?,
+$event.ocsf.user_result = {
+  name: $event.ocsf.user.name?,
+  type: $event.ocsf.user.type?,
+  uid: $event.ocsf.user.uid?,
 }
-ocsf.actor = {
+$event.ocsf.actor = {
   user: {
-    name: move cim.src_user_name? else move cim.src_user?,
-    type: move cim.src_user_type?,
+    name: move $event.cim.src_user_name? else move $event.cim.src_user?,
+    type: move $event.cim.src_user_type?,
   },
 }
-ocsf.src_endpoint = {
-  hostname: move cim.src?,
+$event.ocsf.src_endpoint = {
+  hostname: move $event.cim.src?,
 }
-if cim.dvc? != null {
-  ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "host"]
-  ocsf.device = {
-    hostname: move cim.dvc,
+if $event.cim.dvc? != null {
+  $event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "host"]
+  $event.ocsf.device = {
+    hostname: move $event.cim.dvc,
   }
 }
-ocsf.http_request = {
-  user_agent: move cim.user_agent?,
+$event.ocsf.http_request = {
+  user_agent: move $event.cim.user_agent?,
 }
-if cim.vendor_account? != null or cim.vendor_region? != null {
-  ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "cloud"]
-  ocsf.cloud = {
+if $event.cim.vendor_account? != null or $event.cim.vendor_region? != null {
+  $event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "cloud"]
+  $event.ocsf.cloud = {
     account: {
-      uid: move cim.vendor_account?,
+      uid: move $event.cim.vendor_account?,
     },
-    region: move cim.vendor_region?,
+    region: move $event.cim.vendor_region?,
   }
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.account_change"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/api_activity.tql
+++ b/splunk/operators/ocsf/cim/api_activity.tql
@@ -1,84 +1,87 @@
 ---
 description: Splunk CIM Data Access → OCSF API Activity (6003)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "create" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "read" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "update" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "delete" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 6
-ocsf.class_uid = 6003
-splunk::ocsf::cim::helpers::common
+$event.ocsf.category_uid = 6
+$event.ocsf.class_uid = 6003
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: API attributes ---------------------
 
-ocsf.api = {
-  operation: move cim.object?,
+$event.ocsf.api = {
+  operation: move $event.cim.object?,
   service: {
-    name: move cim.app?,
+    name: move $event.cim.app?,
   },
 }
-ocsf.resources = [
+$event.ocsf.resources = [
   {
-    name: ocsf.api.operation?,
-    type: move cim.object_category?,
-    uid: move cim.object_id?,
+    name: $event.ocsf.api.operation?,
+    type: move $event.cim.object_category?,
+    uid: move $event.cim.object_id?,
   },
 ]
-ocsf.http_request = {
+$event.ocsf.http_request = {
   url: {
-    url_string: move cim.dest_url?,
+    url_string: move $event.cim.dest_url?,
   },
-  user_agent: move cim.user_agent?,
+  user_agent: move $event.cim.user_agent?,
 }
-ocsf.src_endpoint = {
-  ip: move cim.src?,
+$event.ocsf.src_endpoint = {
+  ip: move $event.cim.src?,
 }
-ocsf.dst_endpoint = {
-  hostname: move cim.dest?,
+$event.ocsf.dst_endpoint = {
+  hostname: move $event.cim.dest?,
 }
-ocsf.actor = {
+$event.ocsf.actor = {
   user: {
-    name: move cim.user_name? else move cim.user?,
-    type: move cim.user_type? else move cim.user_role?,
-    uid: move cim.user_id?,
+    name: move $event.cim.user_name? else move $event.cim.user?,
+    type: move $event.cim.user_type? else move $event.cim.user_role?,
+    uid: move $event.cim.user_id?,
   },
 }
-if cim.dvc? != null {
-  ocsf.metadata.profiles = ["host"]
-  ocsf.device = {
-    hostname: move cim.dvc,
+if $event.cim.dvc? != null {
+  $event.ocsf.metadata.profiles = ["host"]
+  $event.ocsf.device = {
+    hostname: move $event.cim.dvc,
   }
 }
-if cim.vendor_account? != null or cim.vendor_region? != null {
-  ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "cloud"]
-  ocsf.cloud = {
+if $event.cim.vendor_account? != null or $event.cim.vendor_region? != null {
+  $event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "cloud"]
+  $event.ocsf.cloud = {
     account: {
-      uid: move cim.vendor_account?,
+      uid: move $event.cim.vendor_account?,
     },
-    region: move cim.vendor_region?,
+    region: move $event.cim.vendor_region?,
   }
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.api_activity"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/authentication.tql
+++ b/splunk/operators/ocsf/cim/authentication.tql
@@ -1,119 +1,122 @@
 ---
 description: Splunk CIM Authentication → OCSF Authentication (3002)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 1
-ocsf.category_uid = 3
-ocsf.class_uid = 3002
-if cim.action? != null {
-  match cim.action.to_lower() {
+$event.ocsf.activity_id = 1
+$event.ocsf.category_uid = 3
+$event.ocsf.class_uid = 3002
+if $event.cim.action? != null {
+  match $event.cim.action.to_lower() {
     "success" => {
-      ocsf.status_id = 1
+      $event.ocsf.status_id = 1
     }
     "failure" => {
-      ocsf.status_id = 2
+      $event.ocsf.status_id = 2
     }
     "unknown" => {
-      ocsf.status_id = 0
+      $event.ocsf.status_id = 0
     }
     _ => {}
   }
 }
-splunk::ocsf::cim::helpers::common
-splunk::ocsf::cim::helpers::status
+splunk::ocsf::cim::helpers::common event=$event
+splunk::ocsf::cim::helpers::status event=$event
 
 // --- OCSF: occurrence attributes --------------
 
-if cim.duration? != null {
-  ocsf.duration = (move cim.duration).seconds().count_milliseconds().round()
+if $event.cim.duration? != null {
+  $event.ocsf.duration = (move $event.cim.duration).seconds().count_milliseconds().round()
 }
 
 // --- OCSF: authentication attributes ----------
 
-if cim.authentication_method? != null {
-  ocsf.auth_protocol = move cim.authentication_method
-  match ocsf.auth_protocol.to_lower() {
+if $event.cim.authentication_method? != null {
+  $event.ocsf.auth_protocol = move $event.cim.authentication_method
+  match $event.ocsf.auth_protocol.to_lower() {
     "ntlm" => {
-      ocsf.auth_protocol_id = 1
+      $event.ocsf.auth_protocol_id = 1
     }
     "kerberos" => {
-      ocsf.auth_protocol_id = 2
+      $event.ocsf.auth_protocol_id = 2
     }
     "digest" => {
-      ocsf.auth_protocol_id = 3
+      $event.ocsf.auth_protocol_id = 3
     }
     "openid" => {
-      ocsf.auth_protocol_id = 4
+      $event.ocsf.auth_protocol_id = 4
     }
     "saml" => {
-      ocsf.auth_protocol_id = 5
+      $event.ocsf.auth_protocol_id = 5
     }
     "oauth 2.0" | "oauth2" => {
-      ocsf.auth_protocol_id = 6
+      $event.ocsf.auth_protocol_id = 6
     }
     "pap" => {
-      ocsf.auth_protocol_id = 7
+      $event.ocsf.auth_protocol_id = 7
     }
     "chap" => {
-      ocsf.auth_protocol_id = 8
+      $event.ocsf.auth_protocol_id = 8
     }
     "eap" => {
-      ocsf.auth_protocol_id = 9
+      $event.ocsf.auth_protocol_id = 9
     }
     "radius" => {
-      ocsf.auth_protocol_id = 10
+      $event.ocsf.auth_protocol_id = 10
     }
     "basic authentication" | "basic" => {
-      ocsf.auth_protocol_id = 11
+      $event.ocsf.auth_protocol_id = 11
     }
     "ldap" => {
-      ocsf.auth_protocol_id = 12
+      $event.ocsf.auth_protocol_id = 12
     }
     _ => {
-      ocsf.auth_protocol_id = 99
+      $event.ocsf.auth_protocol_id = 99
     }
   }
 }
-ocsf.service = {
-  name: move cim.authentication_service? else move cim.app?,
+$event.ocsf.service = {
+  name: move $event.cim.authentication_service? else move $event.cim.app?,
 }
-ocsf.session = {
-  uid: move cim.session_id?,
+$event.ocsf.session = {
+  uid: move $event.cim.session_id?,
 }
-ocsf.user = {
-  name: move cim.user?,
-  uid: move cim.user_id?,
-  type: move cim.user_type? else move cim.user_role?,
+$event.ocsf.user = {
+  name: move $event.cim.user?,
+  uid: move $event.cim.user_id?,
+  type: move $event.cim.user_type? else move $event.cim.user_role?,
 }
-ocsf.actor = {
+$event.ocsf.actor = {
   user: {
-    name: move cim.src_user?,
-    uid: move cim.src_user_id?,
-    type: move cim.src_user_type? else move cim.src_user_role?,
+    name: move $event.cim.src_user?,
+    uid: move $event.cim.src_user_id?,
+    type: move $event.cim.src_user_type? else move $event.cim.src_user_role?,
   },
   process: {
-    cmd_line: move cim.process?,
+    cmd_line: move $event.cim.process?,
   },
 }
-ocsf.src_endpoint = {
-  hostname: move cim.src?,
+$event.ocsf.src_endpoint = {
+  hostname: move $event.cim.src?,
 }
-ocsf.dst_endpoint = {
-  hostname: move cim.dest?,
+$event.ocsf.dst_endpoint = {
+  hostname: move $event.cim.dest?,
 }
-ocsf.http_request = {
-  user_agent: move cim.user_agent?,
+$event.ocsf.http_request = {
+  user_agent: move $event.cim.user_agent?,
 }
-if cim.vendor_account? != null {
-  ocsf.metadata.profiles = ["cloud"]
-  ocsf.cloud = {
+if $event.cim.vendor_account? != null {
+  $event.ocsf.metadata.profiles = ["cloud"]
+  $event.ocsf.cloud = {
     account: {
-      uid: move cim.vendor_account,
+      uid: move $event.cim.vendor_account,
     },
   }
 }
@@ -121,4 +124,4 @@ if cim.vendor_account? != null {
 // --- Finalize ---------------------------------
 
 @name = "ocsf.authentication"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/datastore_activity.tql
+++ b/splunk/operators/ocsf/cim/datastore_activity.tql
@@ -1,45 +1,48 @@
 ---
 description: Splunk CIM Databases Database Query → OCSF Datastore Activity (6005)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 4
-ocsf.category_uid = 6
-ocsf.class_uid = 6005
-splunk::ocsf::cim::helpers::common
+$event.ocsf.activity_id = 4
+$event.ocsf.category_uid = 6
+$event.ocsf.class_uid = 6005
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: datastore attributes ---------------
 
-if cim.duration? != null {
-  ocsf.duration = (move cim.duration).seconds().count_milliseconds().round()
-} else if cim.response_time? != null {
-  ocsf.duration = (move cim.response_time).seconds().count_milliseconds().round()
+if $event.cim.duration? != null {
+  $event.ocsf.duration = (move $event.cim.duration).seconds().count_milliseconds().round()
+} else if $event.cim.response_time? != null {
+  $event.ocsf.duration = (move $event.cim.response_time).seconds().count_milliseconds().round()
 }
-ocsf.table = {
-  name: move cim.object?,
+$event.ocsf.table = {
+  name: move $event.cim.object?,
 }
-ocsf.database = {
-  name: move cim.dest?,
+$event.ocsf.database = {
+  name: move $event.cim.dest?,
 }
-ocsf.query_info = {
-  query_string: move cim.query?,
-  query_time: move cim.query_time?,
-  uid: move cim.query_id?,
+$event.ocsf.query_info = {
+  query_string: move $event.cim.query?,
+  query_time: move $event.cim.query_time?,
+  uid: move $event.cim.query_id?,
 }
-ocsf.src_endpoint = {
-  ip: move cim.src?,
+$event.ocsf.src_endpoint = {
+  ip: move $event.cim.src?,
 }
-ocsf.actor = {
+$event.ocsf.actor = {
   user: {
-    name: move cim.user?,
+    name: move $event.cim.user?,
   },
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.datastore_activity"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/detection_finding.tql
+++ b/splunk/operators/ocsf/cim/detection_finding.tql
@@ -1,29 +1,32 @@
 ---
 description: Splunk CIM Alerts → OCSF Detection Finding (2004)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 1
-ocsf.category_uid = 2
-ocsf.class_uid = 2004
-ocsf.is_alert = cim.type? == "alert"
-splunk::ocsf::cim::helpers::common
+$event.ocsf.activity_id = 1
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2004
+$event.ocsf.is_alert = $event.cim.type? == "alert"
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: finding attributes -----------------
 
-ocsf.finding_info = {
-  desc: move cim.description?,
-  title: move cim.signature?,
-  uid: move cim.id? else move cim.signature_id?,
+$event.ocsf.finding_info = {
+  desc: move $event.cim.description?,
+  title: move $event.cim.signature?,
+  uid: move $event.cim.id? else move $event.cim.signature_id?,
 }
-ocsf.message = move cim.subject?
-ocsf.metadata.product.name = move cim.app? else ocsf.metadata.product.name
-if cim.mitre_technique_id? != null {
-  ocsf.finding_info.attacks = (move cim.mitre_technique_id).map(t => {
+$event.ocsf.message = move $event.cim.subject?
+$event.ocsf.metadata.product.name = move $event.cim.app? else $event.ocsf.metadata.product.name
+if $event.cim.mitre_technique_id? != null {
+  $event.ocsf.finding_info.attacks = (move $event.cim.mitre_technique_id).map(t => {
     technique: {
       uid: t,
     },
@@ -36,4 +39,4 @@ if cim.mitre_technique_id? != null {
 // --- Finalize ---------------------------------
 
 @name = "ocsf.detection_finding"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/dns_activity.tql
+++ b/splunk/operators/ocsf/cim/dns_activity.tql
@@ -1,238 +1,241 @@
 ---
 description: Splunk CIM Network Resolution DNS → OCSF DNS Activity (4003)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.message_type? {
+match $event.cim.message_type? {
   "Traffic" => {
-    ocsf.activity_id = 6
+    $event.ocsf.activity_id = 6
   }
   "Response" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
-  _ if cim.answer? != null or cim.reply_code? != null or cim.reply_code_id? != null => {
-    ocsf.activity_id = 6
+  _ if $event.cim.answer? != null or $event.cim.reply_code? != null or $event.cim.reply_code_id? != null => {
+    $event.ocsf.activity_id = 6
   }
   _ => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
 }
-ocsf.category_uid = 4
-ocsf.class_uid = 4003
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4003
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: occurrence attributes --------------
 
-ocsf.time = move cim._time?
-if cim.duration? != null {
-  ocsf.duration = (move cim.duration).seconds().count_milliseconds().round()
+$event.ocsf.time = move $event.cim._time?
+if $event.cim.duration? != null {
+  $event.ocsf.duration = (move $event.cim.duration).seconds().count_milliseconds().round()
 }
 
-if cim.response_time? != null {
-  ocsf.response_time = ocsf.time
-  ocsf.query_time = ocsf.time - (move cim.response_time).seconds()
+if $event.cim.response_time? != null {
+  $event.ocsf.response_time = $event.ocsf.time
+  $event.ocsf.query_time = $event.ocsf.time - (move $event.cim.response_time).seconds()
 }
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata = {
+$event.ocsf.metadata = {
   product: {
-    name: move cim.product? else move cim.vendor_product? else "Splunk CIM",
-    vendor_name: move cim.vendor?,
+    name: move $event.cim.product? else move $event.cim.vendor_product? else "Splunk CIM",
+    vendor_name: move $event.cim.vendor?,
   },
   version: "1.8.0",
 }
 
-ocsf.connection_info = {
-  protocol_name: move cim.transport?,
+$event.ocsf.connection_info = {
+  protocol_name: move $event.cim.transport?,
 }
-match ocsf.connection_info.protocol_name {
+match $event.ocsf.connection_info.protocol_name {
   "icmp" => {
-    ocsf.connection_info.protocol_num = 1
+    $event.ocsf.connection_info.protocol_num = 1
   }
   "tcp" => {
-    ocsf.connection_info.protocol_num = 6
+    $event.ocsf.connection_info.protocol_num = 6
   }
   "udp" => {
-    ocsf.connection_info.protocol_num = 17
+    $event.ocsf.connection_info.protocol_num = 17
   }
   _ => {}
 }
 
 // --- OCSF: primary DNS attributes -------------
 
-ocsf.query = {
-  hostname: move cim.query?,
-  opcode: move cim.query_type?,
-  packet_uid: move cim.transaction_id?,
-  type: move cim.record_type?,
+$event.ocsf.query = {
+  hostname: move $event.cim.query?,
+  opcode: move $event.cim.query_type?,
+  packet_uid: move $event.cim.transaction_id?,
+  type: move $event.cim.record_type?,
 }
-match ocsf.query.opcode {
+match $event.ocsf.query.opcode {
   "Query" => {
-    ocsf.query.opcode_id = 0
+    $event.ocsf.query.opcode_id = 0
   }
   "IQuery" => {
-    ocsf.query.opcode_id = 1
+    $event.ocsf.query.opcode_id = 1
   }
   "Status" => {
-    ocsf.query.opcode_id = 2
+    $event.ocsf.query.opcode_id = 2
   }
   "Notify" => {
-    ocsf.query.opcode_id = 4
+    $event.ocsf.query.opcode_id = 4
   }
   "Update" => {
-    ocsf.query.opcode_id = 5
+    $event.ocsf.query.opcode_id = 5
   }
   _ => {
-    ocsf.query.opcode_id = 99 if ocsf.query.opcode? != null
+    $event.ocsf.query.opcode_id = 99 if $event.ocsf.query.opcode? != null
   }
 }
 
-if cim.answer? != null and cim.ttl? != null {
-  ocsf.answers = zip(move cim.answer, move cim.ttl).map(x => {
+if $event.cim.answer? != null and $event.cim.ttl? != null {
+  $event.ocsf.answers = zip(move $event.cim.answer, move $event.cim.ttl).map(x => {
     rdata: x.left,
     ttl: x.right,
-    type: ocsf.query.type?,
+    type: $event.ocsf.query.type?,
   })
-} else if cim.answer? != null {
-  ocsf.answers = (move cim.answer).map(x => {
+} else if $event.cim.answer? != null {
+  $event.ocsf.answers = (move $event.cim.answer).map(x => {
     rdata: x,
-    type: ocsf.query.type?,
+    type: $event.ocsf.query.type?,
   })
 }
 
-ocsf.rcode_id = move cim.reply_code_id?
-ocsf.rcode = move cim.reply_code?
-if ocsf.rcode_id == null {
-  match ocsf.rcode {
+$event.ocsf.rcode_id = move $event.cim.reply_code_id?
+$event.ocsf.rcode = move $event.cim.reply_code?
+if $event.ocsf.rcode_id == null {
+  match $event.ocsf.rcode {
     "No Error" => {
-      ocsf.rcode_id = 0
+      $event.ocsf.rcode_id = 0
     }
     "NoError" => {
-      ocsf.rcode_id = 0
+      $event.ocsf.rcode_id = 0
     }
     "Format Error" => {
-      ocsf.rcode_id = 1
+      $event.ocsf.rcode_id = 1
     }
     "Server Failure" => {
-      ocsf.rcode_id = 2
+      $event.ocsf.rcode_id = 2
     }
     "Non-Existent Domain" => {
-      ocsf.rcode_id = 3
+      $event.ocsf.rcode_id = 3
     }
     "NXDomain" => {
-      ocsf.rcode_id = 3
+      $event.ocsf.rcode_id = 3
     }
     "Not Implemented" => {
-      ocsf.rcode_id = 4
+      $event.ocsf.rcode_id = 4
     }
     "Query Refused" => {
-      ocsf.rcode_id = 5
+      $event.ocsf.rcode_id = 5
     }
     _ => {}
   }
 }
 
-match ocsf.rcode_id {
+match $event.ocsf.rcode_id {
   0 => {
-    ocsf.rcode = "NoError"
+    $event.ocsf.rcode = "NoError"
   }
   1 => {
-    ocsf.rcode = "FormError"
+    $event.ocsf.rcode = "FormError"
   }
   2 => {
-    ocsf.rcode = "ServError"
+    $event.ocsf.rcode = "ServError"
   }
   3 => {
-    ocsf.rcode = "NXDomain"
+    $event.ocsf.rcode = "NXDomain"
   }
   4 => {
-    ocsf.rcode = "NotImp"
+    $event.ocsf.rcode = "NotImp"
   }
   5 => {
-    ocsf.rcode = "Refused"
+    $event.ocsf.rcode = "Refused"
   }
   6 => {
-    ocsf.rcode = "YXDomain"
+    $event.ocsf.rcode = "YXDomain"
   }
   7 => {
-    ocsf.rcode = "YXRRSet"
+    $event.ocsf.rcode = "YXRRSet"
   }
   8 => {
-    ocsf.rcode = "NXRRSet"
+    $event.ocsf.rcode = "NXRRSet"
   }
   9 => {
-    ocsf.rcode = "NotAuth"
+    $event.ocsf.rcode = "NotAuth"
   }
   10 => {
-    ocsf.rcode = "NotZone"
+    $event.ocsf.rcode = "NotZone"
   }
   11 => {
-    ocsf.rcode = "DSOTYPENI"
+    $event.ocsf.rcode = "DSOTYPENI"
   }
   16 => {
-    ocsf.rcode = "BADSIG_VERS"
+    $event.ocsf.rcode = "BADSIG_VERS"
   }
   17 => {
-    ocsf.rcode = "BADKEY"
+    $event.ocsf.rcode = "BADKEY"
   }
   18 => {
-    ocsf.rcode = "BADTIME"
+    $event.ocsf.rcode = "BADTIME"
   }
   19 => {
-    ocsf.rcode = "BADMODE"
+    $event.ocsf.rcode = "BADMODE"
   }
   20 => {
-    ocsf.rcode = "BADNAME"
+    $event.ocsf.rcode = "BADNAME"
   }
   21 => {
-    ocsf.rcode = "BADALG"
+    $event.ocsf.rcode = "BADALG"
   }
   22 => {
-    ocsf.rcode = "BADTRUNC"
+    $event.ocsf.rcode = "BADTRUNC"
   }
   23 => {
-    ocsf.rcode = "BADCOOKIE"
+    $event.ocsf.rcode = "BADCOOKIE"
   }
   24 => {
-    ocsf.rcode = "Unassigned"
+    $event.ocsf.rcode = "Unassigned"
   }
   25 => {
-    ocsf.rcode = "Reserved"
+    $event.ocsf.rcode = "Reserved"
   }
   _ => {}
 }
 
-match ocsf.rcode_id {
+match $event.ocsf.rcode_id {
   null => {
-    ocsf.status_id = 0
+    $event.ocsf.status_id = 0
   }
   0 => {
-    ocsf.status_id = 1
+    $event.ocsf.status_id = 1
   }
   _ => {
-    ocsf.status_id = 2
+    $event.ocsf.status_id = 2
   }
 }
 
 // --- OCSF: endpoint attributes ----------------
 
-ocsf.src_endpoint = {
-  ip: move cim.src_ip?,
-  port: move cim.src_port?,
+$event.ocsf.src_endpoint = {
+  ip: move $event.cim.src_ip?,
+  port: move $event.cim.src_port?,
 }
 
-ocsf.dst_endpoint = {
-  ip: move cim.dest_ip?,
-  port: move cim.dest_port?,
+$event.ocsf.dst_endpoint = {
+  ip: move $event.cim.dest_ip?,
+  port: move $event.cim.dest_port?,
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.dns_activity"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/email_activity.tql
+++ b/splunk/operators/ocsf/cim/email_activity.tql
@@ -1,74 +1,77 @@
 ---
 description: Splunk CIM Email → OCSF Email Activity (4009)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "send" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "receive" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "scan" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "trace" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   "mta_relay" => {
-    ocsf.activity_id = 5
+    $event.ocsf.activity_id = 5
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 4
-ocsf.class_uid = 4009
-splunk::ocsf::cim::helpers::common
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4009
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: occurrence and email attributes ----
 
-if cim.duration? != null {
-  ocsf.duration = (move cim.duration).seconds().count_milliseconds().round()
+if $event.cim.duration? != null {
+  $event.ocsf.duration = (move $event.cim.duration).seconds().count_milliseconds().round()
 }
-ocsf.email = {
+$event.ocsf.email = {
   files: [],
-  from: move cim.src_user?,
-  message_uid: move cim.message_id?,
-  return_path: move cim.return_addr?,
-  size: move cim.size?,
-  subject: move cim.subject?,
-  to: move cim.recipient?,
-  uid: move cim.xref?,
+  from: move $event.cim.src_user?,
+  message_uid: move $event.cim.message_id?,
+  return_path: move $event.cim.return_addr?,
+  size: move $event.cim.size?,
+  subject: move $event.cim.subject?,
+  to: move $event.cim.recipient?,
+  uid: move $event.cim.xref?,
 }
-ocsf.message = move cim.message_info?
-ocsf.message_trace_uid = move cim.internal_message_id?
-ocsf.protocol_name = move cim.protocol?
-ocsf.status_code = move cim.status_code?
-if cim.url? != null {
-  ocsf.email.urls = (move cim.url).map(u => {
+$event.ocsf.message = move $event.cim.message_info?
+$event.ocsf.message_trace_uid = move $event.cim.internal_message_id?
+$event.ocsf.protocol_name = move $event.cim.protocol?
+$event.ocsf.status_code = move $event.cim.status_code?
+if $event.cim.url? != null {
+  $event.ocsf.email.urls = (move $event.cim.url).map(u => {
     url_string: u,
   })
 }
-if cim.file_name? != null {
-  ocsf.email.files = zip(move cim.file_name, [...move cim.file_size?]).map(x => {
+if $event.cim.file_name? != null {
+  $event.ocsf.email.files = zip(move $event.cim.file_name, [...move $event.cim.file_size?]).map(x => {
     name: x.left,
     size: x.right,
   })
 }
-ocsf.src_endpoint = {
-  hostname: move cim.src?,
+$event.ocsf.src_endpoint = {
+  hostname: move $event.cim.src?,
 }
-ocsf.dst_endpoint = {
-  hostname: move cim.dest?,
+$event.ocsf.dst_endpoint = {
+  hostname: move $event.cim.dest?,
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.email_activity"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/entity_management.tql
+++ b/splunk/operators/ocsf/cim/entity_management.tql
@@ -1,98 +1,101 @@
 ---
 description: Splunk CIM Change → OCSF Entity Management (3004)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "create" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "read" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "update" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "delete" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   "move" | "rename" => {
-    ocsf.activity_id = 5
+    $event.ocsf.activity_id = 5
   }
   "enroll" => {
-    ocsf.activity_id = 6
+    $event.ocsf.activity_id = 6
   }
   "unenroll" => {
-    ocsf.activity_id = 7
+    $event.ocsf.activity_id = 7
   }
   "enable" => {
-    ocsf.activity_id = 8
+    $event.ocsf.activity_id = 8
   }
   "disable" => {
-    ocsf.activity_id = 9
+    $event.ocsf.activity_id = 9
   }
   "activate" => {
-    ocsf.activity_id = 10
+    $event.ocsf.activity_id = 10
   }
   "deactivate" => {
-    ocsf.activity_id = 11
+    $event.ocsf.activity_id = 11
   }
   "suspend" => {
-    ocsf.activity_id = 12
+    $event.ocsf.activity_id = 12
   }
   "resume" => {
-    ocsf.activity_id = 13
+    $event.ocsf.activity_id = 13
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 3
-ocsf.class_uid = 3004
-splunk::ocsf::cim::helpers::common
-splunk::ocsf::cim::helpers::status
+$event.ocsf.category_uid = 3
+$event.ocsf.class_uid = 3004
+splunk::ocsf::cim::helpers::common event=$event
+splunk::ocsf::cim::helpers::status event=$event
 
 // --- OCSF: entity attributes ------------------
 
-ocsf.entity = {
-  name: move cim.object?,
-  type: move cim.object_category?,
-  uid: move cim.object_id?,
+$event.ocsf.entity = {
+  name: move $event.cim.object?,
+  type: move $event.cim.object_category?,
+  uid: move $event.cim.object_id?,
 }
-ocsf.comment = move cim.command?
-ocsf.actor = {
+$event.ocsf.comment = move $event.cim.command?
+$event.ocsf.actor = {
   user: {
-    name: move cim.user_name? else move cim.user?,
-    type: move cim.user_type?,
+    name: move $event.cim.user_name? else move $event.cim.user?,
+    type: move $event.cim.user_type?,
   },
 }
-ocsf.src_endpoint = {
-  hostname: move cim.src?,
+$event.ocsf.src_endpoint = {
+  hostname: move $event.cim.src?,
 }
-if cim.dvc? != null {
-  ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "host"]
-  ocsf.device = {
-    hostname: move cim.dvc,
+if $event.cim.dvc? != null {
+  $event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "host"]
+  $event.ocsf.device = {
+    hostname: move $event.cim.dvc,
   }
 }
-ocsf.http_request = {
-  user_agent: move cim.user_agent?,
+$event.ocsf.http_request = {
+  user_agent: move $event.cim.user_agent?,
 }
-if cim.vendor_account? != null or cim.vendor_region? != null {
-  ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "cloud"]
-  ocsf.cloud = {
+if $event.cim.vendor_account? != null or $event.cim.vendor_region? != null {
+  $event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "cloud"]
+  $event.ocsf.cloud = {
     account: {
-      uid: move cim.vendor_account?,
+      uid: move $event.cim.vendor_account?,
     },
-    region: move cim.vendor_region?,
+    region: move $event.cim.vendor_region?,
   }
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.entity_management"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/event_log_activity.tql
+++ b/splunk/operators/ocsf/cim/event_log_activity.tql
@@ -1,78 +1,81 @@
 ---
 description: Splunk CIM Change Auditing Changes → OCSF Event Log Activity (1008)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "clear" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "delete" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "export" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "archive" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   "rotate" => {
-    ocsf.activity_id = 5
+    $event.ocsf.activity_id = 5
   }
   "start" => {
-    ocsf.activity_id = 6
+    $event.ocsf.activity_id = 6
   }
   "stop" => {
-    ocsf.activity_id = 7
+    $event.ocsf.activity_id = 7
   }
   "restart" => {
-    ocsf.activity_id = 8
+    $event.ocsf.activity_id = 8
   }
   "enable" => {
-    ocsf.activity_id = 9
+    $event.ocsf.activity_id = 9
   }
   "disable" => {
-    ocsf.activity_id = 10
+    $event.ocsf.activity_id = 10
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 1
-ocsf.class_uid = 1008
-splunk::ocsf::cim::helpers::common
-splunk::ocsf::cim::helpers::status
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1008
+splunk::ocsf::cim::helpers::common event=$event
+splunk::ocsf::cim::helpers::status event=$event
 
 // --- OCSF: event log attributes ---------------
 
-ocsf.log_name = move cim.object?
-ocsf.log_provider = move cim.command?
-ocsf.log_type = move cim.object_category?
-ocsf.file = {
-  path: move cim.object_path?,
-  uid: move cim.object_id?,
+$event.ocsf.log_name = move $event.cim.object?
+$event.ocsf.log_provider = move $event.cim.command?
+$event.ocsf.log_type = move $event.cim.object_category?
+$event.ocsf.file = {
+  path: move $event.cim.object_path?,
+  uid: move $event.cim.object_id?,
 }
-ocsf.actor = {
+$event.ocsf.actor = {
   user: {
-    name: move cim.user?,
-    type: move cim.user_type?,
+    name: move $event.cim.user?,
+    type: move $event.cim.user_type?,
   },
 }
-ocsf.src_endpoint = {
-  hostname: move cim.src?,
+$event.ocsf.src_endpoint = {
+  hostname: move $event.cim.src?,
 }
-ocsf.dst_endpoint = {
-  hostname: move cim.dest?,
+$event.ocsf.dst_endpoint = {
+  hostname: move $event.cim.dest?,
 }
-ocsf.device = {
-  hostname: move cim.dvc?,
+$event.ocsf.device = {
+  hostname: move $event.cim.dvc?,
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.event_log_activity"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/file_activity.tql
+++ b/splunk/operators/ocsf/cim/file_activity.tql
@@ -1,126 +1,129 @@
 ---
 description: Splunk CIM Endpoint Filesystem → OCSF File System Activity (1001)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "create" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "read" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "update" | "write" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "delete" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   "rename" => {
-    ocsf.activity_id = 5
+    $event.ocsf.activity_id = 5
   }
   "set_attributes" => {
-    ocsf.activity_id = 6
+    $event.ocsf.activity_id = 6
   }
   "set_security" => {
-    ocsf.activity_id = 7
+    $event.ocsf.activity_id = 7
   }
   "get_attributes" => {
-    ocsf.activity_id = 8
+    $event.ocsf.activity_id = 8
   }
   "get_security" => {
-    ocsf.activity_id = 9
+    $event.ocsf.activity_id = 9
   }
   "encrypt" => {
-    ocsf.activity_id = 10
+    $event.ocsf.activity_id = 10
   }
   "decrypt" => {
-    ocsf.activity_id = 11
+    $event.ocsf.activity_id = 11
   }
   "mount" => {
-    ocsf.activity_id = 12
+    $event.ocsf.activity_id = 12
   }
   "unmount" => {
-    ocsf.activity_id = 13
+    $event.ocsf.activity_id = 13
   }
   "open" => {
-    ocsf.activity_id = 14
+    $event.ocsf.activity_id = 14
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 1
-ocsf.class_uid = 1001
-splunk::ocsf::cim::helpers::common
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1001
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: primary file attributes -----------
 
-ocsf.file = {
-  accessed_time: move cim.file_access_time?,
-  created_time: move cim.file_create_time?,
-  modified_time: move cim.file_modify_time?,
-  name: move cim.file_name?,
-  path: move cim.file_path?,
-  security_descriptor: move cim.file_acl?,
+$event.ocsf.file = {
+  accessed_time: move $event.cim.file_access_time?,
+  created_time: move $event.cim.file_create_time?,
+  modified_time: move $event.cim.file_modify_time?,
+  name: move $event.cim.file_name?,
+  path: move $event.cim.file_path?,
+  security_descriptor: move $event.cim.file_acl?,
 }
-if cim.file_size? != null {
-  ocsf.file.size = int((move cim.file_size) * 1024)
+if $event.cim.file_size? != null {
+  $event.ocsf.file.size = int((move $event.cim.file_size) * 1024)
 }
-if cim.file_hash? != null {
-  ocsf.file.hashes = (move cim.file_hash).map(h => {
+if $event.cim.file_hash? != null {
+  $event.ocsf.file.hashes = (move $event.cim.file_hash).map(h => {
     value: h,
   })
 }
 
 // --- OCSF: actor and device attributes --------
 
-ocsf.actor = {
+$event.ocsf.actor = {
   process: {
-    cmd_line: move cim.process?,
+    cmd_line: move $event.cim.process?,
     file: {
-      name: move cim.process_exec?,
-      path: move cim.process_path?,
+      name: move $event.cim.process_exec?,
+      path: move $event.cim.process_path?,
     },
-    name: move cim.process_name?,
-    pid: move cim.process_id?,
-    uid: move cim.process_guid?,
+    name: move $event.cim.process_name?,
+    pid: move $event.cim.process_id?,
+    uid: move $event.cim.process_guid?,
   },
   user: {
-    name: move cim.user?,
+    name: move $event.cim.user?,
   },
 }
-if cim.process_hash? != null {
-  ocsf.actor.process.file.hashes = (move cim.process_hash).map(h => {
+if $event.cim.process_hash? != null {
+  $event.ocsf.actor.process.file.hashes = (move $event.cim.process_hash).map(h => {
     value: h,
   })
 }
-if cim.parent_process? != null or cim.parent_process_name? != null {
-  ocsf.actor.process.parent_process = {
-    cmd_line: move cim.parent_process?,
+if $event.cim.parent_process? != null or $event.cim.parent_process_name? != null {
+  $event.ocsf.actor.process.parent_process = {
+    cmd_line: move $event.cim.parent_process?,
     file: {
-      name: move cim.parent_process_exec?,
-      path: move cim.parent_process_path?,
+      name: move $event.cim.parent_process_exec?,
+      path: move $event.cim.parent_process_path?,
     },
-    name: move cim.parent_process_name?,
-    pid: move cim.parent_process_id?,
-    uid: move cim.parent_process_guid?,
+    name: move $event.cim.parent_process_name?,
+    pid: move $event.cim.parent_process_id?,
+    uid: move $event.cim.parent_process_guid?,
   }
-  if cim.parent_process_hash? != null {
-    ocsf.actor.process.parent_process.file.hashes = (move cim.parent_process_hash).map(h => {
+  if $event.cim.parent_process_hash? != null {
+    $event.ocsf.actor.process.parent_process.file.hashes = (move $event.cim.parent_process_hash).map(h => {
       value: h,
     })
   }
 }
-ocsf.device = {
-  hostname: move cim.dest?,
+$event.ocsf.device = {
+  hostname: move $event.cim.dest?,
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.file_activity"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/file_hosting.tql
+++ b/splunk/operators/ocsf/cim/file_hosting.tql
@@ -1,120 +1,123 @@
 ---
 description: Splunk CIM Data Access → OCSF File Hosting Activity (6006)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "upload" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "download" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "update" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "delete" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   "rename" => {
-    ocsf.activity_id = 5
+    $event.ocsf.activity_id = 5
   }
   "copy" => {
-    ocsf.activity_id = 6
+    $event.ocsf.activity_id = 6
   }
   "move" => {
-    ocsf.activity_id = 7
+    $event.ocsf.activity_id = 7
   }
   "restore" => {
-    ocsf.activity_id = 8
+    $event.ocsf.activity_id = 8
   }
   "preview" => {
-    ocsf.activity_id = 9
+    $event.ocsf.activity_id = 9
   }
   "lock" => {
-    ocsf.activity_id = 10
+    $event.ocsf.activity_id = 10
   }
   "unlock" => {
-    ocsf.activity_id = 11
+    $event.ocsf.activity_id = 11
   }
   "share" => {
-    ocsf.activity_id = 12
+    $event.ocsf.activity_id = 12
   }
   "unshare" => {
-    ocsf.activity_id = 13
+    $event.ocsf.activity_id = 13
   }
   "open" => {
-    ocsf.activity_id = 14
+    $event.ocsf.activity_id = 14
   }
   "sync" => {
-    ocsf.activity_id = 15
+    $event.ocsf.activity_id = 15
   }
   "unsync" => {
-    ocsf.activity_id = 16
+    $event.ocsf.activity_id = 16
   }
   "access_check" => {
-    ocsf.activity_id = 17
+    $event.ocsf.activity_id = 17
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 6
-ocsf.class_uid = 6006
-splunk::ocsf::cim::helpers::common
+$event.ocsf.category_uid = 6
+$event.ocsf.class_uid = 6006
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: file attributes --------------------
 
-ocsf.file = {
-  name: move cim.object?,
-  size: move cim.object_size?,
-  type: move cim.object_category?,
-  uid: move cim.object_id?,
+$event.ocsf.file = {
+  name: move $event.cim.object?,
+  size: move $event.cim.object_size?,
+  type: move $event.cim.object_category?,
+  uid: move $event.cim.object_id?,
   url: {
-    url_string: move cim.dest_url?,
+    url_string: move $event.cim.dest_url?,
   },
-  path: move cim.object_path?,
+  path: move $event.cim.object_path?,
 }
-ocsf.share = move cim.parent_object?
-ocsf.share_type = move cim.parent_object_category?
-ocsf.http_request = {
-  user_agent: move cim.user_agent?,
+$event.ocsf.share = move $event.cim.parent_object?
+$event.ocsf.share_type = move $event.cim.parent_object_category?
+$event.ocsf.http_request = {
+  user_agent: move $event.cim.user_agent?,
 }
-ocsf.src_endpoint = {
-  ip: move cim.src?,
+$event.ocsf.src_endpoint = {
+  ip: move $event.cim.src?,
 }
-ocsf.dst_endpoint = {
-  hostname: move cim.dest?,
+$event.ocsf.dst_endpoint = {
+  hostname: move $event.cim.dest?,
 }
-ocsf.actor = {
-  app_name: move cim.app?,
+$event.ocsf.actor = {
+  app_name: move $event.cim.app?,
   user: {
-    name: move cim.user_name? else move cim.user?,
-    type: move cim.user_type? else move cim.user_role?,
-    uid: move cim.user_id?,
+    name: move $event.cim.user_name? else move $event.cim.user?,
+    type: move $event.cim.user_type? else move $event.cim.user_role?,
+    uid: move $event.cim.user_id?,
   },
 }
-if cim.dvc? != null {
-  ocsf.metadata.profiles = ["host"]
-  ocsf.device = {
-    hostname: move cim.dvc,
+if $event.cim.dvc? != null {
+  $event.ocsf.metadata.profiles = ["host"]
+  $event.ocsf.device = {
+    hostname: move $event.cim.dvc,
   }
 }
-if cim.vendor_account? != null or cim.vendor_region? != null {
-  ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "cloud"]
-  ocsf.cloud = {
+if $event.cim.vendor_account? != null or $event.cim.vendor_region? != null {
+  $event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "cloud"]
+  $event.ocsf.cloud = {
     account: {
-      uid: move cim.vendor_account?,
+      uid: move $event.cim.vendor_account?,
     },
-    region: move cim.vendor_region?,
+    region: move $event.cim.vendor_region?,
   }
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.file_hosting"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/group_management.tql
+++ b/splunk/operators/ocsf/cim/group_management.tql
@@ -1,87 +1,90 @@
 ---
 description: Splunk CIM Change Account Management → OCSF Group Management (3006)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "assign_privileges" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "revoke_privileges" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "add_user" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "remove_user" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   "delete" => {
-    ocsf.activity_id = 5
+    $event.ocsf.activity_id = 5
   }
   "create" => {
-    ocsf.activity_id = 6
+    $event.ocsf.activity_id = 6
   }
   "add_subgroup" => {
-    ocsf.activity_id = 7
+    $event.ocsf.activity_id = 7
   }
   "remove_subgroup" => {
-    ocsf.activity_id = 8
+    $event.ocsf.activity_id = 8
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 3
-ocsf.class_uid = 3006
-splunk::ocsf::cim::helpers::common
-splunk::ocsf::cim::helpers::status
+$event.ocsf.category_uid = 3
+$event.ocsf.class_uid = 3006
+splunk::ocsf::cim::helpers::common event=$event
+splunk::ocsf::cim::helpers::status event=$event
 
 // --- OCSF: group attributes -------------------
 
-ocsf.group = {
-  name: move cim.object?,
-  type: move cim.object_category?,
-  uid: move cim.object_id?,
+$event.ocsf.group = {
+  name: move $event.cim.object?,
+  type: move $event.cim.object_category?,
+  uid: move $event.cim.object_id?,
 }
-ocsf.privileges = move cim.object_attrs?
-ocsf.user = {
-  name: move cim.user_name? else move cim.user?,
-  type: move cim.user_type?,
+$event.ocsf.privileges = move $event.cim.object_attrs?
+$event.ocsf.user = {
+  name: move $event.cim.user_name? else move $event.cim.user?,
+  type: move $event.cim.user_type?,
 }
-ocsf.actor = {
+$event.ocsf.actor = {
   user: {
-    name: move cim.src_user_name? else move cim.src_user?,
-    type: move cim.src_user_type?,
+    name: move $event.cim.src_user_name? else move $event.cim.src_user?,
+    type: move $event.cim.src_user_type?,
   },
 }
-ocsf.src_endpoint = {
-  hostname: move cim.src?,
+$event.ocsf.src_endpoint = {
+  hostname: move $event.cim.src?,
 }
-if cim.dvc? != null {
-  ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "host"]
-  ocsf.device = {
-    hostname: move cim.dvc,
+if $event.cim.dvc? != null {
+  $event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "host"]
+  $event.ocsf.device = {
+    hostname: move $event.cim.dvc,
   }
 }
-ocsf.http_request = {
-  user_agent: move cim.user_agent?,
+$event.ocsf.http_request = {
+  user_agent: move $event.cim.user_agent?,
 }
-if cim.vendor_account? != null or cim.vendor_region? != null {
-  ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "cloud"]
-  ocsf.cloud = {
+if $event.cim.vendor_account? != null or $event.cim.vendor_region? != null {
+  $event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "cloud"]
+  $event.ocsf.cloud = {
     account: {
-      uid: move cim.vendor_account?,
+      uid: move $event.cim.vendor_account?,
     },
-    region: move cim.vendor_region?,
+    region: move $event.cim.vendor_region?,
   }
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.group_management"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/helpers/common.tql
+++ b/splunk/operators/ocsf/cim/helpers/common.tql
@@ -1,8 +1,13 @@
 ---
 description: Common Splunk CIM → OCSF base attributes
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-ocsf.time = move cim._time?
+$event.ocsf.time = move $event.cim._time?
 
 let $severity_ids = {
   "0": 0,
@@ -23,23 +28,23 @@ let $severity_names = {
   "critical": 5,
   "fatal": 6,
 }
-if ocsf.severity_id? == null {
-  if cim.severity_id? != null {
-    ocsf.severity_id = $severity_ids[(move cim.severity_id).string()]? else 1
-  } else if cim.severity? != null {
-    ocsf.severity = move cim.severity
-    ocsf.severity_id = $severity_names[ocsf.severity.to_lower()]? else 1
+if $event.ocsf.severity_id? == null {
+  if $event.cim.severity_id? != null {
+    $event.ocsf.severity_id = $severity_ids[(move $event.cim.severity_id).string()]? else 1
+  } else if $event.cim.severity? != null {
+    $event.ocsf.severity = move $event.cim.severity
+    $event.ocsf.severity_id = $severity_names[$event.ocsf.severity.to_lower()]? else 1
   } else {
-    ocsf.severity_id = 1
+    $event.ocsf.severity_id = 1
   }
 }
 
-ocsf.metadata = {
+$event.ocsf.metadata = {
   product: {
-    name: move cim.product? else move cim.vendor_product? else "Splunk CIM",
-    vendor_name: move cim.vendor?,
+    name: move $event.cim.product? else move $event.cim.vendor_product? else "Splunk CIM",
+    vendor_name: move $event.cim.vendor?,
   },
   version: "1.8.0",
 }
 
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id

--- a/splunk/operators/ocsf/cim/helpers/status.tql
+++ b/splunk/operators/ocsf/cim/helpers/status.tql
@@ -1,23 +1,28 @@
 ---
 description: Common Splunk CIM status/result fields → OCSF status attributes
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-if ocsf.status_id? == null {
-  match cim.status?.to_lower() {
+if $event.ocsf.status_id? == null {
+  match $event.cim.status?.to_lower() {
     "success" | "successful" => {
-      ocsf.status_id = 1
+      $event.ocsf.status_id = 1
     }
     "failure" | "failed" | "error" => {
-      ocsf.status_id = 2
+      $event.ocsf.status_id = 2
     }
     "unknown" => {
-      ocsf.status_id = 0
+      $event.ocsf.status_id = 0
     }
     _ => {
-      ocsf.status_id = 0
+      $event.ocsf.status_id = 0
     }
   }
 }
 
-ocsf.status_detail = move cim.reason? else move cim.result?
-ocsf.status_code = move cim.reason_id? else move cim.result_id?
+$event.ocsf.status_detail = move $event.cim.reason? else move $event.cim.result?
+$event.ocsf.status_code = move $event.cim.reason_id? else move $event.cim.result_id?

--- a/splunk/operators/ocsf/cim/http_activity.tql
+++ b/splunk/operators/ocsf/cim/http_activity.tql
@@ -1,92 +1,95 @@
 ---
 description: Splunk CIM Web → OCSF HTTP Activity (4002)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.http_method?.to_upper() {
+match $event.cim.http_method?.to_upper() {
   "CONNECT" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "DELETE" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "GET" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "HEAD" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   "OPTIONS" => {
-    ocsf.activity_id = 5
+    $event.ocsf.activity_id = 5
   }
   "POST" => {
-    ocsf.activity_id = 6
+    $event.ocsf.activity_id = 6
   }
   "PUT" => {
-    ocsf.activity_id = 7
+    $event.ocsf.activity_id = 7
   }
   "TRACE" => {
-    ocsf.activity_id = 8
+    $event.ocsf.activity_id = 8
   }
   "PATCH" => {
-    ocsf.activity_id = 9
+    $event.ocsf.activity_id = 9
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 4
-ocsf.class_uid = 4002
-splunk::ocsf::cim::helpers::common
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4002
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: occurrence and HTTP attributes -----
 
-if cim.duration? != null {
-  ocsf.duration = (move cim.duration).seconds().count_milliseconds().round()
+if $event.cim.duration? != null {
+  $event.ocsf.duration = (move $event.cim.duration).seconds().count_milliseconds().round()
 }
-ocsf.http_request = {
-  http_method: move cim.http_method?,
-  referrer: move cim.http_referrer?,
-  user_agent: move cim.http_user_agent?,
+$event.ocsf.http_request = {
+  http_method: move $event.cim.http_method?,
+  referrer: move $event.cim.http_referrer?,
+  user_agent: move $event.cim.http_user_agent?,
   url: {
-    domain: move cim.url_domain?,
-    path: move cim.uri_path?,
-    query_string: move cim.uri_query?,
-    url_string: move cim.url?,
+    domain: move $event.cim.url_domain?,
+    path: move $event.cim.uri_path?,
+    query_string: move $event.cim.uri_query?,
+    url_string: move $event.cim.url?,
   },
 }
-ocsf.http_response = {
-  code: int(move cim.status?),
-  content_type: move cim.http_content_type?,
-  latency: move cim.response_time?,
-  length: move cim.bytes_out?,
+$event.ocsf.http_response = {
+  code: int(move $event.cim.status?),
+  content_type: move $event.cim.http_content_type?,
+  latency: move $event.cim.response_time?,
+  length: move $event.cim.bytes_out?,
 }
-ocsf.traffic = {
-  bytes: move cim.bytes?,
-  bytes_in: move cim.bytes_in?,
+$event.ocsf.traffic = {
+  bytes: move $event.cim.bytes?,
+  bytes_in: move $event.cim.bytes_in?,
 }
 
 // --- OCSF: endpoint and user attributes -------
 
-ocsf.src_endpoint = {
-  ip: move cim.src_ip?,
+$event.ocsf.src_endpoint = {
+  ip: move $event.cim.src_ip?,
 }
-ocsf.dst_endpoint = {
-  ip: move cim.dest_ip?,
-  port: move cim.dest_port?,
+$event.ocsf.dst_endpoint = {
+  ip: move $event.cim.dest_ip?,
+  port: move $event.cim.dest_port?,
 }
-ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "host"]
-ocsf.actor = {
+$event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "host"]
+$event.ocsf.actor = {
   user: {
-    name: move cim.user?,
+    name: move $event.cim.user?,
   },
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.http_activity"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/map.tql
+++ b/splunk/operators/ocsf/cim/map.tql
@@ -56,3 +56,8 @@ if $event.cim.tag? != null {
     splunk::ocsf::cim::http_activity event=$event
   }
 }
+
+// Preserve pass-through behavior for non-CIM or unsupported CIM events.
+if $event.cim? != null and $event.ocsf? != null {
+  $event = $event.cim
+}

--- a/splunk/operators/ocsf/cim/map.tql
+++ b/splunk/operators/ocsf/cim/map.tql
@@ -1,51 +1,58 @@
 ---
 description: Splunk CIM → OCSF
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
+$event = {...$event, cim: $event, ocsf: {}}
 
-if tag? != null {
-  if "network" in tag and "resolution" in tag and "dns" in tag {
-    splunk::ocsf::cim::dns_activity
-  } else if "endpoint" in tag and "filesystem" in tag {
-    splunk::ocsf::cim::file_activity
-  } else if "process" in tag and "report" in tag {
-    splunk::ocsf::cim::process_activity
-  } else if "change" in tag and "audit" in tag {
-    splunk::ocsf::cim::event_log_activity
-  } else if "alert" in tag {
-    splunk::ocsf::cim::detection_finding
-  } else if "vulnerability" in tag and "report" in tag {
-    splunk::ocsf::cim::vulnerability_finding
-  } else if "authentication" in tag {
-    splunk::ocsf::cim::authentication
-  } else if "change" in tag and "account" in tag and object_category?.to_lower() == "group" {
-    splunk::ocsf::cim::group_management
-  } else if "change" in tag and "account" in tag and action? in ["assign_privileges", "revoke_privileges"] {
-    splunk::ocsf::cim::user_access
-  } else if "change" in tag and "account" in tag {
-    splunk::ocsf::cim::account_change
-  } else if "change" in tag {
-    splunk::ocsf::cim::entity_management
-  } else if "network" in tag and "session" in tag and "vpn" in tag {
-    splunk::ocsf::cim::tunnel_activity
-  } else if "network" in tag and "communicate" in tag {
-    splunk::ocsf::cim::network_activity
-  } else if "email" in tag {
-    splunk::ocsf::cim::email_activity
-  } else if "database" in tag {
-    splunk::ocsf::cim::datastore_activity
-  } else if "data" in tag and "access" in tag and object_category?.to_lower() == "api" {
-    splunk::ocsf::cim::api_activity
-  } else if "data" in tag and "access" in tag and (
-    object_size? != null or parent_object? != null or object_category?.to_lower() in ["file", "regular file", "folder"]
+if $event.cim.tag? != null {
+  if "network" in $event.cim.tag and "resolution" in $event.cim.tag and "dns" in $event.cim.tag {
+    splunk::ocsf::cim::dns_activity event=$event
+  } else if "endpoint" in $event.cim.tag and "filesystem" in $event.cim.tag {
+    splunk::ocsf::cim::file_activity event=$event
+  } else if "process" in $event.cim.tag and "report" in $event.cim.tag {
+    splunk::ocsf::cim::process_activity event=$event
+  } else if "change" in $event.cim.tag and "audit" in $event.cim.tag {
+    splunk::ocsf::cim::event_log_activity event=$event
+  } else if "alert" in $event.cim.tag {
+    splunk::ocsf::cim::detection_finding event=$event
+  } else if "vulnerability" in $event.cim.tag and "report" in $event.cim.tag {
+    splunk::ocsf::cim::vulnerability_finding event=$event
+  } else if "authentication" in $event.cim.tag {
+    splunk::ocsf::cim::authentication event=$event
+  } else if "change" in $event.cim.tag and "account" in $event.cim.tag and $event.cim.object_category?.to_lower() == "group" {
+    splunk::ocsf::cim::group_management event=$event
+  } else if "change" in $event.cim.tag and "account" in $event.cim.tag and $event.cim.action? in ["assign_privileges", "revoke_privileges"] {
+    splunk::ocsf::cim::user_access event=$event
+  } else if "change" in $event.cim.tag and "account" in $event.cim.tag {
+    splunk::ocsf::cim::account_change event=$event
+  } else if "change" in $event.cim.tag {
+    splunk::ocsf::cim::entity_management event=$event
+  } else if "network" in $event.cim.tag and "session" in $event.cim.tag and "vpn" in $event.cim.tag {
+    splunk::ocsf::cim::tunnel_activity event=$event
+  } else if "network" in $event.cim.tag and "communicate" in $event.cim.tag {
+    splunk::ocsf::cim::network_activity event=$event
+  } else if "email" in $event.cim.tag {
+    splunk::ocsf::cim::email_activity event=$event
+  } else if "database" in $event.cim.tag {
+    splunk::ocsf::cim::datastore_activity event=$event
+  } else if "data" in $event.cim.tag and "access" in $event.cim.tag and $event.cim.object_category?.to_lower() == "api" {
+    splunk::ocsf::cim::api_activity event=$event
+  } else if "data" in $event.cim.tag and "access" in $event.cim.tag and (
+    $event.cim.object_size? != null or $event.cim.parent_object? != null or $event.cim.object_category?.to_lower() in ["file", "regular file", "folder"]
   ) {
-    splunk::ocsf::cim::file_hosting
-  } else if "data" in tag and "access" in tag {
-    splunk::ocsf::cim::api_activity
-  } else if "web" in tag and action? in ["access_grant", "access_deny", "access_revoke", "access_error"] {
-    splunk::ocsf::cim::web_resource_access_activity
-  } else if "web" in tag and action? in ["create", "read", "update", "delete", "search", "import", "export", "share"] {
-    splunk::ocsf::cim::web_resources_activity
-  } else if "web" in tag {
-    splunk::ocsf::cim::http_activity
+    splunk::ocsf::cim::file_hosting event=$event
+  } else if "data" in $event.cim.tag and "access" in $event.cim.tag {
+    splunk::ocsf::cim::api_activity event=$event
+  } else if "web" in $event.cim.tag and $event.cim.action? in ["access_grant", "access_deny", "access_revoke", "access_error"] {
+    splunk::ocsf::cim::web_resource_access_activity event=$event
+  } else if "web" in $event.cim.tag and $event.cim.action? in ["create", "read", "update", "delete", "search", "import", "export", "share"] {
+    splunk::ocsf::cim::web_resources_activity event=$event
+  } else if "web" in $event.cim.tag {
+    splunk::ocsf::cim::http_activity event=$event
   }
 }

--- a/splunk/operators/ocsf/cim/network_activity.tql
+++ b/splunk/operators/ocsf/cim/network_activity.tql
@@ -1,130 +1,133 @@
 ---
 description: Splunk CIM Network Traffic All Traffic → OCSF Network Activity (4001)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "open" | "allowed" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "close" | "closed" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "reset" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "fail" | "failure" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   "refuse" | "blocked" => {
-    ocsf.activity_id = 5
+    $event.ocsf.activity_id = 5
   }
   "traffic" | "observed" => {
-    ocsf.activity_id = 6
+    $event.ocsf.activity_id = 6
   }
   "listen" => {
-    ocsf.activity_id = 7
+    $event.ocsf.activity_id = 7
   }
   _ => {
-    ocsf.activity_id = 6
+    $event.ocsf.activity_id = 6
   }
 }
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
-splunk::ocsf::cim::helpers::common
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: traffic and connection attributes --
 
-if cim.duration? != null {
-  ocsf.duration = (move cim.duration).seconds().count_milliseconds().round()
+if $event.cim.duration? != null {
+  $event.ocsf.duration = (move $event.cim.duration).seconds().count_milliseconds().round()
 }
-ocsf.traffic = {
-  bytes: move cim.bytes?,
-  bytes_in: move cim.bytes_in?,
-  bytes_out: move cim.bytes_out?,
-  packets: move cim.packets?,
-  packets_in: move cim.packets_in?,
-  packets_out: move cim.packets_out?,
+$event.ocsf.traffic = {
+  bytes: move $event.cim.bytes?,
+  bytes_in: move $event.cim.bytes_in?,
+  bytes_out: move $event.cim.bytes_out?,
+  packets: move $event.cim.packets?,
+  packets_in: move $event.cim.packets_in?,
+  packets_out: move $event.cim.packets_out?,
 }
-ocsf.connection_info = {
-  community_uid: move cim.flow_id?,
-  protocol_name: move cim.transport? else move cim.protocol?,
-  protocol_ver: move cim.protocol_version?,
+$event.ocsf.connection_info = {
+  community_uid: move $event.cim.flow_id?,
+  protocol_name: move $event.cim.transport? else move $event.cim.protocol?,
+  protocol_ver: move $event.cim.protocol_version?,
   session: {
-    uid: move cim.session_id?,
+    uid: move $event.cim.session_id?,
   },
-  tcp_flags: move cim.tcp_flag?,
+  tcp_flags: move $event.cim.tcp_flag?,
 }
-match cim.direction?.to_lower() {
+match $event.cim.direction?.to_lower() {
   "inbound" => {
-    ocsf.connection_info.direction_id = 1
+    $event.ocsf.connection_info.direction_id = 1
   }
   "outbound" => {
-    ocsf.connection_info.direction_id = 2
+    $event.ocsf.connection_info.direction_id = 2
   }
   "lateral" => {
-    ocsf.connection_info.direction_id = 3
+    $event.ocsf.connection_info.direction_id = 3
   }
   "local" => {
-    ocsf.connection_info.direction_id = 4
+    $event.ocsf.connection_info.direction_id = 4
   }
   "unknown" => {
-    ocsf.connection_info.direction_id = 0
+    $event.ocsf.connection_info.direction_id = 0
   }
-  _ if cim.direction? != null => {
-    ocsf.connection_info.direction_id = 99
+  _ if $event.cim.direction? != null => {
+    $event.ocsf.connection_info.direction_id = 99
   }
   _ => {}
 }
-match ocsf.connection_info.protocol_name {
+match $event.ocsf.connection_info.protocol_name {
   "icmp" => {
-    ocsf.connection_info.protocol_num = 1
+    $event.ocsf.connection_info.protocol_num = 1
   }
   "tcp" => {
-    ocsf.connection_info.protocol_num = 6
+    $event.ocsf.connection_info.protocol_num = 6
   }
   "udp" => {
-    ocsf.connection_info.protocol_num = 17
+    $event.ocsf.connection_info.protocol_num = 17
   }
   _ => {}
 }
 
 // --- OCSF: endpoint attributes ----------------
 
-ocsf.src_endpoint = {
-  ip: move cim.src_ip?,
-  mac: move cim.src_mac?,
-  interface_name: move cim.src_interface?,
-  network_scope: move cim.src_zone?,
-  port: move cim.src_port?,
+$event.ocsf.src_endpoint = {
+  ip: move $event.cim.src_ip?,
+  mac: move $event.cim.src_mac?,
+  interface_name: move $event.cim.src_interface?,
+  network_scope: move $event.cim.src_zone?,
+  port: move $event.cim.src_port?,
   proxy_endpoint: {
-    ip: move cim.src_translated_ip?,
-    port: move cim.src_translated_port?,
+    ip: move $event.cim.src_translated_ip?,
+    port: move $event.cim.src_translated_port?,
   },
 }
-ocsf.dst_endpoint = {
-  ip: move cim.dest_ip?,
-  mac: move cim.dest_mac?,
-  interface_name: move cim.dest_interface?,
-  network_scope: move cim.dest_zone?,
-  port: move cim.dest_port?,
+$event.ocsf.dst_endpoint = {
+  ip: move $event.cim.dest_ip?,
+  mac: move $event.cim.dest_mac?,
+  interface_name: move $event.cim.dest_interface?,
+  network_scope: move $event.cim.dest_zone?,
+  port: move $event.cim.dest_port?,
   proxy_endpoint: {
-    ip: move cim.dest_translated_ip?,
-    port: move cim.dest_translated_port?,
+    ip: move $event.cim.dest_translated_ip?,
+    port: move $event.cim.dest_translated_port?,
   },
 }
-ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "host"]
-ocsf.device = {
-  hostname: move cim.dvc?,
-  ip: move cim.dvc_ip?,
-  mac: move cim.dvc_mac?,
+$event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "host"]
+$event.ocsf.device = {
+  hostname: move $event.cim.dvc?,
+  ip: move $event.cim.dvc_ip?,
+  mac: move $event.cim.dvc_mac?,
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.network_activity"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/process_activity.tql
+++ b/splunk/operators/ocsf/cim/process_activity.tql
@@ -1,113 +1,116 @@
 ---
 description: Splunk CIM Endpoint Processes → OCSF Process Activity (1007)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "launch" | "create" | "start" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "terminate" | "stop" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "open" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "inject" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   "set_user_id" => {
-    ocsf.activity_id = 5
+    $event.ocsf.activity_id = 5
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 1
-ocsf.class_uid = 1007
-splunk::ocsf::cim::helpers::common
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1007
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: process attributes -----------------
 
-ocsf.process = {
-  cmd_line: move cim.process?,
+$event.ocsf.process = {
+  cmd_line: move $event.cim.process?,
   file: {
-    name: move cim.process_exec?,
-    path: move cim.process_path?,
+    name: move $event.cim.process_exec?,
+    path: move $event.cim.process_path?,
   },
-  name: move cim.process_name?,
-  pid: move cim.process_id?,
-  uid: move cim.process_guid?,
+  name: move $event.cim.process_name?,
+  pid: move $event.cim.process_id?,
+  uid: move $event.cim.process_guid?,
   user: {
-    name: move cim.user?,
-    uid: move cim.user_id?,
+    name: move $event.cim.user?,
+    uid: move $event.cim.user_id?,
   },
-  working_directory: move cim.process_current_directory?,
+  working_directory: move $event.cim.process_current_directory?,
 }
-match cim.process_integrity_level?.to_lower() {
+match $event.cim.process_integrity_level?.to_lower() {
   "unknown" => {
-    ocsf.process.integrity_id = 0
+    $event.ocsf.process.integrity_id = 0
   }
   "untrusted" => {
-    ocsf.process.integrity_id = 1
+    $event.ocsf.process.integrity_id = 1
   }
   "low" => {
-    ocsf.process.integrity_id = 2
+    $event.ocsf.process.integrity_id = 2
   }
   "medium" => {
-    ocsf.process.integrity_id = 3
+    $event.ocsf.process.integrity_id = 3
   }
   "high" => {
-    ocsf.process.integrity_id = 4
+    $event.ocsf.process.integrity_id = 4
   }
   "system" => {
-    ocsf.process.integrity_id = 5
+    $event.ocsf.process.integrity_id = 5
   }
   "protected" => {
-    ocsf.process.integrity_id = 6
+    $event.ocsf.process.integrity_id = 6
   }
-  _ if cim.process_integrity_level? != null => {
-    ocsf.process.integrity_id = 99
+  _ if $event.cim.process_integrity_level? != null => {
+    $event.ocsf.process.integrity_id = 99
   }
   _ => {}
 }
-if cim.process_hash? != null {
-  ocsf.process.file.hashes = (move cim.process_hash).map(h => {
+if $event.cim.process_hash? != null {
+  $event.ocsf.process.file.hashes = (move $event.cim.process_hash).map(h => {
     value: h,
   })
 }
-if cim.parent_process? != null or cim.parent_process_name? != null {
-  ocsf.process.parent_process = {
-    cmd_line: move cim.parent_process?,
+if $event.cim.parent_process? != null or $event.cim.parent_process_name? != null {
+  $event.ocsf.process.parent_process = {
+    cmd_line: move $event.cim.parent_process?,
     file: {
-      name: move cim.parent_process_exec?,
-      path: move cim.parent_process_path?,
+      name: move $event.cim.parent_process_exec?,
+      path: move $event.cim.parent_process_path?,
     },
-    name: move cim.parent_process_name?,
-    pid: move cim.parent_process_id?,
-    uid: move cim.parent_process_guid?,
+    name: move $event.cim.parent_process_name?,
+    pid: move $event.cim.parent_process_id?,
+    uid: move $event.cim.parent_process_guid?,
     user: {
-      name: move cim.parent_user?,
+      name: move $event.cim.parent_user?,
     },
   }
-  if cim.parent_process_hash? != null {
-    ocsf.process.parent_process.file.hashes = (move cim.parent_process_hash).map(h => {
+  if $event.cim.parent_process_hash? != null {
+    $event.ocsf.process.parent_process.file.hashes = (move $event.cim.parent_process_hash).map(h => {
       value: h,
     })
   }
 }
-ocsf.device = {
-  hostname: move cim.dest?,
+$event.ocsf.device = {
+  hostname: move $event.cim.dest?,
   os: {
-    name: move cim.os?,
+    name: move $event.cim.os?,
   },
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.process_activity"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/tunnel_activity.tql
+++ b/splunk/operators/ocsf/cim/tunnel_activity.tql
@@ -1,61 +1,64 @@
 ---
 description: Splunk CIM Network Sessions VPN → OCSF Tunnel Activity (4014)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "started" | "open" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "ended" | "closed" | "close" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "renewed" | "renew" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "unknown" => {
-    ocsf.activity_id = 0
+    $event.ocsf.activity_id = 0
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 4
-ocsf.class_uid = 4014
-splunk::ocsf::cim::helpers::common
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4014
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: tunnel attributes ------------------
 
-if cim.duration? != null {
-  ocsf.duration = (move cim.duration).seconds().count_milliseconds().round()
+if $event.cim.duration? != null {
+  $event.ocsf.duration = (move $event.cim.duration).seconds().count_milliseconds().round()
 }
-ocsf.tunnel_type = move cim.signature?
-ocsf.tunnel_type_id = int(move cim.signature_id?)
-ocsf.src_endpoint = {
-  hostname: move cim.src_dns? else move cim.src_nt_host?,
-  ip: move cim.src_ip?,
-  mac: move cim.src_mac?,
+$event.ocsf.tunnel_type = move $event.cim.signature?
+$event.ocsf.tunnel_type_id = int(move $event.cim.signature_id?)
+$event.ocsf.src_endpoint = {
+  hostname: move $event.cim.src_dns? else move $event.cim.src_nt_host?,
+  ip: move $event.cim.src_ip?,
+  mac: move $event.cim.src_mac?,
 }
-ocsf.dst_endpoint = {
-  hostname: move cim.dest_dns? else move cim.dest_nt_host?,
-  ip: move cim.dest_ip?,
-  mac: move cim.dest_mac?,
+$event.ocsf.dst_endpoint = {
+  hostname: move $event.cim.dest_dns? else move $event.cim.dest_nt_host?,
+  ip: move $event.cim.dest_ip?,
+  mac: move $event.cim.dest_mac?,
 }
-if cim.dvc? != null {
-  ocsf.metadata.profiles = ["host"]
-  ocsf.device = {
-    hostname: move cim.dvc,
+if $event.cim.dvc? != null {
+  $event.ocsf.metadata.profiles = ["host"]
+  $event.ocsf.device = {
+    hostname: move $event.cim.dvc,
   }
 }
-ocsf.user = {
-  name: move cim.user?,
+$event.ocsf.user = {
+  name: move $event.cim.user?,
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.tunnel_activity"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/user_access.tql
+++ b/splunk/operators/ocsf/cim/user_access.tql
@@ -1,69 +1,72 @@
 ---
 description: Splunk CIM Change Account Management → OCSF User Access Management (3005)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "assign_privileges" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "revoke_privileges" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 3
-ocsf.class_uid = 3005
-splunk::ocsf::cim::helpers::common
-splunk::ocsf::cim::helpers::status
+$event.ocsf.category_uid = 3
+$event.ocsf.class_uid = 3005
+splunk::ocsf::cim::helpers::common event=$event
+splunk::ocsf::cim::helpers::status event=$event
 
 // --- OCSF: access attributes ------------------
 
-ocsf.user = {
-  name: move cim.user_name? else move cim.user?,
-  type: move cim.user_type?,
+$event.ocsf.user = {
+  name: move $event.cim.user_name? else move $event.cim.user?,
+  type: move $event.cim.user_type?,
 }
-ocsf.resource = {
-  name: move cim.object?,
-  type: move cim.object_category?,
-  uid: move cim.object_id?,
+$event.ocsf.resource = {
+  name: move $event.cim.object?,
+  type: move $event.cim.object_category?,
+  uid: move $event.cim.object_id?,
 }
-ocsf.privileges = move cim.object_attrs?
-ocsf.actor = {
+$event.ocsf.privileges = move $event.cim.object_attrs?
+$event.ocsf.actor = {
   user: {
-    name: move cim.src_user_name? else move cim.src_user?,
-    type: move cim.src_user_type?,
+    name: move $event.cim.src_user_name? else move $event.cim.src_user?,
+    type: move $event.cim.src_user_type?,
   },
 }
-ocsf.src_endpoint = {
-  hostname: move cim.src?,
+$event.ocsf.src_endpoint = {
+  hostname: move $event.cim.src?,
 }
-if cim.dvc? != null {
-  ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "host"]
-  ocsf.device = {
-    hostname: move cim.dvc,
+if $event.cim.dvc? != null {
+  $event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "host"]
+  $event.ocsf.device = {
+    hostname: move $event.cim.dvc,
   }
 }
-ocsf.http_request = {
-  user_agent: move cim.user_agent?,
+$event.ocsf.http_request = {
+  user_agent: move $event.cim.user_agent?,
 }
-if cim.vendor_account? != null or cim.vendor_region? != null {
-  ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "cloud"]
-  ocsf.cloud = {
+if $event.cim.vendor_account? != null or $event.cim.vendor_region? != null {
+  $event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "cloud"]
+  $event.ocsf.cloud = {
     account: {
-      uid: move cim.vendor_account?,
+      uid: move $event.cim.vendor_account?,
     },
-    region: move cim.vendor_region?,
+    region: move $event.cim.vendor_region?,
   }
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.user_access"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/vulnerability_finding.tql
+++ b/splunk/operators/ocsf/cim/vulnerability_finding.tql
@@ -1,43 +1,46 @@
 ---
 description: Splunk CIM Vulnerabilities → OCSF Vulnerability Finding (2002)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 1
-ocsf.category_uid = 2
-ocsf.class_uid = 2002
-splunk::ocsf::cim::helpers::common
+$event.ocsf.activity_id = 1
+$event.ocsf.category_uid = 2
+$event.ocsf.class_uid = 2002
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: vulnerability attributes -----------
 
-ocsf.finding_info = {
-  src_url: move cim.url?,
-  title: move cim.signature?,
-  uid: move cim.signature_id?,
+$event.ocsf.finding_info = {
+  src_url: move $event.cim.url?,
+  title: move $event.cim.signature?,
+  uid: move $event.cim.signature_id?,
 }
-ocsf.vulnerabilities = [...cim.cve?].map(c => {
-  category: cim.category?,
+$event.ocsf.vulnerabilities = [...$event.cim.cve?].map(c => {
+  category: $event.cim.category?,
   cve: {
     uid: c,
     ...{
       cvss: [
         {
-          base_score: cim.cvss,
+          base_score: $event.cim.cvss,
         },
       ],
-    } if cim.cvss? != null,
+    } if $event.cim.cvss? != null,
   },
 })
-ocsf.resource = {
-  name: move cim.dest?,
+$event.ocsf.resource = {
+  name: move $event.cim.dest?,
 }
-ocsf.metadata.product.name = move cim.dvc? else ocsf.metadata.product.name
+$event.ocsf.metadata.product.name = move $event.cim.dvc? else $event.ocsf.metadata.product.name
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.vulnerability_finding"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/web_resource_access_activity.tql
+++ b/splunk/operators/ocsf/cim/web_resource_access_activity.tql
@@ -1,68 +1,71 @@
 ---
 description: Splunk CIM Web → OCSF Web Resource Access Activity (6004)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "access_grant" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "access_deny" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "access_revoke" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "access_error" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 6
-ocsf.class_uid = 6004
-splunk::ocsf::cim::helpers::common
+$event.ocsf.category_uid = 6
+$event.ocsf.class_uid = 6004
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: web resource attributes ------------
 
-ocsf.http_request = {
-  http_method: move cim.http_method?,
-  referrer: move cim.http_referrer?,
-  user_agent: move cim.http_user_agent?,
+$event.ocsf.http_request = {
+  http_method: move $event.cim.http_method?,
+  referrer: move $event.cim.http_referrer?,
+  user_agent: move $event.cim.http_user_agent?,
   url: {
-    domain: move cim.url_domain?,
-    path: move cim.uri_path?,
-    query_string: move cim.uri_query?,
-    url_string: move cim.url?,
+    domain: move $event.cim.url_domain?,
+    path: move $event.cim.uri_path?,
+    query_string: move $event.cim.uri_query?,
+    url_string: move $event.cim.url?,
   },
 }
-ocsf.http_response = {
-  code: int(move cim.status?),
-  content_type: move cim.http_content_type?,
-  latency: move cim.response_time?,
+$event.ocsf.http_response = {
+  code: int(move $event.cim.status?),
+  content_type: move $event.cim.http_content_type?,
+  latency: move $event.cim.response_time?,
 }
-ocsf.web_resources = [
+$event.ocsf.web_resources = [
   {
-    url_string: ocsf.http_request.url.url_string?,
+    url_string: $event.ocsf.http_request.url.url_string?,
   },
 ]
-ocsf.src_endpoint = {
-  ip: move cim.src_ip?,
+$event.ocsf.src_endpoint = {
+  ip: move $event.cim.src_ip?,
 }
-ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "host"]
-ocsf.actor = {
-  app_name: move cim.app?,
+$event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "host"]
+$event.ocsf.actor = {
+  app_name: move $event.cim.app?,
   user: {
-    name: move cim.user?,
+    name: move $event.cim.user?,
   },
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.web_resource_access_activity"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/cim/web_resources_activity.tql
+++ b/splunk/operators/ocsf/cim/web_resources_activity.tql
@@ -1,84 +1,87 @@
 ---
 description: Splunk CIM Web → OCSF Web Resources Activity (6001)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-cim = this
-ocsf = {}
 
 // --- OCSF: classification attributes ----------
 
-match cim.action? {
+match $event.cim.action? {
   "create" => {
-    ocsf.activity_id = 1
+    $event.ocsf.activity_id = 1
   }
   "read" => {
-    ocsf.activity_id = 2
+    $event.ocsf.activity_id = 2
   }
   "update" => {
-    ocsf.activity_id = 3
+    $event.ocsf.activity_id = 3
   }
   "delete" => {
-    ocsf.activity_id = 4
+    $event.ocsf.activity_id = 4
   }
   "search" => {
-    ocsf.activity_id = 5
+    $event.ocsf.activity_id = 5
   }
   "import" => {
-    ocsf.activity_id = 6
+    $event.ocsf.activity_id = 6
   }
   "export" => {
-    ocsf.activity_id = 7
+    $event.ocsf.activity_id = 7
   }
   "share" => {
-    ocsf.activity_id = 8
+    $event.ocsf.activity_id = 8
   }
   _ => {
-    ocsf.activity_id = 99
+    $event.ocsf.activity_id = 99
   }
 }
-ocsf.category_uid = 6
-ocsf.class_uid = 6001
-splunk::ocsf::cim::helpers::common
+$event.ocsf.category_uid = 6
+$event.ocsf.class_uid = 6001
+splunk::ocsf::cim::helpers::common event=$event
 
 // --- OCSF: web resource attributes ------------
 
-ocsf.http_request = {
-  http_method: move cim.http_method?,
-  referrer: move cim.http_referrer?,
-  user_agent: move cim.http_user_agent?,
+$event.ocsf.http_request = {
+  http_method: move $event.cim.http_method?,
+  referrer: move $event.cim.http_referrer?,
+  user_agent: move $event.cim.http_user_agent?,
   url: {
-    domain: move cim.url_domain?,
-    path: move cim.uri_path?,
-    query_string: move cim.uri_query?,
-    url_string: move cim.url?,
+    domain: move $event.cim.url_domain?,
+    path: move $event.cim.uri_path?,
+    query_string: move $event.cim.uri_query?,
+    url_string: move $event.cim.url?,
   },
 }
-ocsf.http_response = {
-  code: int(move cim.status?),
-  content_type: move cim.http_content_type?,
-  latency: move cim.response_time?,
+$event.ocsf.http_response = {
+  code: int(move $event.cim.status?),
+  content_type: move $event.cim.http_content_type?,
+  latency: move $event.cim.response_time?,
 }
-ocsf.web_resources = [
+$event.ocsf.web_resources = [
   {
-    url_string: ocsf.http_request.url.url_string?,
+    url_string: $event.ocsf.http_request.url.url_string?,
   },
 ]
-ocsf.src_endpoint = {
-  ip: move cim.src_ip?,
+$event.ocsf.src_endpoint = {
+  ip: move $event.cim.src_ip?,
 }
-ocsf.dst_endpoint = {
-  ip: move cim.dest_ip?,
-  port: move cim.dest_port?,
+$event.ocsf.dst_endpoint = {
+  ip: move $event.cim.dest_ip?,
+  port: move $event.cim.dest_port?,
 }
-ocsf.metadata.profiles = [...ocsf.metadata.profiles?, "host"]
-ocsf.actor = {
-  app_name: move cim.app?,
+$event.ocsf.metadata.profiles = [...$event.ocsf.metadata.profiles?, "host"]
+$event.ocsf.actor = {
+  app_name: move $event.cim.app?,
   user: {
-    name: move cim.user?,
+    name: move $event.cim.user?,
   },
 }
 
 // --- Finalize ---------------------------------
 
 @name = "ocsf.web_resources_activity"
-this = {...ocsf, unmapped: cim}
+$event = {...$event.ocsf, unmapped: $event.cim}

--- a/splunk/operators/ocsf/map.tql
+++ b/splunk/operators/ocsf/map.tql
@@ -1,5 +1,11 @@
 ---
 description: Splunk → OCSF
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-splunk::ocsf::cim::map
+splunk::ocsf::cim::map event=$event

--- a/splunk/tests/cim/ocsf/pass_through.tql
+++ b/splunk/tests/cim/ocsf/pass_through.tql
@@ -1,0 +1,9 @@
+from {
+  class_uid: 0,
+  message: "base",
+}, {
+  class_uid: 9999,
+  message: "unsupported",
+}
+splunk::cim::ocsf::map
+sort class_uid

--- a/splunk/tests/cim/ocsf/pass_through.txt
+++ b/splunk/tests/cim/ocsf/pass_through.txt
@@ -1,0 +1,8 @@
+{
+  class_uid: 0,
+  message: "base",
+}
+{
+  class_uid: 9999,
+  message: "unsupported",
+}

--- a/splunk/tests/ocsf/cim/pass_through.tql
+++ b/splunk/tests/ocsf/cim/pass_through.tql
@@ -1,0 +1,10 @@
+from {
+  message: "no tag",
+}, {
+  message: "unsupported",
+  tag: [
+    "unknown",
+  ],
+}
+splunk::ocsf::cim::map
+sort message

--- a/splunk/tests/ocsf/cim/pass_through.txt
+++ b/splunk/tests/ocsf/cim/pass_through.txt
@@ -1,0 +1,9 @@
+{
+  message: "no tag",
+}
+{
+  message: "unsupported",
+  tag: [
+    "unknown",
+  ],
+}

--- a/suricata/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/suricata/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,22 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:21.077264Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+```

--- a/suricata/operators/ocsf/base.tql
+++ b/suricata/operators/ocsf/base.tql
@@ -1,11 +1,16 @@
 ---
 description: Suricata EVE JSON -> OCSF Base Event (0)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.base_event"
 
-ocsf.category_uid = 0
-ocsf.class_uid = 0
-ocsf.activity_id = 0
-ocsf.severity_id = 0
-ocsf.type_uid = 0
+$event.ocsf.category_uid = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.severity_id = 0
+$event.ocsf.type_uid = 0

--- a/suricata/operators/ocsf/logs/alert.tql
+++ b/suricata/operators/ocsf/logs/alert.tql
@@ -1,107 +1,114 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
-ocsf.category_uid = 2
+$event.ocsf.category_uid = 2
 
-ocsf.activity_id = 1 // Create
-ocsf.class_uid = 2004
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 1 // Create
+$event.ocsf.class_uid = 2004
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-ocsf.metadata.profiles = ["security_control"]
+$event.ocsf.metadata.profiles = ["security_control"]
 
 let $severities = [0, 4, 3, 2, 1]
-ocsf.severity_id = $severities[suricata.alert.severity]? else 0
-drop suricata.alert.severity
+$event.ocsf.severity_id = $severities[$event.suricata.alert.severity]? else 0
+drop $event.suricata.alert.severity
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.is_alert = true
+$event.ocsf.is_alert = true
 
-if suricata.alert.action? != null {
-  match suricata.alert.action {
+if $event.suricata.alert.action? != null {
+  match $event.suricata.alert.action {
     "allowed" => {
-      ocsf.action_id = 1
-      ocsf.disposition_id = 1
-      drop suricata.alert.action
+      $event.ocsf.action_id = 1
+      $event.ocsf.disposition_id = 1
+      drop $event.suricata.alert.action
     }
     "blocked" => {
-      ocsf.action_id = 2
-      ocsf.disposition_id = 2
-      drop suricata.alert.action
+      $event.ocsf.action_id = 2
+      $event.ocsf.disposition_id = 2
+      drop $event.suricata.alert.action
     }
     _ => {
-      ocsf.action = move suricata.alert.action
-      ocsf.action_id = 99
-      ocsf.disposition = ocsf.action
-      ocsf.disposition_id = 99
+      $event.ocsf.action = move $event.suricata.alert.action
+      $event.ocsf.action_id = 99
+      $event.ocsf.disposition = $event.ocsf.action
+      $event.ocsf.disposition_id = 99
     }
   }
 }
 
-if suricata.alert.metadata?.confidence? != null {
+if $event.suricata.alert.metadata?.confidence? != null {
   let $confidence_ids = {
     low: 1,
     medium: 2,
     high: 3,
   }
-  suricata.alert._confidence = suricata.alert.metadata.confidence[0]
-  ocsf.confidence_id = $confidence_ids[suricata.alert._confidence.to_lower()]? else 99
-  if ocsf.confidence_id == 99 {
-    ocsf.confidence = suricata.alert._confidence
+  $event.suricata.alert._confidence = $event.suricata.alert.metadata.confidence[0]
+  $event.ocsf.confidence_id = $confidence_ids[$event.suricata.alert._confidence.to_lower()]? else 99
+  if $event.ocsf.confidence_id == 99 {
+    $event.ocsf.confidence = $event.suricata.alert._confidence
   }
-  drop suricata.alert._confidence
-  drop suricata.alert.metadata.confidence
+  drop $event.suricata.alert._confidence
+  drop $event.suricata.alert.metadata.confidence
 }
 
 // Suricata alerts can have a bunch of different records, based on the
 // respective protocol analyzer. Our strategy here is to map them as evidence.
-if ocsf.has("src_endpoint") {
-  _evidence.src_endpoint = move ocsf.src_endpoint
+if $event.ocsf.has("src_endpoint") {
+  $event._evidence.src_endpoint = move $event.ocsf.src_endpoint
 }
-if ocsf.has("dst_endpoint") {
-  _evidence.dst_endpoint = move ocsf.dst_endpoint
+if $event.ocsf.has("dst_endpoint") {
+  $event._evidence.dst_endpoint = move $event.ocsf.dst_endpoint
 }
-if ocsf.has("connection_info") {
-  _evidence.connection_info = move ocsf.connection_info
+if $event.ocsf.has("connection_info") {
+  $event._evidence.connection_info = move $event.ocsf.connection_info
 }
-if suricata.dns?.queries? != null {
-  suricata::ocsf::map_dns_query
-  _evidence.query = move ocsf.query
+if $event.suricata.dns?.queries? != null {
+  suricata::ocsf::map_dns_query event=$event
+  $event._evidence.query = move $event.ocsf.query
 }
-if suricata.has("http") {
-  suricata::ocsf::map_http
-  if ocsf.has("http_request") {
-    _evidence.http_request = move ocsf.http_request
+if $event.suricata.has("http") {
+  suricata::ocsf::map_http event=$event
+  if $event.ocsf.has("http_request") {
+    $event._evidence.http_request = move $event.ocsf.http_request
   }
-  if ocsf.has("http_response") {
-    _evidence.http_response = move ocsf.http_response
+  if $event.ocsf.has("http_response") {
+    $event._evidence.http_response = move $event.ocsf.http_response
   }
 }
-if suricata.smb?.filename? != null {
-  suricata::ocsf::map_smb_file
-  _evidence.file = move ocsf.file
+if $event.suricata.smb?.filename? != null {
+  suricata::ocsf::map_smb_file event=$event
+  $event._evidence.file = move $event.ocsf.file
 }
-if this.has("_evidence") {
-  ocsf.evidences = [_evidence]
-  drop _evidence
+if $event.has("_evidence") {
+  $event.ocsf.evidences = [$event._evidence]
+  drop $event._evidence
 }
 
-ocsf.finding_info = {
+$event.ocsf.finding_info = {
   analytic: {
     type: "Rule",
     type_id: 1,
   },
 }
 // The generator ID is a reasonable field for algorithm.
-ocsf.finding_info.analytic.algorithm = suricata.alert.gid.string()
-ocsf.finding_info.analytic.category = move suricata.alert.category
-ocsf.finding_info.analytic.name = move suricata.alert.signature
-ocsf.finding_info.analytic.uid = suricata.alert.signature_id.string()
-ocsf.finding_info.analytic.version = suricata.alert.rev.string()
-drop suricata.alert.gid
-drop suricata.alert.signature_id
-drop suricata.alert.rev
-ocsf.finding_info.uid = ocsf.finding_info.analytic.uid
-ocsf.finding_info.title = ocsf.finding_info.analytic.name
+$event.ocsf.finding_info.analytic.algorithm = $event.suricata.alert.gid.string()
+$event.ocsf.finding_info.analytic.category = move $event.suricata.alert.category
+$event.ocsf.finding_info.analytic.name = move $event.suricata.alert.signature
+$event.ocsf.finding_info.analytic.uid = $event.suricata.alert.signature_id.string()
+$event.ocsf.finding_info.analytic.version = $event.suricata.alert.rev.string()
+drop $event.suricata.alert.gid
+drop $event.suricata.alert.signature_id
+drop $event.suricata.alert.rev
+$event.ocsf.finding_info.uid = $event.ocsf.finding_info.analytic.uid
+$event.ocsf.finding_info.title = $event.ocsf.finding_info.analytic.name
 
 // --- Finalize ---------------------------------
 

--- a/suricata/operators/ocsf/logs/anomaly.tql
+++ b/suricata/operators/ocsf/logs/anomaly.tql
@@ -1,15 +1,22 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 0
-ocsf.class_uid = 4001
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 0
+$event.ocsf.class_uid = 4001
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.app_protocol_name = move suricata.anomaly.app_proto
-ocsf.message = move suricata.anomaly.event
-ocsf.status_id = 0
+$event.ocsf.app_protocol_name = move $event.suricata.anomaly.app_proto
+$event.ocsf.message = move $event.suricata.anomaly.event
+$event.ocsf.status_id = 0
 
 // --- Finalize ---------------------------------
 

--- a/suricata/operators/ocsf/logs/dhcp.tql
+++ b/suricata/operators/ocsf/logs/dhcp.tql
@@ -1,3 +1,10 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
 let $activity_id = {
@@ -11,49 +18,49 @@ let $activity_id = {
   inform: 8,
 }
 
-ocsf.class_uid = 4004
-ocsf.activity_id = $activity_id[suricata.dhcp.dhcp_type.string()] else 0
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.class_uid = 4004
+$event.ocsf.activity_id = $activity_id[$event.suricata.dhcp.dhcp_type.string()] else 0
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: primary attributes -----------------
 
-if suricata.dhcp.type? == "reply" {
-  _server_endpoint = ocsf.src_endpoint
-  ocsf.src_endpoint = ocsf.dst_endpoint
-  ocsf.dst_endpoint = _server_endpoint
-  drop _server_endpoint
+if $event.suricata.dhcp.type? == "reply" {
+  $event._server_endpoint = $event.ocsf.src_endpoint
+  $event.ocsf.src_endpoint = $event.ocsf.dst_endpoint
+  $event.ocsf.dst_endpoint = $event._server_endpoint
+  drop $event._server_endpoint
 }
 
-if suricata.dhcp.has("hostname") {
-  ocsf.src_endpoint.hostname = move suricata.dhcp.hostname
+if $event.suricata.dhcp.has("hostname") {
+  $event.ocsf.src_endpoint.hostname = move $event.suricata.dhcp.hostname
 }
 
-if suricata.dhcp.has("client_mac") {
-  ocsf.src_endpoint.mac = move suricata.dhcp.client_mac
+if $event.suricata.dhcp.has("client_mac") {
+  $event.ocsf.src_endpoint.mac = move $event.suricata.dhcp.client_mac
 }
 
-if suricata.dhcp.has("assigned_ip") {
-  ocsf.src_endpoint.ip = move suricata.dhcp.assigned_ip
+if $event.suricata.dhcp.has("assigned_ip") {
+  $event.ocsf.src_endpoint.ip = move $event.suricata.dhcp.assigned_ip
 }
 
-if suricata.dhcp.has("lease_time") {
-  ocsf.lease_dur = move suricata.dhcp.lease_time
+if $event.suricata.dhcp.has("lease_time") {
+  $event.ocsf.lease_dur = move $event.suricata.dhcp.lease_time
 }
 
-match suricata.dhcp.dhcp_type {
+match $event.suricata.dhcp.dhcp_type {
   "offer" | "ack" => {
-    ocsf.status_id = 1
+    $event.ocsf.status_id = 1
   }
   "decline" | "nak" => {
-    ocsf.status_id = 2
+    $event.ocsf.status_id = 2
   }
   _ => {
-    ocsf.status_id = 0
+    $event.ocsf.status_id = 0
   }
 }
 
-ocsf.transaction_uid = (move suricata.dhcp.id).string()
+$event.ocsf.transaction_uid = (move $event.suricata.dhcp.id).string()
 
 // --- Finalize ---------------------------------
 

--- a/suricata/operators/ocsf/logs/dns.tql
+++ b/suricata/operators/ocsf/logs/dns.tql
@@ -1,36 +1,43 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
-if (suricata.dns.has("queries") and suricata.dns.has("answers")) {
-  ocsf.activity_id = 6
-} else if (suricata.dns.has("queries")) {
-  ocsf.activity_id = 1
-} else if (suricata.dns.has("answers")) {
-  ocsf.activity_id = 2
+if ($event.suricata.dns.has("queries") and $event.suricata.dns.has("answers")) {
+  $event.ocsf.activity_id = 6
+} else if ($event.suricata.dns.has("queries")) {
+  $event.ocsf.activity_id = 1
+} else if ($event.suricata.dns.has("answers")) {
+  $event.ocsf.activity_id = 2
 } else {
-  ocsf.activity_id = 0
+  $event.ocsf.activity_id = 0
 }
 
-ocsf.class_uid = 4003
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.class_uid = 4003
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: primary attributes -----------------
 
 // TODO: support `grouped`.
 
-if suricata.dns.has("queries") {
-  suricata::ocsf::map_dns_query
+if $event.suricata.dns.has("queries") {
+  suricata::ocsf::map_dns_query event=$event
 }
 
-if suricata.dns.has("answers") {
-  ocsf.answers = (suricata.dns.answers).map(answer => {
+if $event.suricata.dns.has("answers") {
+  $event.ocsf.answers = ($event.suricata.dns.answers).map(answer => {
     rdata: answer.rdata,
     type: answer.rrtype,
     ttl: answer.ttl,
   })
 }
 
-if suricata.dns.has("rcode") {
+if $event.suricata.dns.has("rcode") {
   let $rcode_id = {
     NOERROR: 0,
     FORMERROR: 1,
@@ -53,14 +60,14 @@ if suricata.dns.has("rcode") {
     BADTRUNC: 22,
     BADCOOKIE: 23,
   }
-  ocsf.rcode_id = $rcode_id[suricata.dns.rcode] else 99
-  if ocsf.rcode_id == 99 {
-    ocsf.rcode = suricata.dns.rcode
+  $event.ocsf.rcode_id = $rcode_id[$event.suricata.dns.rcode] else 99
+  if $event.ocsf.rcode_id == 99 {
+    $event.ocsf.rcode = $event.suricata.dns.rcode
   }
-  ocsf.status_id = 1 if ocsf.rcode_id == 0 else 2
-  drop suricata.dns.rcode
+  $event.ocsf.status_id = 1 if $event.ocsf.rcode_id == 0 else 2
+  drop $event.suricata.dns.rcode
 } else {
-  ocsf.status_id = 0
+  $event.ocsf.status_id = 0
 }
 
 // --- Finalize ---------------------------------

--- a/suricata/operators/ocsf/logs/fileinfo.tql
+++ b/suricata/operators/ocsf/logs/fileinfo.tql
@@ -1,17 +1,24 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
-ocsf.class_uid = 4010
-ocsf.category_uid = 4
-ocsf.activity_id = 0
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.class_uid = 4010
+$event.ocsf.category_uid = 4
+$event.ocsf.activity_id = 0
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.file = {
+$event.ocsf.file = {
   type_id: 0,
-  name: move suricata.fileinfo.filename,
-  size: move suricata.fileinfo.size,
+  name: move $event.suricata.fileinfo.filename,
+  size: move $event.suricata.fileinfo.size,
 }
 
 // --- Finalize ---------------------------------

--- a/suricata/operators/ocsf/logs/flow.tql
+++ b/suricata/operators/ocsf/logs/flow.tql
@@ -1,23 +1,30 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
 // TODO: coudl be more precise
-ocsf.activity_id = 6
+$event.ocsf.activity_id = 6
 
-ocsf.class_uid = 4001
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.class_uid = 4001
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: primary attributes -----------------
 
-suricata::ocsf::map_flow
+suricata::ocsf::map_flow event=$event
 
-if suricata.flow.state? != null {
-  ocsf.status_detail = move suricata.flow.state
+if $event.suricata.flow.state? != null {
+  $event.ocsf.status_detail = move $event.suricata.flow.state
 }
-if suricata.flow.reason? != null {
-  ocsf.status_code = move suricata.flow.reason
+if $event.suricata.flow.reason? != null {
+  $event.ocsf.status_code = move $event.suricata.flow.reason
 }
-ocsf.status_id = 1 if ocsf.status_detail? == "established" else 0
+$event.ocsf.status_id = 1 if $event.ocsf.status_detail? == "established" else 0
 
 // --- Finalize ---------------------------------
 

--- a/suricata/operators/ocsf/logs/ftp.tql
+++ b/suricata/operators/ocsf/logs/ftp.tql
@@ -1,3 +1,10 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
 let $commands = {
@@ -53,39 +60,39 @@ let $commands = {
   XMKD: 0,
 }
 
-ocsf.activity_id = $commands[suricata.ftp.command?]? else 0
-ocsf.class_uid = 4008
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = $commands[$event.suricata.ftp.command?]? else 0
+$event.ocsf.class_uid = 4008
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: primary attributes -----------------
 
-if suricata.ftp.completion_code? != null {
-  suricata.ftp._completion_code = suricata.ftp.completion_code[0]
-  ocsf.codes = suricata.ftp.completion_code.map(code => int(code))
-  if suricata.ftp._completion_code.starts_with("2") or suricata.ftp._completion_code.starts_with("3") {
-    ocsf.status_id = 1
-  } else if suricata.ftp._completion_code.starts_with("4") or suricata.ftp._completion_code.starts_with("5") {
-    ocsf.status_id = 2
+if $event.suricata.ftp.completion_code? != null {
+  $event.suricata.ftp._completion_code = $event.suricata.ftp.completion_code[0]
+  $event.ocsf.codes = $event.suricata.ftp.completion_code.map(code => int(code))
+  if $event.suricata.ftp._completion_code.starts_with("2") or $event.suricata.ftp._completion_code.starts_with("3") {
+    $event.ocsf.status_id = 1
+  } else if $event.suricata.ftp._completion_code.starts_with("4") or $event.suricata.ftp._completion_code.starts_with("5") {
+    $event.ocsf.status_id = 2
   } else {
-    ocsf.status_id = 0
+    $event.ocsf.status_id = 0
   }
-  drop suricata.ftp._completion_code
-  drop suricata.ftp.completion_code
+  drop $event.suricata.ftp._completion_code
+  drop $event.suricata.ftp.completion_code
 } else {
-  ocsf.status_id = 0
+  $event.ocsf.status_id = 0
 }
-ocsf.command = move suricata.ftp.command?
-if suricata.ftp.reply? != null {
-  ocsf.command_responses = move suricata.ftp.reply
+$event.ocsf.command = move $event.suricata.ftp.command?
+if $event.suricata.ftp.reply? != null {
+  $event.ocsf.command_responses = move $event.suricata.ftp.reply
 }
-ocsf.name = move suricata.ftp.command_data?
+$event.ocsf.name = move $event.suricata.ftp.command_data?
 
-if suricata.ftp.has("dynamic_port") {
-  ocsf.port = move suricata.ftp.dynamic_port
+if $event.suricata.ftp.has("dynamic_port") {
+  $event.ocsf.port = move $event.suricata.ftp.dynamic_port
 }
-if suricata.ftp.has("mode") {
-  ocsf.type = move suricata.ftp.mode
+if $event.suricata.ftp.has("mode") {
+  $event.ocsf.type = move $event.suricata.ftp.mode
 }
 
 // --- Finalize ---------------------------------

--- a/suricata/operators/ocsf/logs/http.tql
+++ b/suricata/operators/ocsf/logs/http.tql
@@ -1,3 +1,10 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
 let $activity_id = {
@@ -12,34 +19,34 @@ let $activity_id = {
   PATCH: 9,
 }
 
-ocsf.activity_id = $activity_id[suricata.http.http_method] else 99
-ocsf.category_uid = 4
-ocsf.class_uid = 4002
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = $activity_id[$event.suricata.http.http_method] else 99
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4002
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-if suricata.http.has("fileinfo") {
-  ocsf.file = {
+if $event.suricata.http.has("fileinfo") {
+  $event.ocsf.file = {
     type_id: 0,
-    name: move suricata.fileinfo.filename,
-    size: move suricata.fileinfo.size,
+    name: move $event.suricata.fileinfo.filename,
+    size: move $event.suricata.fileinfo.size,
   }
 }
 
 // --- OCSF: primary attributes -----------------
 
-suricata::ocsf::map_http
+suricata::ocsf::map_http event=$event
 
-if ocsf.http_response.code? == null {
-  ocsf.status_id = 0
-} else if ocsf.http_response.code >= 200 and ocsf.http_response.code < 400 {
-  ocsf.status_id = 1
-} else if ocsf.http_response.code >= 400 and ocsf.http_response.code < 600 {
-  ocsf.status_id = 2
+if $event.ocsf.http_response.code? == null {
+  $event.ocsf.status_id = 0
+} else if $event.ocsf.http_response.code >= 200 and $event.ocsf.http_response.code < 400 {
+  $event.ocsf.status_id = 1
+} else if $event.ocsf.http_response.code >= 400 and $event.ocsf.http_response.code < 600 {
+  $event.ocsf.status_id = 2
 } else {
-  ocsf.status_id = 0
+  $event.ocsf.status_id = 0
 }
 
 // --- Finalize ---------------------------------

--- a/suricata/operators/ocsf/logs/krb5.tql
+++ b/suricata/operators/ocsf/logs/krb5.tql
@@ -1,3 +1,10 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
 /*
@@ -14,35 +21,35 @@ let $krb5_activity_map = {
   KRB_TGS_REP: 4,
 }
 
-match suricata.krb5.msg_type {
-  "KRB_ERROR" if suricata.krb5.error_code? == "KDC_ERR_PREAUTH_REQUIRED" => {
-    ocsf.activity_id = 6
+match $event.suricata.krb5.msg_type {
+  "KRB_ERROR" if $event.suricata.krb5.error_code? == "KDC_ERR_PREAUTH_REQUIRED" => {
+    $event.ocsf.activity_id = 6
   }
   "KRB_ERROR" => {
     // For other errors, map based on the failed_request field.
-    ocsf.activity_id = $krb5_activity_map[suricata.krb5.failed_request?]? else 99
+    $event.ocsf.activity_id = $krb5_activity_map[$event.suricata.krb5.failed_request?]? else 99
   }
   _ => {
-    ocsf.activity_id = $krb5_activity_map[suricata.krb5.msg_type]? else 99
+    $event.ocsf.activity_id = $krb5_activity_map[$event.suricata.krb5.msg_type]? else 99
   }
 }
 
-ocsf.category_uid = 3
-ocsf.class_uid = 3002
+$event.ocsf.category_uid = 3
+$event.ocsf.class_uid = 3002
 
 // Severity: informational for success, low for authentication failures
-ocsf.severity_id = 1 if suricata.krb5.msg_type in ["KRB_AS_REP", "KRB_TGS_REP"] else 2
+$event.ocsf.severity_id = 1 if $event.suricata.krb5.msg_type in ["KRB_AS_REP", "KRB_TGS_REP"] else 2
 
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.is_cleartext = move suricata.krb5.weak_encryption
+$event.ocsf.is_cleartext = move $event.suricata.krb5.weak_encryption
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.auth_protocol = "Kerberos"
-ocsf.auth_protocol_id = 2
+$event.ocsf.auth_protocol = "Kerberos"
+$event.ocsf.auth_protocol_id = 2
 
 // Map Kerberos encryption types to OCSF algorithm names
 let $krb5_to_algo = {
@@ -92,38 +99,38 @@ let $algo_to_id = {
 
 // For successful authentications, create an authentication_token object to
 // represent the Kerberos ticket
-if suricata.krb5.msg_type in ["KRB_AS_REP", "KRB_TGS_REP"] {
-  ocsf.authentication_token = {
+if $event.suricata.krb5.msg_type in ["KRB_AS_REP", "KRB_TGS_REP"] {
+  $event.ocsf.authentication_token = {
     // Map Kerberos message type to token type
-    type: "Ticket Granting Ticket" if suricata.krb5.msg_type == "KRB_AS_REP" else "Service Ticket",
-    type_id: 1 if suricata.krb5.msg_type == "KRB_AS_REP" else 2,
+    type: "Ticket Granting Ticket" if $event.suricata.krb5.msg_type == "KRB_AS_REP" else "Service Ticket",
+    type_id: 1 if $event.suricata.krb5.msg_type == "KRB_AS_REP" else 2,
   }
-  if suricata.krb5.has("encryption") and suricata.krb5.encryption != "<none>" {
-    ocsf.authentication_token.encryption_details = {
-      algorithm: $krb5_to_algo[suricata.krb5.encryption]? else "Other",
-      algorithm_id: $algo_to_id[$krb5_to_algo[suricata.krb5.encryption]? else "Other"],
-      type: move suricata.krb5.encryption,
+  if $event.suricata.krb5.has("encryption") and $event.suricata.krb5.encryption != "<none>" {
+    $event.ocsf.authentication_token.encryption_details = {
+      algorithm: $krb5_to_algo[$event.suricata.krb5.encryption]? else "Other",
+      algorithm_id: $algo_to_id[$krb5_to_algo[$event.suricata.krb5.encryption]? else "Other"],
+      type: move $event.suricata.krb5.encryption,
     }
   }
 }
 
 // Service (target) information - the service principal being accessed
-ocsf.service = {
-  name: move suricata.krb5.sname,
+$event.ocsf.service = {
+  name: move $event.suricata.krb5.sname,
 }
 
-ocsf.status_code = move suricata.krb5.error_code?
-ocsf.status_detail = move suricata.krb5.failed_request?
-ocsf.status_id = 1 if suricata.krb5.msg_type in ["KRB_AS_REP", "KRB_TGS_REP"] else 2
+$event.ocsf.status_code = move $event.suricata.krb5.error_code?
+$event.ocsf.status_detail = move $event.suricata.krb5.failed_request?
+$event.ocsf.status_id = 1 if $event.suricata.krb5.msg_type in ["KRB_AS_REP", "KRB_TGS_REP"] else 2
 
-if suricata.krb5.has("realm") and suricata.krb5.realm != "<empty>" {
-  ocsf.user.domain = move suricata.krb5.realm
+if $event.suricata.krb5.has("realm") and $event.suricata.krb5.realm != "<empty>" {
+  $event.ocsf.user.domain = move $event.suricata.krb5.realm
 }
-if suricata.krb5.has("cname") and suricata.krb5.cname != "<empty>" {
-  ocsf.user.name = move suricata.krb5.cname
+if $event.suricata.krb5.has("cname") and $event.suricata.krb5.cname != "<empty>" {
+  $event.ocsf.user.name = move $event.suricata.krb5.cname
 }
 
-drop suricata.krb5.msg_type
+drop $event.suricata.krb5.msg_type
 
 // --- Finalize ---------------------------------
 

--- a/suricata/operators/ocsf/logs/mqtt.tql
+++ b/suricata/operators/ocsf/logs/mqtt.tql
@@ -1,3 +1,10 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
 /*
@@ -7,68 +14,68 @@
  * - disconnect: Network connection closed = activity_id 2
  * - publish/subscribe/suback/etc: Traffic = activity_id 6
  */
-if suricata.mqtt.has("connect") or (suricata.mqtt.has("connack") and suricata.mqtt.connack.return_code == 0) {
-  ocsf.activity_id = 1
-} else if suricata.mqtt.has("connack") and suricata.mqtt.connack.return_code != 0 {
-  ocsf.activity_id = 4
-} else if suricata.mqtt.has("disconnect") {
-  ocsf.activity_id = 2
-} else if suricata.mqtt.has("publish") or suricata.mqtt.has("subscribe") or suricata.mqtt.has("suback") {
-  ocsf.activity_id = 6
+if $event.suricata.mqtt.has("connect") or ($event.suricata.mqtt.has("connack") and $event.suricata.mqtt.connack.return_code == 0) {
+  $event.ocsf.activity_id = 1
+} else if $event.suricata.mqtt.has("connack") and $event.suricata.mqtt.connack.return_code != 0 {
+  $event.ocsf.activity_id = 4
+} else if $event.suricata.mqtt.has("disconnect") {
+  $event.ocsf.activity_id = 2
+} else if $event.suricata.mqtt.has("publish") or $event.suricata.mqtt.has("subscribe") or $event.suricata.mqtt.has("suback") {
+  $event.ocsf.activity_id = 6
 } else {
-  ocsf.activity_id = 99
+  $event.ocsf.activity_id = 99
 }
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
 
 // Severity: informational for normal operations
-ocsf.severity_id = 1
+$event.ocsf.severity_id = 1
 
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
 // Protocol details for MQTT
-if suricata.mqtt.has("connect") {
-  ocsf.app_protocol_name = "mqtt"
-  ocsf.connection_info.session.uid = move suricata.mqtt.connect.client_id?
+if $event.suricata.mqtt.has("connect") {
+  $event.ocsf.app_protocol_name = "mqtt"
+  $event.ocsf.connection_info.session.uid = move $event.suricata.mqtt.connect.client_id?
 }
 
 // --- OCSF: primary attributes -----------------
 
-if suricata.mqtt.has("connack") {
-  suricata.mqtt.connack._return_code = suricata.mqtt.connack.return_code
-  ocsf.status_code = string(move suricata.mqtt.connack.return_code)
-  ocsf.status_id = 1 if suricata.mqtt.connack._return_code == 0 else 2
-  drop suricata.mqtt.connack._return_code
+if $event.suricata.mqtt.has("connack") {
+  $event.suricata.mqtt.connack._return_code = $event.suricata.mqtt.connack.return_code
+  $event.ocsf.status_code = string(move $event.suricata.mqtt.connack.return_code)
+  $event.ocsf.status_id = 1 if $event.suricata.mqtt.connack._return_code == 0 else 2
+  drop $event.suricata.mqtt.connack._return_code
 }
 
-if suricata.mqtt.has("disconnect") {
-  if suricata.mqtt.disconnect.has("reason_code") {
-    ocsf.status_code = string(move suricata.mqtt.disconnect.reason_code)
+if $event.suricata.mqtt.has("disconnect") {
+  if $event.suricata.mqtt.disconnect.has("reason_code") {
+    $event.ocsf.status_code = string(move $event.suricata.mqtt.disconnect.reason_code)
   }
 }
 
-if suricata.mqtt.has("publish") {
-  ocsf.message = move suricata.mqtt.publish.topic
-  drop suricata.mqtt.publish.message_id?
-  drop suricata.mqtt.publish.qos?
-  drop suricata.mqtt.publish.message // binary
+if $event.suricata.mqtt.has("publish") {
+  $event.ocsf.message = move $event.suricata.mqtt.publish.topic
+  drop $event.suricata.mqtt.publish.message_id?
+  drop $event.suricata.mqtt.publish.qos?
+  drop $event.suricata.mqtt.publish.message // binary
 }
 
-if suricata.mqtt.has("subscribe") {
-  drop suricata.mqtt.subscribe.message_id?
-  drop suricata.mqtt.subscribe.qos?
+if $event.suricata.mqtt.has("subscribe") {
+  drop $event.suricata.mqtt.subscribe.message_id?
+  drop $event.suricata.mqtt.subscribe.qos?
 }
 
-if suricata.mqtt.has("suback") {
-  drop suricata.mqtt.suback.message_id?
-  drop suricata.mqtt.suback.qos_granted?
+if $event.suricata.mqtt.has("suback") {
+  drop $event.suricata.mqtt.suback.message_id?
+  drop $event.suricata.mqtt.suback.qos_granted?
 }
 
-if ocsf.status_id? == null {
-  ocsf.status_id = 1
+if $event.ocsf.status_id? == null {
+  $event.ocsf.status_id = 1
 }
 
 // --- Finalize ---------------------------------

--- a/suricata/operators/ocsf/logs/sip.tql
+++ b/suricata/operators/ocsf/logs/sip.tql
@@ -1,3 +1,10 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
 /*
@@ -6,45 +13,45 @@
  * - BYE: Network connection closed = activity_id 2
  * - Response codes 4xx/5xx/6xx: Connection failed = activity_id 4
  */
-if suricata.sip.has("method") and suricata.sip.method == "INVITE" {
-  ocsf.activity_id = 1
-} else if suricata.sip.has("method") and suricata.sip.method == "BYE" {
-  ocsf.activity_id = 2
-} else if suricata.sip.has("code") and int(suricata.sip.code) >= 400 and int(suricata.sip.code) < 700 {
-  ocsf.activity_id = 4
-} else if suricata.sip.has("method") or suricata.sip.has("code") {
-  ocsf.activity_id = 6
+if $event.suricata.sip.has("method") and $event.suricata.sip.method == "INVITE" {
+  $event.ocsf.activity_id = 1
+} else if $event.suricata.sip.has("method") and $event.suricata.sip.method == "BYE" {
+  $event.ocsf.activity_id = 2
+} else if $event.suricata.sip.has("code") and int($event.suricata.sip.code) >= 400 and int($event.suricata.sip.code) < 700 {
+  $event.ocsf.activity_id = 4
+} else if $event.suricata.sip.has("method") or $event.suricata.sip.has("code") {
+  $event.ocsf.activity_id = 6
 } else {
-  ocsf.activity_id = 0
+  $event.ocsf.activity_id = 0
 }
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
 
 // Severity: informational for normal operations
-ocsf.severity_id = 1
+$event.ocsf.severity_id = 1
 
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.app_protocol_name = "sip"
+$event.ocsf.app_protocol_name = "sip"
 
 // --- OCSF: primary attributes -----------------
 
-if suricata.sip.has("request_line") {
-  ocsf.message = move suricata.sip.request_line
-} else if suricata.sip.has("response_line") {
-  ocsf.message = move suricata.sip.response_line
+if $event.suricata.sip.has("request_line") {
+  $event.ocsf.message = move $event.suricata.sip.request_line
+} else if $event.suricata.sip.has("response_line") {
+  $event.ocsf.message = move $event.suricata.sip.response_line
 }
 
-ocsf.status_detail = move suricata.sip.reason?
+$event.ocsf.status_detail = move $event.suricata.sip.reason?
 
-if suricata.sip.has("code") {
-  ocsf.status_code = move suricata.sip.code?
-  ocsf.status_id = 2 if int(ocsf.status_code) >= 400 else 1
+if $event.suricata.sip.has("code") {
+  $event.ocsf.status_code = move $event.suricata.sip.code?
+  $event.ocsf.status_id = 2 if int($event.ocsf.status_code) >= 400 else 1
 } else {
-  ocsf.status_id = 0
+  $event.ocsf.status_id = 0
 }
 
 // --- Finalize ---------------------------------

--- a/suricata/operators/ocsf/logs/smb.tql
+++ b/suricata/operators/ocsf/logs/smb.tql
@@ -1,3 +1,10 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
 /*
@@ -18,50 +25,50 @@ let $smb_activity_id = {
   FILE_OVERWRITE_IF: 6,
 }
 
-ocsf.activity_id = $smb_activity_id[suricata.smb.disposition?]? else 0
+$event.ocsf.activity_id = $smb_activity_id[$event.suricata.smb.disposition?]? else 0
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4006
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4006
 
 // Severity: informational for normal operations
-ocsf.severity_id = 1
+$event.ocsf.severity_id = 1
 
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-if suricata.smb.client_dialects? != null {
-  ocsf.client_dialects = move suricata.smb.client_dialects
+if $event.suricata.smb.client_dialects? != null {
+  $event.ocsf.client_dialects = move $event.suricata.smb.client_dialects
 }
-ocsf.dialect = move suricata.smb.dialect?
+$event.ocsf.dialect = move $event.suricata.smb.dialect?
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.command = move suricata.smb.command?
+$event.ocsf.command = move $event.suricata.smb.command?
 
-if suricata.smb.has("session_id") {
-  ocsf.connection_info.session = {
-    uid: string(move suricata.smb.session_id),
+if $event.suricata.smb.has("session_id") {
+  $event.ocsf.connection_info.session = {
+    uid: string(move $event.suricata.smb.session_id),
   }
 }
 
 // Map server (device) information from response
-if suricata.smb.has("response") {
-  if suricata.smb.response.has("native_os") {
-    ocsf.device.os.name = move suricata.smb.response.native_os?
-    ocsf.metadata.profiles = ocsf.metadata?.profiles?.add("host")
+if $event.suricata.smb.has("response") {
+  if $event.suricata.smb.response.has("native_os") {
+    $event.ocsf.device.os.name = move $event.suricata.smb.response.native_os?
+    $event.ocsf.metadata.profiles = $event.ocsf.metadata?.profiles?.add("host")
   }
 }
 
-if suricata.smb.has("filename") {
-  suricata::ocsf::map_smb_file
+if $event.suricata.smb.has("filename") {
+  suricata::ocsf::map_smb_file event=$event
 }
 
-ocsf.status_code = move suricata.smb.status_code
-ocsf.status_detail = move suricata.smb.status
-ocsf.status_id = 1 if ocsf.status_code? == "0x0" else 2
+$event.ocsf.status_code = move $event.suricata.smb.status_code
+$event.ocsf.status_detail = move $event.suricata.smb.status
+$event.ocsf.status_id = 1 if $event.ocsf.status_code? == "0x0" else 2
 
-ocsf.tree_uid = string(move suricata.smb.tree_id?)
+$event.ocsf.tree_uid = string(move $event.suricata.smb.tree_id?)
 
 // --- Finalize ---------------------------------
 

--- a/suricata/operators/ocsf/logs/smtp.tql
+++ b/suricata/operators/ocsf/logs/smtp.tql
@@ -1,31 +1,38 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 5
+$event.ocsf.activity_id = 5
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4009
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4009
 
 // Severity: informational for normal operations
-ocsf.severity_id = 1
+$event.ocsf.severity_id = 1
 
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.direction_id = 0
+$event.ocsf.direction_id = 0
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.protocol_name = "SMTP"
-ocsf.smtp_hello = move suricata.smtp.helo?
-ocsf.email = {
-  smtp_from: move suricata.smtp?.mail_from?,
-  smtp_to: move suricata.smtp?.rcpt_to?,
-  from_mailbox: move suricata.email?.from?,
-  to_mailboxes: move suricata.email?.to?,
+$event.ocsf.protocol_name = "SMTP"
+$event.ocsf.smtp_hello = move $event.suricata.smtp.helo?
+$event.ocsf.email = {
+  smtp_from: move $event.suricata.smtp?.mail_from?,
+  smtp_to: move $event.suricata.smtp?.rcpt_to?,
+  from_mailbox: move $event.suricata.email?.from?,
+  to_mailboxes: move $event.suricata.email?.to?,
 }
-ocsf.status_id = 1 if suricata.email?.status? == "PARSE_DONE" else 0
-ocsf.status_detail = move suricata.email?.status?
+$event.ocsf.status_id = 1 if $event.suricata.email?.status? == "PARSE_DONE" else 0
+$event.ocsf.status_detail = move $event.suricata.email?.status?
 
 drop_null_fields
 

--- a/suricata/operators/ocsf/logs/snmp.tql
+++ b/suricata/operators/ocsf/logs/snmp.tql
@@ -1,15 +1,22 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 0
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 0
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.app_protocol_name = "snmp"
-ocsf.status_id = 0
+$event.ocsf.app_protocol_name = "snmp"
+$event.ocsf.status_id = 0
 
 // --- Finalize ---------------------------------
 

--- a/suricata/operators/ocsf/logs/ssh.tql
+++ b/suricata/operators/ocsf/logs/ssh.tql
@@ -1,41 +1,48 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 6
+$event.ocsf.activity_id = 6
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4007
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4007
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: primary attributes -----------------
 
-if suricata.ssh.server?.proto_version? != null {
-  ocsf.protocol_ver = move suricata.ssh.server.proto_version
-} else if suricata.ssh.client?.proto_version? != null {
-  ocsf.protocol_ver = move suricata.ssh.client.proto_version
+if $event.suricata.ssh.server?.proto_version? != null {
+  $event.ocsf.protocol_ver = move $event.suricata.ssh.server.proto_version
+} else if $event.suricata.ssh.client?.proto_version? != null {
+  $event.ocsf.protocol_ver = move $event.suricata.ssh.client.proto_version
 }
 
-if suricata.ssh.client?.has("hassh") {
-  ocsf.client_hassh = {
-    algorithm: move suricata.ssh.client.hassh.string,
+if $event.suricata.ssh.client?.has("hassh") {
+  $event.ocsf.client_hassh = {
+    algorithm: move $event.suricata.ssh.client.hassh.string,
     fingerprint: {
       algorithm_id: 20,
-      value: move suricata.ssh.client.hassh.hash,
+      value: move $event.suricata.ssh.client.hassh.hash,
     },
   }
 }
 
-if suricata.ssh.server?.has("hassh") {
-  ocsf.server_hassh = {
-    algorithm: move suricata.ssh.server.hassh.string,
+if $event.suricata.ssh.server?.has("hassh") {
+  $event.ocsf.server_hassh = {
+    algorithm: move $event.suricata.ssh.server.hassh.string,
     fingerprint: {
       algorithm_id: 20,
-      value: move suricata.ssh.server.hassh.hash,
+      value: move $event.suricata.ssh.server.hassh.hash,
     },
   }
 }
 
-ocsf.status_id = 0
+$event.ocsf.status_id = 0
 
 // --- Finalize ---------------------------------
 

--- a/suricata/operators/ocsf/logs/tls.tql
+++ b/suricata/operators/ocsf/logs/tls.tql
@@ -1,46 +1,53 @@
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 6
+$event.ocsf.activity_id = 6
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.app_protocol_name = "tls"
-ocsf.tls = {
+$event.ocsf.app_protocol_name = "tls"
+$event.ocsf.tls = {
   ja3_hash: {
     algorithm_id: 1,
-    value: move suricata.tls.ja3?.hash?,
+    value: move $event.suricata.tls.ja3?.hash?,
   },
   ja3s_hash: {
     algorithm_id: 1,
-    value: move suricata.tls.ja3s?.hash?,
+    value: move $event.suricata.tls.ja3s?.hash?,
   },
-  sni: move suricata.tls.sni?,
-  version: move suricata.tls.version? else "Unknown",
+  sni: move $event.suricata.tls.sni?,
+  version: move $event.suricata.tls.version? else "Unknown",
 }
 
-ocsf.tls.certificate = {
-  expiration_time: move suricata.tls.notafter?,
-  issuer: move suricata.tls.issuerdn?,
-  serial_number: move suricata.tls.serial?,
-  subject: move suricata.tls.subject?,
+$event.ocsf.tls.certificate = {
+  expiration_time: move $event.suricata.tls.notafter?,
+  issuer: move $event.suricata.tls.issuerdn?,
+  serial_number: move $event.suricata.tls.serial?,
+  subject: move $event.suricata.tls.subject?,
 }
 
-if suricata.tls.has("fingerprint") {
-  ocsf.tls.certificate.fingerprints = [{
+if $event.suricata.tls.has("fingerprint") {
+  $event.ocsf.tls.certificate.fingerprints = [{
     algorithm_id: 2,
-    value: suricata.tls.fingerprint.replace(":", ""),
+    value: $event.suricata.tls.fingerprint.replace(":", ""),
   }]
-  drop suricata.tls.fingerprint
+  drop $event.suricata.tls.fingerprint
 }
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.status_id = 0
+$event.ocsf.status_id = 0
 
 drop_null_fields
 

--- a/suricata/operators/ocsf/map.tql
+++ b/suricata/operators/ocsf/map.tql
@@ -1,32 +1,37 @@
 ---
 description: Suricata EVE JSON -> OCSF
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
 // Helpful information for mappers:
 // - https://github.com/OISF/suricata/blob/main/etc/schema.json
 
-this = {suricata: this}
-ocsf = {}
+$event = {...$event, suricata: $event, ocsf: {}}
 
 // --- OCSF: classification attributes ----------
 
-ocsf.category_uid = 4
-ocsf.severity_id = 1
+$event.ocsf.category_uid = 4
+$event.ocsf.severity_id = 1
 
 // --- OCSF: occurrence attributes --------------
 
-ocsf.time = move suricata.timestamp
-if suricata.event_type in ["flow", "netflow"] and suricata.flow? != null {
-  ocsf.start_time = move suricata.flow.start
-  ocsf.end_time = move suricata.flow.end
-  ocsf.duration = count_milliseconds(ocsf.end_time - ocsf.start_time).round()
+$event.ocsf.time = move $event.suricata.timestamp
+if $event.suricata.event_type in ["flow", "netflow"] and $event.suricata.flow? != null {
+  $event.ocsf.start_time = move $event.suricata.flow.start
+  $event.ocsf.end_time = move $event.suricata.flow.end
+  $event.ocsf.duration = count_milliseconds($event.ocsf.end_time - $event.ocsf.start_time).round()
 }
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata = {
+$event.ocsf.metadata = {
   log_format: "json",
-  log_name: suricata.event_type,
+  log_name: $event.suricata.event_type,
   product: {
     name: "Suricata",
     vendor_name: "Open Information Security Foundation",
@@ -34,130 +39,130 @@ ocsf.metadata = {
   },
   version: "1.8.0",
 }
-if suricata.pcap_cnt? != null {
-  ocsf.metadata.sequence = move suricata.pcap_cnt
+if $event.suricata.pcap_cnt? != null {
+  $event.ocsf.metadata.sequence = move $event.suricata.pcap_cnt
 }
-if suricata.flow_id? != null {
-  ocsf.metadata.original_event_uid = suricata.flow_id.string()
-  ocsf.metadata.correlation_uid = suricata.flow_id.string()
+if $event.suricata.flow_id? != null {
+  $event.ocsf.metadata.original_event_uid = $event.suricata.flow_id.string()
+  $event.ocsf.metadata.correlation_uid = $event.suricata.flow_id.string()
 }
 
 // Prefer flow initiator/responder fields when Suricata provides them. Alert
 // packets can point in the opposite direction of the flow that triggered them.
-if suricata.flow?.src_ip? != null {
-  ocsf.src_endpoint.ip = move suricata.flow.src_ip
-} else if suricata.src_ip? != null {
-  ocsf.src_endpoint.ip = move suricata.src_ip
+if $event.suricata.flow?.src_ip? != null {
+  $event.ocsf.src_endpoint.ip = move $event.suricata.flow.src_ip
+} else if $event.suricata.src_ip? != null {
+  $event.ocsf.src_endpoint.ip = move $event.suricata.src_ip
 }
-if suricata.flow?.dest_ip? != null {
-  ocsf.dst_endpoint.ip = move suricata.flow.dest_ip
-} else if suricata.dest_ip? != null {
-  ocsf.dst_endpoint.ip = move suricata.dest_ip
+if $event.suricata.flow?.dest_ip? != null {
+  $event.ocsf.dst_endpoint.ip = move $event.suricata.flow.dest_ip
+} else if $event.suricata.dest_ip? != null {
+  $event.ocsf.dst_endpoint.ip = move $event.suricata.dest_ip
 }
-if suricata.flow?.src_port? != null {
-  ocsf.src_endpoint.port = move suricata.flow.src_port
-} else if suricata.src_port? != null {
-  ocsf.src_endpoint.port = move suricata.src_port
+if $event.suricata.flow?.src_port? != null {
+  $event.ocsf.src_endpoint.port = move $event.suricata.flow.src_port
+} else if $event.suricata.src_port? != null {
+  $event.ocsf.src_endpoint.port = move $event.suricata.src_port
 }
-if suricata.flow?.dest_port? != null {
-  ocsf.dst_endpoint.port = move suricata.flow.dest_port
-} else if suricata.dest_port? != null {
-  ocsf.dst_endpoint.port = move suricata.dest_port
+if $event.suricata.flow?.dest_port? != null {
+  $event.ocsf.dst_endpoint.port = move $event.suricata.flow.dest_port
+} else if $event.suricata.dest_port? != null {
+  $event.ocsf.dst_endpoint.port = move $event.suricata.dest_port
 }
 
-if suricata.event_type != "krb5" and suricata.event_type != "smtp" {
-  if suricata.ip_v? != null {
-    ocsf.connection_info.protocol_ver_id = move suricata.ip_v
-  } else if ocsf.src_endpoint?.ip? != null {
-    ocsf.connection_info.protocol_ver_id = 6 if ocsf.src_endpoint.ip.is_v6() else 4
-  } else if ocsf.dst_endpoint?.ip? != null {
-    ocsf.connection_info.protocol_ver_id = 6 if ocsf.dst_endpoint.ip.is_v6() else 4
+if $event.suricata.event_type != "krb5" and $event.suricata.event_type != "smtp" {
+  if $event.suricata.ip_v? != null {
+    $event.ocsf.connection_info.protocol_ver_id = move $event.suricata.ip_v
+  } else if $event.ocsf.src_endpoint?.ip? != null {
+    $event.ocsf.connection_info.protocol_ver_id = 6 if $event.ocsf.src_endpoint.ip.is_v6() else 4
+  } else if $event.ocsf.dst_endpoint?.ip? != null {
+    $event.ocsf.connection_info.protocol_ver_id = 6 if $event.ocsf.dst_endpoint.ip.is_v6() else 4
   }
 
-  if suricata.flow_id? != null {
-    ocsf.connection_info.uid = suricata.flow_id.string()
+  if $event.suricata.flow_id? != null {
+    $event.ocsf.connection_info.uid = $event.suricata.flow_id.string()
   }
 
-  if suricata.proto? != null {
+  if $event.suricata.proto? != null {
     let $proto_nums = {
       TCP: 6,
       UDP: 17,
       ICMP: 1,
       ICMPV6: 58,
     }
-    ocsf.connection_info.protocol_name = suricata.proto.to_lower()
-    ocsf.connection_info.protocol_num = $proto_nums[suricata.proto] else -1
-    drop suricata.proto
+    $event.ocsf.connection_info.protocol_name = $event.suricata.proto.to_lower()
+    $event.ocsf.connection_info.protocol_num = $proto_nums[$event.suricata.proto] else -1
+    drop $event.suricata.proto
   }
 
-  if suricata.community_id? != null {
-    ocsf.connection_info.community_uid = move suricata.community_id
+  if $event.suricata.community_id? != null {
+    $event.ocsf.connection_info.community_uid = move $event.suricata.community_id
   }
 }
 
 let $event_types_without_app_proto = ["alert", "krb5", "smtp"]
-if suricata.app_proto? != null and suricata.app_proto != "failed" and not (suricata.event_type in $event_types_without_app_proto) {
-  ocsf.app_protocol_name = move suricata.app_proto
+if $event.suricata.app_proto? != null and $event.suricata.app_proto != "failed" and not ($event.suricata.event_type in $event_types_without_app_proto) {
+  $event.ocsf.app_protocol_name = move $event.suricata.app_proto
 }
-drop suricata.flow_id?
+drop $event.suricata.flow_id?
 
 // --- Event-specific mapping -------------------
 
-match suricata.event_type {
+match $event.suricata.event_type {
   "alert" => {
-    suricata::ocsf::logs::alert
+    suricata::ocsf::logs::alert event=$event
   }
   "anomaly" => {
-    suricata::ocsf::logs::anomaly
+    suricata::ocsf::logs::anomaly event=$event
   }
   "dhcp" => {
-    suricata::ocsf::logs::dhcp
+    suricata::ocsf::logs::dhcp event=$event
   }
   "dns" => {
-    suricata::ocsf::logs::dns
+    suricata::ocsf::logs::dns event=$event
   }
   "fileinfo" => {
-    suricata::ocsf::logs::fileinfo
+    suricata::ocsf::logs::fileinfo event=$event
   }
   "flow" | "netflow" => {
-    suricata::ocsf::logs::flow
+    suricata::ocsf::logs::flow event=$event
   }
   "ftp" => {
-    suricata::ocsf::logs::ftp
+    suricata::ocsf::logs::ftp event=$event
   }
   "http" => {
-    suricata::ocsf::logs::http
+    suricata::ocsf::logs::http event=$event
   }
   "krb5" => {
-    suricata::ocsf::logs::krb5
+    suricata::ocsf::logs::krb5 event=$event
   }
   "mqtt" => {
-    suricata::ocsf::logs::mqtt
+    suricata::ocsf::logs::mqtt event=$event
   }
   "sip" => {
-    suricata::ocsf::logs::sip
+    suricata::ocsf::logs::sip event=$event
   }
   "smb" => {
-    suricata::ocsf::logs::smb
+    suricata::ocsf::logs::smb event=$event
   }
   "smtp" => {
-    suricata::ocsf::logs::smtp
+    suricata::ocsf::logs::smtp event=$event
   }
   "snmp" => {
-    suricata::ocsf::logs::snmp
+    suricata::ocsf::logs::snmp event=$event
   }
   "ssh" => {
-    suricata::ocsf::logs::ssh
+    suricata::ocsf::logs::ssh event=$event
   }
   "tls" => {
-    suricata::ocsf::logs::tls
+    suricata::ocsf::logs::tls event=$event
   }
   _ => {
-    suricata::ocsf::base
+    suricata::ocsf::base event=$event
   }
 }
 
 // --- Epilogue ---------------------------------
 
-drop suricata.event_type
-this = {...ocsf, unmapped: suricata}
+drop $event.suricata.event_type
+$event = {...$event.ocsf, unmapped: $event.suricata}

--- a/suricata/operators/ocsf/map_dns_query.tql
+++ b/suricata/operators/ocsf/map_dns_query.tql
@@ -1,9 +1,16 @@
-assert suricata.dns.has("queries")
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
+assert $event.suricata.dns.has("queries")
 
-ocsf.query = {
-  hostname: suricata.dns.queries[0].rrname,
-  type: suricata.dns.queries[0].rrtype,
+$event.ocsf.query = {
+  hostname: $event.suricata.dns.queries[0].rrname,
+  type: $event.suricata.dns.queries[0].rrtype,
 }
 // TODO: is there ever more than one query in practice?
 //assert suricata.dns.queries.length() == 1
-drop suricata.dns.queries
+drop $event.suricata.dns.queries

--- a/suricata/operators/ocsf/map_flow.tql
+++ b/suricata/operators/ocsf/map_flow.tql
@@ -1,10 +1,17 @@
-assert suricata.has("flow")
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
+assert $event.suricata.has("flow")
 
-ocsf.traffic = {
-  bytes_in: move suricata.flow.bytes_toclient,
-  bytes_out: move suricata.flow.bytes_toserver,
-  packets_in: move suricata.flow.pkts_toclient,
-  packets_out: move suricata.flow.pkts_toserver,
+$event.ocsf.traffic = {
+  bytes_in: move $event.suricata.flow.bytes_toclient,
+  bytes_out: move $event.suricata.flow.bytes_toserver,
+  packets_in: move $event.suricata.flow.pkts_toclient,
+  packets_out: move $event.suricata.flow.pkts_toserver,
 }
-ocsf.traffic.bytes = ocsf.traffic.bytes_in + ocsf.traffic.bytes_out
-ocsf.traffic.packets = ocsf.traffic.packets_in + ocsf.traffic.packets_out
+$event.ocsf.traffic.bytes = $event.ocsf.traffic.bytes_in + $event.ocsf.traffic.bytes_out
+$event.ocsf.traffic.packets = $event.ocsf.traffic.packets_in + $event.ocsf.traffic.packets_out

--- a/suricata/operators/ocsf/map_http.tql
+++ b/suricata/operators/ocsf/map_http.tql
@@ -1,34 +1,41 @@
-assert suricata.has("http")
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
+assert $event.suricata.has("http")
 
-suricata.http._hostname = move suricata.http.hostname
-suricata.http._url = move suricata.http.url
-suricata.http._url_parts = suricata.http._url.split("?", max=1)
+$event.suricata.http._hostname = move $event.suricata.http.hostname
+$event.suricata.http._url = move $event.suricata.http.url
+$event.suricata.http._url_parts = $event.suricata.http._url.split("?", max=1)
 
-ocsf.http_request.url = {
-  hostname: suricata.http._hostname.string(),
-  path: suricata.http._url_parts[0],
+$event.ocsf.http_request.url = {
+  hostname: $event.suricata.http._hostname.string(),
+  path: $event.suricata.http._url_parts[0],
   scheme: "http",
-  url_string: f"http://{suricata.http._hostname.string()}{suricata.http._url}",
+  url_string: f"http://{$event.suricata.http._hostname.string()}{$event.suricata.http._url}",
 }
-ocsf.http_request.http_method = move suricata.http.http_method?
-ocsf.http_request.referrer = move suricata.http.http_refer?
-ocsf.http_request.user_agent = move suricata.http.http_user_agent?
-ocsf.http_request.version = move suricata.http.protocol?
-if suricata.http._url_parts.length() == 2 {
-  ocsf.http_request.url.query_string = suricata.http._url_parts[1]
+$event.ocsf.http_request.http_method = move $event.suricata.http.http_method?
+$event.ocsf.http_request.referrer = move $event.suricata.http.http_refer?
+$event.ocsf.http_request.user_agent = move $event.suricata.http.http_user_agent?
+$event.ocsf.http_request.version = move $event.suricata.http.protocol?
+if $event.suricata.http._url_parts.length() == 2 {
+  $event.ocsf.http_request.url.query_string = $event.suricata.http._url_parts[1]
 }
-drop suricata.http._hostname
-drop suricata.http._url
-drop suricata.http._url_parts
-if suricata.http.has("request_headers") {
-  ocsf.http_request.http_headers = move suricata.http.request_headers
+drop $event.suricata.http._hostname
+drop $event.suricata.http._url
+drop $event.suricata.http._url_parts
+if $event.suricata.http.has("request_headers") {
+  $event.ocsf.http_request.http_headers = move $event.suricata.http.request_headers
 }
 
-ocsf.http_response.body_length = move suricata.http.length?
-ocsf.http_response.content_type = move suricata.http.http_content_type?
-if suricata.http.has("status") {
-  ocsf.http_response.code = move suricata.http.status
+$event.ocsf.http_response.body_length = move $event.suricata.http.length?
+$event.ocsf.http_response.content_type = move $event.suricata.http.http_content_type?
+if $event.suricata.http.has("status") {
+  $event.ocsf.http_response.code = move $event.suricata.http.status
 }
-if suricata.http.has("response_headers") {
-  ocsf.http_response.http_headers = move suricata.http.response_headers
+if $event.suricata.http.has("response_headers") {
+  $event.ocsf.http_response.http_headers = move $event.suricata.http.response_headers
 }

--- a/suricata/operators/ocsf/map_smb_file.tql
+++ b/suricata/operators/ocsf/map_smb_file.tql
@@ -1,9 +1,16 @@
-assert suricata.smb.has("filename")
+---
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+---
+assert $event.suricata.smb.has("filename")
 
-ocsf.file = {
-  accessed_time: move suricata.smb.accessed?.milliseconds().from_epoch(),
-  created_time: move suricata.smb.created?.milliseconds().from_epoch(),
-  modified_time: move suricata.smb.modified?.milliseconds().from_epoch(),
-  name: move suricata.smb.filename,
+$event.ocsf.file = {
+  accessed_time: move $event.suricata.smb.accessed?.milliseconds().from_epoch(),
+  created_time: move $event.suricata.smb.created?.milliseconds().from_epoch(),
+  modified_time: move $event.suricata.smb.modified?.milliseconds().from_epoch(),
+  name: move $event.suricata.smb.filename,
   type_id: 0,
 }

--- a/sysmon/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/sysmon/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,25 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:23.948112Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope. Preserve raw log data by parsing first, mapping the parsed event, and assigning `raw_data` and `raw_data_size` after mapping.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+source.raw_data = move raw
+source.raw_data_size = source.raw_data.length_bytes()
+this = source
+```

--- a/sysmon/operators/ocsf/events/clipboard_change.tql
+++ b/sysmon/operators/ocsf/events/clipboard_change.tql
@@ -3,10 +3,15 @@ description: >
   Sysmon ClipboardChange (EID 24) → OCSF Base Event (0).
   No OCSF 1.7.0 class covers clipboard monitoring events;
   all fields are preserved in unmapped for downstream use.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // Base Event — no specific OCSF class for clipboard activity.
-ocsf.category_uid = 0
-ocsf.class_uid = 0
-ocsf.activity_id = 0
-ocsf.type_uid = 0
+$event.ocsf.category_uid = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.type_uid = 0

--- a/sysmon/operators/ocsf/events/create_remote_thread.tql
+++ b/sysmon/operators/ocsf/events/create_remote_thread.tql
@@ -1,71 +1,76 @@
 ---
 description: Sysmon CreateRemoteThread (EID 8) → OCSF Process Activity (1007, Inject)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.process_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1007
-ocsf.activity_id = 4  // Inject
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1007
+$event.ocsf.activity_id = 4  // Inject
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-ocsf.injection_type_id = 1  // Remote Thread
+$event.ocsf.injection_type_id = 1  // Remote Thread
 
 // The process that injected the thread is the actor.
-_src_user = (move sysmon.EventData.SourceUser).split("\\")
-ocsf.actor = {
+$event._src_user = (move $event.sysmon.EventData.SourceUser).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid:  move sysmon.EventData.SourceProcessGuid,
-    pid:  (move sysmon.EventData.SourceProcessId).int(),
-    path: move sysmon.EventData.SourceImage,
+    uid:  move $event.sysmon.EventData.SourceProcessGuid,
+    pid:  (move $event.sysmon.EventData.SourceProcessId).int(),
+    path: move $event.sysmon.EventData.SourceImage,
     file: { type_id: 8 },
   },
   user: {
-    name:   _src_user[-1],
-    domain: _src_user[0] if _src_user.length() > 1 else null,
+    name:   $event._src_user[-1],
+    domain: $event._src_user[0] if $event._src_user.length() > 1 else null,
   },
 }
-drop _src_user
+drop $event._src_user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path
 
 // The target process that received the injected thread.
-_tgt_user = (move sysmon.EventData.TargetUser).split("\\")
-ocsf.process = {
-  uid:  move sysmon.EventData.TargetProcessGuid,
-  pid:  (move sysmon.EventData.TargetProcessId).int(),
-  path: move sysmon.EventData.TargetImage,
+$event._tgt_user = (move $event.sysmon.EventData.TargetUser).split("\\")
+$event.ocsf.process = {
+  uid:  move $event.sysmon.EventData.TargetProcessGuid,
+  pid:  (move $event.sysmon.EventData.TargetProcessId).int(),
+  path: move $event.sysmon.EventData.TargetImage,
   file: { type_id: 8 },
   user: {
-    name:   _tgt_user[-1],
-    domain: _tgt_user[0] if _tgt_user.length() > 1 else null,
+    name:   $event._tgt_user[-1],
+    domain: $event._tgt_user[0] if $event._tgt_user.length() > 1 else null,
   },
 }
-drop _tgt_user
+drop $event._tgt_user
 
-ocsf.process.name = ocsf.process.path.split("\\")[-1]
-ocsf.process.file.name = ocsf.process.name
-ocsf.process.file.path = ocsf.process.path
+$event.ocsf.process.name = $event.ocsf.process.path.split("\\")[-1]
+$event.ocsf.process.file.name = $event.ocsf.process.name
+$event.ocsf.process.file.path = $event.ocsf.process.path
 
 
 // The injected module carries the thread's start address and optional module/function.
 // Replace "-" sentinels so absent fields can be handled without branching on strings.
-replace sysmon.EventData.StartModule,   what="-", with=null
-replace sysmon.EventData.StartFunction, what="-", with=null
+replace $event.sysmon.EventData.StartModule,   what="-", with=null
+replace $event.sysmon.EventData.StartFunction, what="-", with=null
 
-ocsf.module = {
-  base_address: move sysmon.EventData.StartAddress,
+$event.ocsf.module = {
+  base_address: move $event.sysmon.EventData.StartAddress,
 }
-if sysmon.EventData.StartModule != null {
-  ocsf.module.file = { name: move sysmon.EventData.StartModule }
+if $event.sysmon.EventData.StartModule != null {
+  $event.ocsf.module.file = { name: move $event.sysmon.EventData.StartModule }
 }
-if sysmon.EventData.StartFunction != null {
-  ocsf.module.function_name = move sysmon.EventData.StartFunction
+if $event.sysmon.EventData.StartFunction != null {
+  $event.ocsf.module.function_name = move $event.sysmon.EventData.StartFunction
 }
-drop sysmon.EventData.StartModule
-drop sysmon.EventData.StartFunction
+drop $event.sysmon.EventData.StartModule
+drop $event.sysmon.EventData.StartFunction
 
 // Map the new thread's ID to process.ptid (the canonical OCSF thread identifier).
-ocsf.process.ptid = (move sysmon.EventData.NewThreadId).int()
+$event.ocsf.process.ptid = (move $event.sysmon.EventData.NewThreadId).int()

--- a/sysmon/operators/ocsf/events/dns_query.tql
+++ b/sysmon/operators/ocsf/events/dns_query.tql
@@ -1,28 +1,33 @@
 ---
 description: Sysmon DnsQuery (EID 22) → OCSF DNS Activity (4003, Query)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.dns_activity"
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4003
-ocsf.activity_id = 1  // Query
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4003
+$event.ocsf.activity_id = 1  // Query
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // Sysmon always knows the DNS client process; the query is outbound.
 // Note: is_src_dst_assignment_known is not part of DNS Activity (4003) — only
 // Network Activity (4001) defines it.
-ocsf.connection_info = { direction_id: 2 }  // Outbound
+$event.ocsf.connection_info = { direction_id: 2 }  // Outbound
 
-ocsf.query = {
-  hostname:  move sysmon.EventData.QueryName,
+$event.ocsf.query = {
+  hostname:  move $event.sysmon.EventData.QueryName,
   opcode_id: 0,  // Standard query
 }
 
 // QueryStatus 0 = success (RCODE NOERROR); anything else is an error.
 // Read first for status_id, then move for status_code.
-ocsf.status_id = 1 if sysmon.EventData.QueryStatus == 0 else 2
-ocsf.status_code = (move sysmon.EventData.QueryStatus).string()
+$event.ocsf.status_id = 1 if $event.sysmon.EventData.QueryStatus == 0 else 2
+$event.ocsf.status_code = (move $event.sysmon.EventData.QueryStatus).string()
 
 // Sysmon bundles CNAME chains + IPs into QueryResults as a semicolon-separated
 // string (e.g. "type:  5 cdn.example.com;::ffff:1.2.3.4;"). There is no clean
@@ -30,23 +35,23 @@ ocsf.status_code = (move sysmon.EventData.QueryStatus).string()
 // raw field is left in unmapped.EventData for consumers that need it.
 
 // The process and user that issued the query — mapped via the Host profile actor.
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid:  move sysmon.EventData.ProcessGuid,
-    pid:  (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid:  move $event.sysmon.EventData.ProcessGuid,
+    pid:  (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: { type_id: 8 },
   },
   user: {
-    name:   _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name:   $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path
 
-drop sysmon.EventData.Initiated  // always "true" for Sysmon DNS events
+drop $event.sysmon.EventData.Initiated  // always "true" for Sysmon DNS events

--- a/sysmon/operators/ocsf/events/driver_load.tql
+++ b/sysmon/operators/ocsf/events/driver_load.tql
@@ -1,30 +1,35 @@
 ---
 description: Sysmon DriverLoad (EID 6) → OCSF Kernel Extension Activity (1002, Load)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.kernel_extension_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1002
-ocsf.activity_id = 1  // Load
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1002
+$event.ocsf.activity_id = 1  // Load
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 let $algorithms = { MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4 }
 let $sig_states  = { Valid: 1, Expired: 2, Revoked: 3, Untrusted: 6 }
 
 // Sysmon reports driver loads from the kernel (PID 4 / System), so there is no
 // meaningful user-space actor. The required actor object is left empty.
-ocsf.actor = {}
+$event.ocsf.actor = {}
 
 // Replace "-" sentinels before building the file object.
-replace sysmon.EventData.Signature, what="-", with=null
-replace sysmon.EventData.SignatureStatus, what="-", with=null
+replace $event.sysmon.EventData.Signature, what="-", with=null
+replace $event.sysmon.EventData.SignatureStatus, what="-", with=null
 
-ocsf.driver = {
+$event.ocsf.driver = {
   file: {
-    path: move sysmon.EventData.ImageLoaded,
+    path: move $event.sysmon.EventData.ImageLoaded,
     type_id: 8,  // Executable File (kernel drivers are PE images)
-    hashes: ((move sysmon.EventData.Hashes)
+    hashes: ((move $event.sysmon.EventData.Hashes)
                .split(",")
                .map(h => h.split("=", max=1))
                .map(kv => {
@@ -33,20 +38,20 @@ ocsf.driver = {
                })),
   },
 }
-ocsf.driver.file.name = ocsf.driver.file.path.split("\\")[-1]
+$event.ocsf.driver.file.name = $event.ocsf.driver.file.path.split("\\")[-1]
 
 // Attach digital-signature details when the driver is signed.
-if sysmon.EventData.Signed {
-  ocsf.driver.file.signature = {
+if $event.sysmon.EventData.Signed {
+  $event.ocsf.driver.file.signature = {
     algorithm_id: 0,  // Unknown — Sysmon does not report the algorithm
-    state_id: $sig_states[sysmon.EventData.SignatureStatus]?,
+    state_id: $sig_states[$event.sysmon.EventData.SignatureStatus]?,
   }
-  if sysmon.EventData.Signature != null {
-    ocsf.driver.file.signature.certificate = {
-      issuer: move sysmon.EventData.Signature,
+  if $event.sysmon.EventData.Signature != null {
+    $event.ocsf.driver.file.signature.certificate = {
+      issuer: move $event.sysmon.EventData.Signature,
     }
   }
 }
-drop sysmon.EventData.Signed
-drop sysmon.EventData.Signature
-drop sysmon.EventData.SignatureStatus
+drop $event.sysmon.EventData.Signed
+drop $event.sysmon.EventData.Signature
+drop $event.sysmon.EventData.SignatureStatus

--- a/sysmon/operators/ocsf/events/file_block.tql
+++ b/sysmon/operators/ocsf/events/file_block.tql
@@ -4,32 +4,37 @@ description: >
   OCSF File System Activity (1001).
   EID 27 blocks PE creation (activity Create, status Failure).
   EID 28 blocks secure-delete/shredding (activity Delete, status Failure).
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.file_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1001
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1001
 
-ocsf.activity_id = 4 if ocsf.metadata.event_code == "28" else 1  // Delete / Create
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 4 if $event.ocsf.metadata.event_code == "28" else 1  // Delete / Create
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // Both events are blocking events — the operation was prevented.
-ocsf.status_id = 2  // Failure
+$event.ocsf.status_id = 2  // Failure
 
 let $algorithms = { MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4 }
 
 
 // IsExecutable is present on EID 28; absent on EID 27 (implicitly true).
 // If explicitly false, downgrade type_id to Regular File.
-ocsf.file = {
-  path: move sysmon.EventData.TargetFilename,
-  type_id: 1 if sysmon.EventData.IsExecutable? == false else 8,
+$event.ocsf.file = {
+  path: move $event.sysmon.EventData.TargetFilename,
+  type_id: 1 if $event.sysmon.EventData.IsExecutable? == false else 8,
 }
-ocsf.file.name = ocsf.file.path.split("\\")[-1]
-drop sysmon.EventData.IsExecutable?  // may be absent on EID 27
+$event.ocsf.file.name = $event.ocsf.file.path.split("\\")[-1]
+drop $event.sysmon.EventData.IsExecutable?  // may be absent on EID 27
 
-ocsf.file.hashes = ((move sysmon.EventData.Hashes)
+$event.ocsf.file.hashes = ((move $event.sysmon.EventData.Hashes)
   .split(",")
   .map(h => h.split("=", max=1))
   .map(kv => {
@@ -37,22 +42,22 @@ ocsf.file.hashes = ((move sysmon.EventData.Hashes)
     value: kv[1]?,
   }))
 
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid: move sysmon.EventData.ProcessGuid,
-    pid: (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid: move $event.sysmon.EventData.ProcessGuid,
+    pid: (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: { type_id: 8 },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path
 

--- a/sysmon/operators/ocsf/events/file_create.tql
+++ b/sysmon/operators/ocsf/events/file_create.tql
@@ -1,41 +1,46 @@
 ---
 description: Sysmon FileCreate (EID 11) → OCSF File System Activity (1001, Create)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.file_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1001
-ocsf.activity_id = 1  // Create
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1001
+$event.ocsf.activity_id = 1  // Create
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 
-ocsf.file = {
-  path: move sysmon.EventData.TargetFilename,
-  created_time: move sysmon.EventData.CreationUtcTime,
+$event.ocsf.file = {
+  path: move $event.sysmon.EventData.TargetFilename,
+  created_time: move $event.sysmon.EventData.CreationUtcTime,
   type_id: 1,  // Regular File
 }
-ocsf.file.name = ocsf.file.path.split("\\")[-1]
+$event.ocsf.file.name = $event.ocsf.file.path.split("\\")[-1]
 
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid: move sysmon.EventData.ProcessGuid,
-    pid: (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid: move $event.sysmon.EventData.ProcessGuid,
+    pid: (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: {
       type_id: 8,
     },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path
 
 

--- a/sysmon/operators/ocsf/events/file_create_stream_hash.tql
+++ b/sysmon/operators/ocsf/events/file_create_stream_hash.tql
@@ -1,35 +1,40 @@
 ---
 description: Sysmon FileCreateStreamHash (EID 15) → OCSF File System Activity (1001, Create)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.file_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1001
-ocsf.activity_id = 1  // Create
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1001
+$event.ocsf.activity_id = 1  // Create
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 let $algorithms = { MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4 }
 
 // TargetFilename format: "C:\path\file.exe:Zone.Identifier"
 // Split on all colons, then rejoin all-but-last to reconstruct the full file path
 // (which itself contains a colon after the drive letter).
-_target = move sysmon.EventData.TargetFilename
+$event._target = move $event.sysmon.EventData.TargetFilename
 
-ocsf.file = {
-  path: _target.split(":").slice(end=-1).join(":"),
-  created_time: move sysmon.EventData.CreationUtcTime,
+$event.ocsf.file = {
+  path: $event._target.split(":").slice(end=-1).join(":"),
+  created_time: move $event.sysmon.EventData.CreationUtcTime,
   type_id: 1,  // Regular File
 }
-ocsf.file.name = ocsf.file.path.split("\\")[-1]
+$event.ocsf.file.name = $event.ocsf.file.path.split("\\")[-1]
 
 // The ADS stream name (e.g. "Zone.Identifier") maps to the OCSF component field.
-ocsf.component = _target.split(":")[-1]
+$event.ocsf.component = $event._target.split(":")[-1]
 
-drop _target
+drop $event._target
 
 // Hash field uses the same comma-separated "ALGO=value" format as Hashes on other EIDs.
-ocsf.file.hashes = ((move sysmon.EventData.Hash)
+$event.ocsf.file.hashes = ((move $event.sysmon.EventData.Hash)
   .split(",")
   .map(h => h.split("=", max=1))
   .map(kv => {
@@ -40,21 +45,21 @@ ocsf.file.hashes = ((move sysmon.EventData.Hash)
 // Contents is the raw ADS content (e.g. Zone.Identifier data) — no OCSF field for it.
 // Left in unmapped.
 
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid: move sysmon.EventData.ProcessGuid,
-    pid: (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid: move $event.sysmon.EventData.ProcessGuid,
+    pid: (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: { type_id: 8 },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path

--- a/sysmon/operators/ocsf/events/file_create_time.tql
+++ b/sysmon/operators/ocsf/events/file_create_time.tql
@@ -1,50 +1,55 @@
 ---
 description: Sysmon FileCreateTime (EID 2) → OCSF File System Activity (1001, Set Attributes)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.file_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1001
-ocsf.activity_id = 6  // Set Attributes (timestamp modification / timestomping)
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1001
+$event.ocsf.activity_id = 6  // Set Attributes (timestamp modification / timestomping)
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 
-ocsf.file = {
-  path: move sysmon.EventData.TargetFilename,
-  created_time: move sysmon.EventData.PreviousCreationUtcTime,
+$event.ocsf.file = {
+  path: move $event.sysmon.EventData.TargetFilename,
+  created_time: move $event.sysmon.EventData.PreviousCreationUtcTime,
   type_id: 1,  // Regular File
 }
-ocsf.file.name = ocsf.file.path.split("\\")[-1]
+$event.ocsf.file.name = $event.ocsf.file.path.split("\\")[-1]
 
 // The resulting file — reflects the *new* (forged) creation timestamp.
-ocsf.file_result = {
-  path: ocsf.file.path,
-  name: ocsf.file.name,
-  created_time: move sysmon.EventData.CreationUtcTime,
+$event.ocsf.file_result = {
+  path: $event.ocsf.file.path,
+  name: $event.ocsf.file.name,
+  created_time: move $event.sysmon.EventData.CreationUtcTime,
   type_id: 1,  // Regular File
 }
 
 // The process that performed the timestamp modification.
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid: move sysmon.EventData.ProcessGuid,
-    pid: (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid: move $event.sysmon.EventData.ProcessGuid,
+    pid: (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: {
       type_id: 8,  // Executable File
     },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path
 
 

--- a/sysmon/operators/ocsf/events/file_delete.tql
+++ b/sysmon/operators/ocsf/events/file_delete.tql
@@ -4,26 +4,31 @@ description: >
   OCSF File System Activity (1001, Delete).
   Both events report a file deletion; EID 23 additionally archives the file
   to the Sysmon ArchiveDirectory (reflected in is_deleted and unmapped).
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.file_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1001
-ocsf.activity_id = 4  // Delete
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1001
+$event.ocsf.activity_id = 4  // Delete
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 let $algorithms = { MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4 }
 
 
-ocsf.file = {
-  path: move sysmon.EventData.TargetFilename,
-  type_id: 8 if (move sysmon.EventData.IsExecutable) else 1,
+$event.ocsf.file = {
+  path: move $event.sysmon.EventData.TargetFilename,
+  type_id: 8 if (move $event.sysmon.EventData.IsExecutable) else 1,
   is_deleted: true,
 }
-ocsf.file.name = ocsf.file.path.split("\\")[-1]
+$event.ocsf.file.name = $event.ocsf.file.path.split("\\")[-1]
 
-ocsf.file.hashes = ((move sysmon.EventData.Hashes)
+$event.ocsf.file.hashes = ((move $event.sysmon.EventData.Hashes)
   .split(",")
   .map(h => h.split("=", max=1))
   .map(kv => {
@@ -31,24 +36,24 @@ ocsf.file.hashes = ((move sysmon.EventData.Hashes)
     value: kv[1]?,
   }))
 
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid: move sysmon.EventData.ProcessGuid,
-    pid: (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid: move $event.sysmon.EventData.ProcessGuid,
+    pid: (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: { type_id: 8 },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path
 
 
 // Archived (EID 23 only) — no OCSF field; left in unmapped.

--- a/sysmon/operators/ocsf/events/file_executable_detected.tql
+++ b/sysmon/operators/ocsf/events/file_executable_detected.tql
@@ -1,5 +1,10 @@
 ---
 description: Sysmon FileExecutableDetected (EID 29) → OCSF File System Activity (1001, Create)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // FileExecutableDetected fires when a new PE file is written to disk (detection-only,
@@ -7,21 +12,21 @@ description: Sysmon FileExecutableDetected (EID 29) → OCSF File System Activit
 
 @name = "ocsf.file_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1001
-ocsf.activity_id = 1  // Create
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1001
+$event.ocsf.activity_id = 1  // Create
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 let $algorithms = { MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4 }
 
 
-ocsf.file = {
-  path: move sysmon.EventData.TargetFilename,
+$event.ocsf.file = {
+  path: move $event.sysmon.EventData.TargetFilename,
   type_id: 8,  // Executable File — EID 29 is PE-specific by definition
 }
-ocsf.file.name = ocsf.file.path.split("\\")[-1]
+$event.ocsf.file.name = $event.ocsf.file.path.split("\\")[-1]
 
-ocsf.file.hashes = ((move sysmon.EventData.Hashes)
+$event.ocsf.file.hashes = ((move $event.sysmon.EventData.Hashes)
   .split(",")
   .map(h => h.split("=", max=1))
   .map(kv => {
@@ -29,22 +34,22 @@ ocsf.file.hashes = ((move sysmon.EventData.Hashes)
     value: kv[1]?,
   }))
 
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid: move sysmon.EventData.ProcessGuid,
-    pid: (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid: move $event.sysmon.EventData.ProcessGuid,
+    pid: (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: { type_id: 8 },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path
 

--- a/sysmon/operators/ocsf/events/image_load.tql
+++ b/sysmon/operators/ocsf/events/image_load.tql
@@ -1,35 +1,40 @@
 ---
 description: Sysmon ImageLoad (EID 7) → OCSF Module Activity (1005, Load)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.module_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1005
-ocsf.activity_id = 1  // Load
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1005
+$event.ocsf.activity_id = 1  // Load
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 let $algorithms = { MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4 }
 let $sig_states  = { Valid: 1, Expired: 2, Revoked: 3, Untrusted: 6 }
 
 // Replace "-" sentinels so optional file-metadata fields can be moved unconditionally.
-replace sysmon.EventData.FileVersion, what="-", with=null
-replace sysmon.EventData.Description, what="-", with=null
-replace sysmon.EventData.Product, what="-", with=null
-replace sysmon.EventData.Company, what="-", with=null
-replace sysmon.EventData.OriginalFileName, what="-", with=null
-replace sysmon.EventData.Signature, what="-", with=null
-replace sysmon.EventData.SignatureStatus, what="-", with=null
+replace $event.sysmon.EventData.FileVersion, what="-", with=null
+replace $event.sysmon.EventData.Description, what="-", with=null
+replace $event.sysmon.EventData.Product, what="-", with=null
+replace $event.sysmon.EventData.Company, what="-", with=null
+replace $event.sysmon.EventData.OriginalFileName, what="-", with=null
+replace $event.sysmon.EventData.Signature, what="-", with=null
+replace $event.sysmon.EventData.SignatureStatus, what="-", with=null
 
-ocsf.module = {
+$event.ocsf.module = {
   file: {
-    path: move sysmon.EventData.ImageLoaded,
+    path: move $event.sysmon.EventData.ImageLoaded,
     type_id: 8,  // Executable File (DLLs are PE images)
-    version: move sysmon.EventData.FileVersion,
-    desc: move sysmon.EventData.Description,
-    company_name: move sysmon.EventData.Company,
-    internal_name: move sysmon.EventData.OriginalFileName,
-    hashes: ((move sysmon.EventData.Hashes)
+    version: move $event.sysmon.EventData.FileVersion,
+    desc: move $event.sysmon.EventData.Description,
+    company_name: move $event.sysmon.EventData.Company,
+    internal_name: move $event.sysmon.EventData.OriginalFileName,
+    hashes: ((move $event.sysmon.EventData.Hashes)
                .split(",")
                .map(h => h.split("=", max=1))
                .map(kv => {
@@ -38,45 +43,45 @@ ocsf.module = {
                })),
   },
 }
-ocsf.module.file.name = ocsf.module.file.path.split("\\")[-1]
+$event.ocsf.module.file.name = $event.ocsf.module.file.path.split("\\")[-1]
 
 // product.name is a required field — only add the object when the source has a value.
-if sysmon.EventData.Product != null {
-  ocsf.module.file.product = { name: move sysmon.EventData.Product }
+if $event.sysmon.EventData.Product != null {
+  $event.ocsf.module.file.product = { name: move $event.sysmon.EventData.Product }
 }
-drop sysmon.EventData.Product
+drop $event.sysmon.EventData.Product
 
 // Attach digital-signature details when the module is signed.
-if sysmon.EventData.Signed {
-  ocsf.module.file.signature = {
+if $event.sysmon.EventData.Signed {
+  $event.ocsf.module.file.signature = {
     algorithm_id: 0,  // Unknown — Sysmon does not report the algorithm
-    state_id: $sig_states[sysmon.EventData.SignatureStatus]?,
+    state_id: $sig_states[$event.sysmon.EventData.SignatureStatus]?,
   }
-  if sysmon.EventData.Signature != null {
-    ocsf.module.file.signature.certificate = {
-      issuer: move sysmon.EventData.Signature,
+  if $event.sysmon.EventData.Signature != null {
+    $event.ocsf.module.file.signature.certificate = {
+      issuer: move $event.sysmon.EventData.Signature,
     }
   }
 }
-drop sysmon.EventData.Signed
-drop sysmon.EventData.Signature
-drop sysmon.EventData.SignatureStatus
+drop $event.sysmon.EventData.Signed
+drop $event.sysmon.EventData.Signature
+drop $event.sysmon.EventData.SignatureStatus
 
 // The process that loaded the module.
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid: move sysmon.EventData.ProcessGuid,
-    pid: (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid: move $event.sysmon.EventData.ProcessGuid,
+    pid: (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: { type_id: 8 },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+drop $event._user
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path

--- a/sysmon/operators/ocsf/events/network_connect.tql
+++ b/sysmon/operators/ocsf/events/network_connect.tql
@@ -1,63 +1,68 @@
 ---
 description: Sysmon NetworkConnect (EID 3) → OCSF Network Activity (4001, Open)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.network_activity"
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4001
-ocsf.activity_id = 1  // Open
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4001
+$event.ocsf.activity_id = 1  // Open
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // Sysmon always knows which side initiated the connection.
-ocsf.is_src_dst_assignment_known = true
+$event.ocsf.is_src_dst_assignment_known = true
 
-replace sysmon.EventData.SourceHostname,      what="-", with=null
-replace sysmon.EventData.SourcePortName,      what="-", with=null
-replace sysmon.EventData.DestinationHostname, what="-", with=null
-replace sysmon.EventData.DestinationPortName, what="-", with=null
+replace $event.sysmon.EventData.SourceHostname,      what="-", with=null
+replace $event.sysmon.EventData.SourcePortName,      what="-", with=null
+replace $event.sysmon.EventData.DestinationHostname, what="-", with=null
+replace $event.sysmon.EventData.DestinationPortName, what="-", with=null
 
-ocsf.connection_info = {
-  direction_id:    2 if (move sysmon.EventData.Initiated) else 1,
-  protocol_name:   move sysmon.EventData.Protocol,
-  protocol_ver_id: 6 if (move sysmon.EventData.SourceIsIpv6) else 4,
+$event.ocsf.connection_info = {
+  direction_id:    2 if (move $event.sysmon.EventData.Initiated) else 1,
+  protocol_name:   move $event.sysmon.EventData.Protocol,
+  protocol_ver_id: 6 if (move $event.sysmon.EventData.SourceIsIpv6) else 4,
 }
-drop sysmon.EventData.DestinationIsIpv6 // redundant to SourceIsIpv6
+drop $event.sysmon.EventData.DestinationIsIpv6 // redundant to SourceIsIpv6
 
 let $protos = { tcp: 6, udp: 17 }
-ocsf.connection_info.protocol_num = $protos[ocsf.connection_info.protocol_name]? else 255
+$event.ocsf.connection_info.protocol_num = $protos[$event.ocsf.connection_info.protocol_name]? else 255
 
-ocsf.src_endpoint = {
-  ip:       move sysmon.EventData.SourceIp,
-  port:     (move sysmon.EventData.SourcePort).int(),
-  hostname: move sysmon.EventData.SourceHostname,
-  svc_name: move sysmon.EventData.SourcePortName,
+$event.ocsf.src_endpoint = {
+  ip:       move $event.sysmon.EventData.SourceIp,
+  port:     (move $event.sysmon.EventData.SourcePort).int(),
+  hostname: move $event.sysmon.EventData.SourceHostname,
+  svc_name: move $event.sysmon.EventData.SourcePortName,
 }
 
-ocsf.dst_endpoint = {
-  ip:       move sysmon.EventData.DestinationIp,
-  port:     (move sysmon.EventData.DestinationPort).int(),
-  hostname: move sysmon.EventData.DestinationHostname,
-  svc_name: move sysmon.EventData.DestinationPortName,
+$event.ocsf.dst_endpoint = {
+  ip:       move $event.sysmon.EventData.DestinationIp,
+  port:     (move $event.sysmon.EventData.DestinationPort).int(),
+  hostname: move $event.sysmon.EventData.DestinationHostname,
+  svc_name: move $event.sysmon.EventData.DestinationPortName,
 }
 
 // The Host profile (applied globally in map.tql) adds actor to Network Activity.
 // Map the process that opened the connection accordingly.
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid:  move sysmon.EventData.ProcessGuid,
-    pid:  (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid:  move $event.sysmon.EventData.ProcessGuid,
+    pid:  (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: { type_id: 8 },
   },
   user: {
-    name:   _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name:   $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path

--- a/sysmon/operators/ocsf/events/pipe_connected.tql
+++ b/sysmon/operators/ocsf/events/pipe_connected.tql
@@ -1,42 +1,47 @@
 ---
 description: Sysmon PipeConnected (EID 18) → OCSF Windows Resource Activity (201003, Access)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.windows_resource_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 201003
-ocsf.activity_id = 1  // Access
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 201003
+$event.ocsf.activity_id = 1  // Access
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 
 // Named pipes have no dedicated type_id in OCSF; Other (99) is the correct
 // choice. type must be the enum caption "Other". The operation and resource kind
 // go into details so the create/connect distinction and "Named Pipe" are not lost.
-ocsf.win_resource = {
-  name:    move sysmon.EventData.PipeName,
+$event.ocsf.win_resource = {
+  name:    move $event.sysmon.EventData.PipeName,
   type_id: 99,  // Other — no dedicated enum value for named pipes
   type:    "Other",
   details: "Named Pipe; EventType=ConnectPipe",
 }
-drop sysmon.EventData.EventType
+drop $event.sysmon.EventData.EventType
 
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid:  move sysmon.EventData.ProcessGuid,
-    pid:  (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid:  move $event.sysmon.EventData.ProcessGuid,
+    pid:  (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: { type_id: 8 },
   },
   user: {
-    name:   _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name:   $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path
 

--- a/sysmon/operators/ocsf/events/pipe_created.tql
+++ b/sysmon/operators/ocsf/events/pipe_created.tql
@@ -1,41 +1,46 @@
 ---
 description: Sysmon PipeCreated (EID 17) → OCSF Windows Resource Activity (201003, Access)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.windows_resource_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 201003
-ocsf.activity_id = 1  // Access (the only defined activity; EventType "CreatePipe" is kept)
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 201003
+$event.ocsf.activity_id = 1  // Access (the only defined activity; EventType "CreatePipe" is kept)
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // Named pipes have no dedicated type_id in OCSF; Other (99) is the correct
 // choice. type must be the enum caption "Other". The operation and resource kind
 // go into details so the create/connect distinction and "Named Pipe" are not lost.
-ocsf.win_resource = {
-  name:    move sysmon.EventData.PipeName,
+$event.ocsf.win_resource = {
+  name:    move $event.sysmon.EventData.PipeName,
   type_id: 99,  // Other — no dedicated enum value for named pipes
   type:    "Other",
   details: "Named Pipe; EventType=CreatePipe",
 }
-drop sysmon.EventData.EventType
+drop $event.sysmon.EventData.EventType
 
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid:  move sysmon.EventData.ProcessGuid,
-    pid:  (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid:  move $event.sysmon.EventData.ProcessGuid,
+    pid:  (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: { type_id: 8 },
   },
   user: {
-    name:   _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name:   $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path
 

--- a/sysmon/operators/ocsf/events/process_access.tql
+++ b/sysmon/operators/ocsf/events/process_access.tql
@@ -1,49 +1,54 @@
 ---
 description: Sysmon ProcessAccess (EID 10) → OCSF Process Activity (1007, Open)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.process_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1007
-ocsf.activity_id = 3  // Open
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1007
+$event.ocsf.activity_id = 3  // Open
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // The process that opened the handle to the target.
-_src_user = (move sysmon.EventData.SourceUser).split("\\")
-ocsf.actor = {
+$event._src_user = (move $event.sysmon.EventData.SourceUser).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid: move sysmon.EventData.SourceProcessGuid,
-    pid: (move sysmon.EventData.SourceProcessId).int(),
-    path: move sysmon.EventData.SourceImage,
+    uid: move $event.sysmon.EventData.SourceProcessGuid,
+    pid: (move $event.sysmon.EventData.SourceProcessId).int(),
+    path: move $event.sysmon.EventData.SourceImage,
     file: { type_id: 8 },
   },
   user: {
-    name: _src_user[-1],
-    domain: _src_user[0] if _src_user.length() > 1 else null,
+    name: $event._src_user[-1],
+    domain: $event._src_user[0] if $event._src_user.length() > 1 else null,
   },
 }
-drop _src_user
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+drop $event._src_user
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path
 
 // The process whose handle was obtained.
-_tgt_user = (move sysmon.EventData.TargetUser).split("\\")
-ocsf.process = {
-  uid: move sysmon.EventData.TargetProcessGuid,
-  pid: (move sysmon.EventData.TargetProcessId).int(),
-  path: move sysmon.EventData.TargetImage,
+$event._tgt_user = (move $event.sysmon.EventData.TargetUser).split("\\")
+$event.ocsf.process = {
+  uid: move $event.sysmon.EventData.TargetProcessGuid,
+  pid: (move $event.sysmon.EventData.TargetProcessId).int(),
+  path: move $event.sysmon.EventData.TargetImage,
   file: { type_id: 8 },
   user: {
-    name: _tgt_user[-1],
-    domain: _tgt_user[0] if _tgt_user.length() > 1 else null,
+    name: $event._tgt_user[-1],
+    domain: $event._tgt_user[0] if $event._tgt_user.length() > 1 else null,
   },
 }
-drop _tgt_user
-ocsf.process.name = ocsf.process.path.split("\\")[-1]
-ocsf.process.file.name = ocsf.process.name
-ocsf.process.file.path = ocsf.process.path
+drop $event._tgt_user
+$event.ocsf.process.name = $event.ocsf.process.path.split("\\")[-1]
+$event.ocsf.process.file.name = $event.ocsf.process.name
+$event.ocsf.process.file.path = $event.ocsf.process.path
 
 // GrantedAccess is a hex string (e.g. "0x1010"); OCSF actual_permissions is
 // integer_t. Leave it in unmapped to avoid a cast type mismatch.

--- a/sysmon/operators/ocsf/events/process_create.tql
+++ b/sysmon/operators/ocsf/events/process_create.tql
@@ -1,15 +1,20 @@
 ---
 description: Sysmon ProcessCreate (EID 1) → OCSF Process Activity (1007, Launch)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.process_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1007
-ocsf.activity_id = 1  // Launch
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1007
+$event.ocsf.activity_id = 1  // Launch
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-ocsf.launch_type_id = 1
+$event.ocsf.launch_type_id = 1
 
 // Map IntegrityLevel string to its OCSF enum id.
 let $integrity_ids = {
@@ -22,50 +27,50 @@ let $integrity_ids = {
   Protected: 6,
 }
 
-_user = (move sysmon.EventData.User).split("\\")
-_parent_user = (move sysmon.EventData.ParentUser).split("\\")
-ocsf.process = {
-  pid: (move sysmon.EventData.ProcessId).int(),
-  uid: move sysmon.EventData.ProcessGuid,
-  path: move sysmon.EventData.Image,
-  cmd_line: move sysmon.EventData.CommandLine,
-  created_time: ocsf.time,
-  working_directory: move sysmon.EventData.CurrentDirectory,
-  integrity_id: $integrity_ids[move sysmon.EventData.IntegrityLevel]? else 0,
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event._parent_user = (move $event.sysmon.EventData.ParentUser).split("\\")
+$event.ocsf.process = {
+  pid: (move $event.sysmon.EventData.ProcessId).int(),
+  uid: move $event.sysmon.EventData.ProcessGuid,
+  path: move $event.sysmon.EventData.Image,
+  cmd_line: move $event.sysmon.EventData.CommandLine,
+  created_time: $event.ocsf.time,
+  working_directory: move $event.sysmon.EventData.CurrentDirectory,
+  integrity_id: $integrity_ids[move $event.sysmon.EventData.IntegrityLevel]? else 0,
   file: {
     type_id: 8,  // Executable File
-    version: move sysmon.EventData.FileVersion,
-    desc: move sysmon.EventData.Description,
-    company_name: move sysmon.EventData.Company,
-    internal_name: move sysmon.EventData.OriginalFileName,
+    version: move $event.sysmon.EventData.FileVersion,
+    desc: move $event.sysmon.EventData.Description,
+    company_name: move $event.sysmon.EventData.Company,
+    internal_name: move $event.sysmon.EventData.OriginalFileName,
     product: {
-      name: move sysmon.EventData.Product,
+      name: move $event.sysmon.EventData.Product,
     },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
   parent_process: {
-    pid: (move sysmon.EventData.ParentProcessId).int(),
-    uid: move sysmon.EventData.ParentProcessGuid,
-    path: move sysmon.EventData.ParentImage,
-    cmd_line: move sysmon.EventData.ParentCommandLine,
+    pid: (move $event.sysmon.EventData.ParentProcessId).int(),
+    uid: move $event.sysmon.EventData.ParentProcessGuid,
+    path: move $event.sysmon.EventData.ParentImage,
+    cmd_line: move $event.sysmon.EventData.ParentCommandLine,
     file: {
       type_id: 8,
     },
     user: {
-      name: _parent_user[-1],
-      domain: _parent_user[0] if _parent_user.length() > 1 else null,
+      name: $event._parent_user[-1],
+      domain: $event._parent_user[0] if $event._parent_user.length() > 1 else null,
     },
   },
 }
-drop _user, _parent_user
-ocsf.process.name = ocsf.process.path.split("\\")[-1]
-ocsf.process.file.name = ocsf.process.name
-ocsf.process.file.path = ocsf.process.path
-ocsf.process.parent_process.file.name = ocsf.process.parent_process.path.split("\\")[-1]
-ocsf.process.parent_process.file.path = ocsf.process.parent_process.path
+drop $event._user, $event._parent_user
+$event.ocsf.process.name = $event.ocsf.process.path.split("\\")[-1]
+$event.ocsf.process.file.name = $event.ocsf.process.name
+$event.ocsf.process.file.path = $event.ocsf.process.path
+$event.ocsf.process.parent_process.file.name = $event.ocsf.process.parent_process.path.split("\\")[-1]
+$event.ocsf.process.parent_process.file.path = $event.ocsf.process.parent_process.path
 
 let $algorithms = {
   MD5: 1,
@@ -75,7 +80,7 @@ let $algorithms = {
 }
 
 // Parse "SHA1=abc,MD5=def,..." into fingerprint objects.
-ocsf.process.file.hashes = ((move sysmon.EventData.Hashes)
+$event.ocsf.process.file.hashes = ((move $event.sysmon.EventData.Hashes)
   .split(",")
   .map(h => h.split("=", max=1))
   .map(kv => {
@@ -87,27 +92,27 @@ ocsf.process.file.hashes = ((move sysmon.EventData.Hashes)
 // for Launch events both actor.process (creator) and process.parent_process (OS
 // parent) should be populated. Sysmon does not distinguish creator from parent,
 // so the same data fills both fields.
-ocsf.actor = {
+$event.ocsf.actor = {
   process: {
-    uid: ocsf.process.parent_process.uid,
-    pid: ocsf.process.parent_process.pid,
-    path: ocsf.process.parent_process.path,
-    name: ocsf.process.parent_process.file.name,
-    cmd_line: ocsf.process.parent_process.cmd_line,
-    file: ocsf.process.parent_process.file,
-    user: ocsf.process.parent_process.user,
+    uid: $event.ocsf.process.parent_process.uid,
+    pid: $event.ocsf.process.parent_process.pid,
+    path: $event.ocsf.process.parent_process.path,
+    name: $event.ocsf.process.parent_process.file.name,
+    cmd_line: $event.ocsf.process.parent_process.cmd_line,
+    file: $event.ocsf.process.parent_process.file,
+    user: $event.ocsf.process.parent_process.user,
   },
-  user: ocsf.process.parent_process.user,
+  user: $event.ocsf.process.parent_process.user,
   // LogonGuid/LogonId are the logon session of the spawned process, not the
   // creator. They are placed in actor.session because it is the only session
   // data available and is useful for cross-event correlation; the two sessions
   // are identical in the common case where the parent did not change the token.
   // TerminalSessionId (RDP/console slot) has no OCSF home; stays in unmapped.
   session: {
-    uid: move sysmon.EventData.LogonGuid,
-    uid_alt: move sysmon.EventData.LogonId,
+    uid: move $event.sysmon.EventData.LogonGuid,
+    uid_alt: move $event.sysmon.EventData.LogonId,
   },
 }
 
 // EID 1 only fires on successful process creation; there is no failure variant.
-ocsf.status_id = 1
+$event.ocsf.status_id = 1

--- a/sysmon/operators/ocsf/events/process_tampering.tql
+++ b/sysmon/operators/ocsf/events/process_tampering.tql
@@ -1,5 +1,10 @@
 ---
 description: Sysmon ProcessTampering (EID 25) → OCSF Process Activity (1007, Inject)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // Process tampering (hollowing, herpaderping) is a form of process injection
@@ -8,50 +13,50 @@ description: Sysmon ProcessTampering (EID 25) → OCSF Process Activity (1007, I
 
 @name = "ocsf.process_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1007
-ocsf.activity_id = 4  // Inject
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1007
+$event.ocsf.activity_id = 4  // Inject
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // injection_type_id 99 (Other) because hollowing/herpaderping are not
 // Remote Thread, Load Library, or Queue APC.
 // injection_type must be the enum caption "Other" when id=99; the Sysmon-specific
 // string (e.g. "Image is replaced") is preserved in unmapped for analysts.
-ocsf.injection_type_id = 99
-ocsf.injection_type = "Other"
-sysmon.EventData.TamperingType = move sysmon.EventData.Type
+$event.ocsf.injection_type_id = 99
+$event.ocsf.injection_type = "Other"
+$event.sysmon.EventData.TamperingType = move $event.sysmon.EventData.Type
 
 // The tampered process is both the actor and the target (Sysmon only reports it).
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.process = {
-  uid: move sysmon.EventData.ProcessGuid,
-  pid: (move sysmon.EventData.ProcessId).int(),
-  path: move sysmon.EventData.Image,
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.process = {
+  uid: move $event.sysmon.EventData.ProcessGuid,
+  pid: (move $event.sysmon.EventData.ProcessId).int(),
+  path: move $event.sysmon.EventData.Image,
   file: { type_id: 8 },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-ocsf.process.name = ocsf.process.path.split("\\")[-1]
-ocsf.process.file.name = ocsf.process.name
-ocsf.process.file.path = ocsf.process.path
+$event.ocsf.process.name = $event.ocsf.process.path.split("\\")[-1]
+$event.ocsf.process.file.name = $event.ocsf.process.name
+$event.ocsf.process.file.path = $event.ocsf.process.path
 
-ocsf.actor = {
+$event.ocsf.actor = {
   process: {
-    uid: ocsf.process.uid,
-    pid: ocsf.process.pid,
-    path: ocsf.process.path,
-    name: ocsf.process.name,
+    uid: $event.ocsf.process.uid,
+    pid: $event.ocsf.process.pid,
+    path: $event.ocsf.process.path,
+    name: $event.ocsf.process.name,
     file: {
       type_id: 8,
-      name: ocsf.process.file.name,
-      path: ocsf.process.file.path,
+      name: $event.ocsf.process.file.name,
+      path: $event.ocsf.process.file.path,
     },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user

--- a/sysmon/operators/ocsf/events/process_terminate.tql
+++ b/sysmon/operators/ocsf/events/process_terminate.tql
@@ -1,51 +1,56 @@
 ---
 description: Sysmon ProcessTerminate (EID 5) → OCSF Process Activity (1007, Terminate)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.process_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1007
-ocsf.activity_id = 2  // Terminate
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1007
+$event.ocsf.activity_id = 2  // Terminate
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // EID 5 has no parent-process or actor context; for a self-exit the terminating
 // process and the actor are the same process.
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.process = {
-  uid: move sysmon.EventData.ProcessGuid,
-  pid: (move sysmon.EventData.ProcessId).int(),
-  path: move sysmon.EventData.Image,
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.process = {
+  uid: move $event.sysmon.EventData.ProcessGuid,
+  pid: (move $event.sysmon.EventData.ProcessId).int(),
+  path: move $event.sysmon.EventData.Image,
   file: {
     type_id: 8,  // Executable File
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-ocsf.process.name = ocsf.process.path.split("\\")[-1]
-ocsf.process.file.name = ocsf.process.name
-ocsf.process.file.path = ocsf.process.path
+$event.ocsf.process.name = $event.ocsf.process.path.split("\\")[-1]
+$event.ocsf.process.file.name = $event.ocsf.process.name
+$event.ocsf.process.file.path = $event.ocsf.process.path
 
 // The actor mirrors the process for a self-termination (the most common case).
 // When a different process causes the exit, Sysmon still reports only the
 // terminating process — actor.process is therefore set to the same values.
-ocsf.actor = {
+$event.ocsf.actor = {
   process: {
-    uid: ocsf.process.uid,
-    pid: ocsf.process.pid,
-    path: ocsf.process.path,
-    name: ocsf.process.name,
+    uid: $event.ocsf.process.uid,
+    pid: $event.ocsf.process.pid,
+    path: $event.ocsf.process.path,
+    name: $event.ocsf.process.name,
     file: {
       type_id: 8,
-      name: ocsf.process.file.name,
-      path: ocsf.process.file.path,
+      name: $event.ocsf.process.file.name,
+      path: $event.ocsf.process.file.path,
     },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user

--- a/sysmon/operators/ocsf/events/raw_access_read.tql
+++ b/sysmon/operators/ocsf/events/raw_access_read.tql
@@ -1,39 +1,44 @@
 ---
 description: Sysmon RawAccessRead (EID 9) → OCSF File System Activity (1001, Read)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.file_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 1001
-ocsf.activity_id = 2  // Read
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 1001
+$event.ocsf.activity_id = 2  // Read
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // RawAccessRead targets a raw disk device, not a regular file.
 // type_id 4 (Block Device) is the closest OCSF match.
-ocsf.file = {
-  path: move sysmon.EventData.Device,
+$event.ocsf.file = {
+  path: move $event.sysmon.EventData.Device,
   type_id: 4,  // Block Device
 }
-ocsf.file.name = ocsf.file.path.split("\\")[-1]
+$event.ocsf.file.name = $event.ocsf.file.path.split("\\")[-1]
 
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid: move sysmon.EventData.ProcessGuid,
-    pid: (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid: move $event.sysmon.EventData.ProcessGuid,
+    pid: (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: {
       type_id: 8,
     },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path

--- a/sysmon/operators/ocsf/events/registry_create_delete.tql
+++ b/sysmon/operators/ocsf/events/registry_create_delete.tql
@@ -3,51 +3,56 @@ description: >
   Sysmon RegistryEvent Object Created/Deleted (EID 12) →
   OCSF Registry Key Activity (201001) for CreateKey/DeleteKey, or
   OCSF Registry Value Activity (201002) for DeleteValue
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-_event_type = move sysmon.EventData.EventType
-_target_obj = move sysmon.EventData.TargetObject
+$event._event_type = move $event.sysmon.EventData.EventType
+$event._target_obj = move $event.sysmon.EventData.TargetObject
 
-ocsf.category_uid = 1
+$event.ocsf.category_uid = 1
 
-if _event_type == "DeleteValue" {
+if $event._event_type == "DeleteValue" {
   // Registry Value Activity — the value itself was deleted.
   @name = "ocsf.registry_value_activity"
-  ocsf.class_uid = 201002
-  ocsf.activity_id = 4  // Delete
-  ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+  $event.ocsf.class_uid = 201002
+  $event.ocsf.activity_id = 4  // Delete
+  $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-  _parts = _target_obj.split("\\")
-  ocsf.reg_value = {
-    path: _parts.slice(end=-1).join("\\"),
-    name: _parts[-1],
+  $event._parts = $event._target_obj.split("\\")
+  $event.ocsf.reg_value = {
+    path: $event._parts.slice(end=-1).join("\\"),
+    name: $event._parts[-1],
   }
-  drop _parts
+  drop $event._parts
 } else {
   // Registry Key Activity — key created or deleted.
   @name = "ocsf.registry_key_activity"
-  ocsf.class_uid = 201001
-  ocsf.activity_id = 4 if _event_type == "DeleteKey" else 1  // Delete / Create
-  ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+  $event.ocsf.class_uid = 201001
+  $event.ocsf.activity_id = 4 if $event._event_type == "DeleteKey" else 1  // Delete / Create
+  $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-  ocsf.reg_key = { path: _target_obj }
+  $event.ocsf.reg_key = { path: $event._target_obj }
 }
-drop _event_type, _target_obj
+drop $event._event_type, $event._target_obj
 
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid: move sysmon.EventData.ProcessGuid,
-    pid: (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid: move $event.sysmon.EventData.ProcessGuid,
+    pid: (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: { type_id: 8 },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+drop $event._user
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path

--- a/sysmon/operators/ocsf/events/registry_rename.tql
+++ b/sysmon/operators/ocsf/events/registry_rename.tql
@@ -1,42 +1,47 @@
 ---
 description: Sysmon RegistryRename (EID 14) → OCSF Registry Key Activity (201001, Rename)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.registry_key_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 201001
-ocsf.activity_id = 5  // Rename
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 201001
+$event.ocsf.activity_id = 5  // Rename
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 
 // reg_key holds the key at its new (post-rename) path.
 // prev_reg_key holds the original path before the rename.
-ocsf.reg_key      = { path: move sysmon.EventData.NewName     }
-ocsf.prev_reg_key = { path: move sysmon.EventData.TargetObject }
+$event.ocsf.reg_key      = { path: move $event.sysmon.EventData.NewName     }
+$event.ocsf.prev_reg_key = { path: move $event.sysmon.EventData.TargetObject }
 
 // EventType "RenameKey" is redundant with activity_id — drop it.
-drop sysmon.EventData.EventType
+drop $event.sysmon.EventData.EventType
 
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid: move sysmon.EventData.ProcessGuid,
-    pid: (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid: move $event.sysmon.EventData.ProcessGuid,
+    pid: (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: {
       type_id: 8,
     },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
+drop $event._user
 
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path
 
 

--- a/sysmon/operators/ocsf/events/registry_value_set.tql
+++ b/sysmon/operators/ocsf/events/registry_value_set.tql
@@ -1,39 +1,44 @@
 ---
 description: Sysmon RegistryValueSet (EID 13) → OCSF Registry Value Activity (201002, Set)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.registry_value_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 201002
-ocsf.activity_id = 2  // Set
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 201002
+$event.ocsf.activity_id = 2  // Set
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-_parts = (move sysmon.EventData.TargetObject).split("\\")
-ocsf.reg_value = {
-  path:            _parts.slice(end=-1).join("\\"),
-  name:            _parts[-1],
-  reg_string_data: move sysmon.EventData.Details,
+$event._parts = (move $event.sysmon.EventData.TargetObject).split("\\")
+$event.ocsf.reg_value = {
+  path:            $event._parts.slice(end=-1).join("\\"),
+  name:            $event._parts[-1],
+  reg_string_data: move $event.sysmon.EventData.Details,
 }
-drop _parts
+drop $event._parts
 
 // EventType "SetValue" is redundant with activity_id — drop it.
-drop sysmon.EventData.EventType
+drop $event.sysmon.EventData.EventType
 
-_user = (move sysmon.EventData.User).split("\\")
-ocsf.actor = {
+$event._user = (move $event.sysmon.EventData.User).split("\\")
+$event.ocsf.actor = {
   process: {
-    uid: move sysmon.EventData.ProcessGuid,
-    pid: (move sysmon.EventData.ProcessId).int(),
-    path: move sysmon.EventData.Image,
+    uid: move $event.sysmon.EventData.ProcessGuid,
+    pid: (move $event.sysmon.EventData.ProcessId).int(),
+    path: move $event.sysmon.EventData.Image,
     file: { type_id: 8 },
   },
   user: {
-    name: _user[-1],
-    domain: _user[0] if _user.length() > 1 else null,
+    name: $event._user[-1],
+    domain: $event._user[0] if $event._user.length() > 1 else null,
   },
 }
-drop _user
-ocsf.actor.process.name = ocsf.actor.process.path.split("\\")[-1]
-ocsf.actor.process.file.name = ocsf.actor.process.name
-ocsf.actor.process.file.path = ocsf.actor.process.path
+drop $event._user
+$event.ocsf.actor.process.name = $event.ocsf.actor.process.path.split("\\")[-1]
+$event.ocsf.actor.process.file.name = $event.ocsf.actor.process.name
+$event.ocsf.actor.process.file.path = $event.ocsf.actor.process.path

--- a/sysmon/operators/ocsf/events/service_state_change.tql
+++ b/sysmon/operators/ocsf/events/service_state_change.tql
@@ -1,26 +1,31 @@
 ---
 description: Sysmon ServiceStateChange (EID 4) → OCSF Windows Service Activity (201004, Start/Stop)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.windows_service_activity"
 
-ocsf.category_uid = 1
-ocsf.class_uid = 201004
+$event.ocsf.category_uid = 1
+$event.ocsf.class_uid = 201004
 
-ocsf.activity_id = 3 if sysmon.EventData.State == "Started" else 4  // Start / Stop
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 3 if $event.sysmon.EventData.State == "Started" else 4  // Start / Stop
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-drop sysmon.EventData.State
+drop $event.sysmon.EventData.State
 
 // The Sysmon service itself — name comes from the provider, version from the event.
-ocsf.win_service = {
+$event.ocsf.win_service = {
   name: "Sysmon",
-  version: (move sysmon.EventData.Version).string(),
+  version: (move $event.sysmon.EventData.Version).string(),
 }
 
 // Windows Service Activity requires actor (inherited from System Activity).
 // EID 4 carries no user/process context — the SCM starts/stops Sysmon autonomously.
-ocsf.actor = {}
+$event.ocsf.actor = {}
 
 // SchemaVersion describes the Sysmon config schema, not the OCSF schema — left in
 // unmapped intentionally so analysts can correlate config changes via EID 16.

--- a/sysmon/operators/ocsf/events/sysmon_config_change.tql
+++ b/sysmon/operators/ocsf/events/sysmon_config_change.tql
@@ -3,10 +3,15 @@ description: >
   Sysmon SysmonConfigChange (EID 16) → OCSF Base Event (0).
   No standard OCSF class covers a security-tool configuration change;
   all fields are preserved in unmapped for downstream use.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // Base Event — no specific OCSF class for Sysmon config changes.
-ocsf.category_uid = 0
-ocsf.class_uid = 0
-ocsf.activity_id = 0
-ocsf.type_uid = 0
+$event.ocsf.category_uid = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.type_uid = 0

--- a/sysmon/operators/ocsf/events/sysmon_error.tql
+++ b/sysmon/operators/ocsf/events/sysmon_error.tql
@@ -3,22 +3,27 @@ description: >
   Sysmon Error (EID 255) → OCSF Base Event (0).
   Internal Sysmon errors have no specific OCSF class, but status and
   severity are set to reflect the error condition.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // Base Event — internal Sysmon errors do not map to any OCSF class.
-ocsf.category_uid = 0
-ocsf.class_uid = 0
-ocsf.activity_id = 0
-ocsf.type_uid = 0
+$event.ocsf.category_uid = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.type_uid = 0
 
 // EID 255 is a Windows Error-level event (Level 2); override the global
 // Informational default set in map.tql.
-ocsf.severity_id = 4  // High
+$event.ocsf.severity_id = 4  // High
 
 // Signal failure explicitly rather than leaving status unset.
-ocsf.status_id = 2  // Failure
+$event.ocsf.status_id = 2  // Failure
 
 // Surface the structured error ID and description directly on the event
 // instead of leaving them in unmapped.
-ocsf.status_code = (move sysmon.EventData.ID).string()
-ocsf.message = move sysmon.EventData.Description
+$event.ocsf.status_code = (move $event.sysmon.EventData.ID).string()
+$event.ocsf.message = move $event.sysmon.EventData.Description

--- a/sysmon/operators/ocsf/events/wmi_events.tql
+++ b/sysmon/operators/ocsf/events/wmi_events.tql
@@ -3,10 +3,15 @@ description: >
   Sysmon WMI subscription events (EIDs 19/20/21) → OCSF Base Event (0).
   No OCSF 1.7.0 class covers WMI filter/consumer/binding registration;
   all fields are preserved in unmapped for downstream use.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // Base Event — no specific OCSF class for WMI subscription events.
-ocsf.category_uid = 0
-ocsf.class_uid = 0
-ocsf.activity_id = 0
-ocsf.type_uid = 0
+$event.ocsf.category_uid = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.type_uid = 0

--- a/sysmon/operators/ocsf/map.tql
+++ b/sysmon/operators/ocsf/map.tql
@@ -1,125 +1,121 @@
 ---
 description: Sysmon → OCSF
 args:
-  positional:
-    - name: log
-      description: The field that holds the raw Sysmon event as XML.
+  named:
+    - name: event
+      description: The field that holds the event to map.
       type: field
+      default: this
 ---
 
-ocsf = {}
+$event = {...$event, sysmon: $event, ocsf: {}}
 
-ocsf.raw_data = $log
-ocsf.raw_data_size = $log.length_bytes()
-
-sysmon = $log.parse_winlog()
-
-ocsf.metadata = {
-  event_code: (move sysmon.System.EventID).string(),
+$event.ocsf.metadata = {
+  event_code: (move $event.sysmon.System.EventID).string(),
   extensions: [{name: "win"}],
   log_format: "xml",
-  log_name: move sysmon.System.Channel,
-  log_level: (move sysmon.System.Level).string(),
-  log_version: (move sysmon.System.Version).string(),
-  logged_time: move sysmon.System.TimeCreated.SystemTime,
-  original_event_uid: (move sysmon.System.EventRecordID).string(),
+  log_name: move $event.sysmon.System.Channel,
+  log_level: (move $event.sysmon.System.Level).string(),
+  log_version: (move $event.sysmon.System.Version).string(),
+  logged_time: move $event.sysmon.System.TimeCreated.SystemTime,
+  original_event_uid: (move $event.sysmon.System.EventRecordID).string(),
   processed_time: now(),
   product: {
-    name: move sysmon.System.Provider.Name,
-    uid: move sysmon.System.Provider.Guid,
+    name: move $event.sysmon.System.Provider.Name,
+    uid: move $event.sysmon.System.Provider.Guid,
     vendor_name: "Microsoft",
   },
   profiles: ["host"],
   version: "1.8.0",
 }
 
-ocsf.severity_id = 1
+$event.ocsf.severity_id = 1
 
-ocsf.time = move sysmon.EventData.UtcTime
+$event.ocsf.time = move $event.sysmon.EventData.UtcTime
 
-ocsf.device = {
-  hostname: move sysmon.System.Computer,
+$event.ocsf.device = {
+  hostname: move $event.sysmon.System.Computer,
 }
 
 // ProcessID and ThreadID identify the Sysmon service itself, not the target event.
-drop sysmon.System.Execution
-drop sysmon.System.Provider
-drop sysmon.System.TimeCreated
+drop $event.sysmon.System.Execution
+drop $event.sysmon.System.Provider
+drop $event.sysmon.System.TimeCreated
 
 // Security.UserID is the Sysmon service account SID (typically S-1-5-18 / SYSTEM),
 // not the device owner — leave it in unmapped.
-drop sysmon.System.Security
+drop $event.sysmon.System.Security
 
 // Correlation is always empty for Sysmon (it does not use ETW ActivityIDs),
 // and OCSF's metadata.correlation_uid is for linking OCSF events — a different
 // concept — so there is no valid mapping target.
-drop sysmon.System.Correlation
+drop $event.sysmon.System.Correlation
 
 // RuleName is a Sysmon filter-rule tag present on most EIDs. It is not a
 // property of any observed object, so it is dropped centrally here rather
 // than in every individual mapping operator.
-drop sysmon.EventData.RuleName?
+drop $event.sysmon.EventData.RuleName?
 
-if ocsf.metadata.event_code == "1" {
-  sysmon::ocsf::events::process_create
-} else if ocsf.metadata.event_code == "2" {
-  sysmon::ocsf::events::file_create_time
-} else if ocsf.metadata.event_code == "3" {
-  sysmon::ocsf::events::network_connect
-} else if ocsf.metadata.event_code == "4" {
-  sysmon::ocsf::events::service_state_change
-} else if ocsf.metadata.event_code == "5" {
-  sysmon::ocsf::events::process_terminate
-} else if ocsf.metadata.event_code == "6" {
-  sysmon::ocsf::events::driver_load
-} else if ocsf.metadata.event_code == "7" {
-  sysmon::ocsf::events::image_load
-} else if ocsf.metadata.event_code == "8" {
-  sysmon::ocsf::events::create_remote_thread
-} else if ocsf.metadata.event_code == "9" {
-  sysmon::ocsf::events::raw_access_read
-} else if ocsf.metadata.event_code == "10" {
-  sysmon::ocsf::events::process_access
-} else if ocsf.metadata.event_code == "11" {
-  sysmon::ocsf::events::file_create
-} else if ocsf.metadata.event_code == "12" {
-  sysmon::ocsf::events::registry_create_delete
-} else if ocsf.metadata.event_code == "13" {
-  sysmon::ocsf::events::registry_value_set
-} else if ocsf.metadata.event_code == "14" {
-  sysmon::ocsf::events::registry_rename
-} else if ocsf.metadata.event_code == "15" {
-  sysmon::ocsf::events::file_create_stream_hash
-} else if ocsf.metadata.event_code == "16" {
-  sysmon::ocsf::events::sysmon_config_change
-} else if ocsf.metadata.event_code == "17" {
-  sysmon::ocsf::events::pipe_created
-} else if ocsf.metadata.event_code == "18" {
-  sysmon::ocsf::events::pipe_connected
-} else if ocsf.metadata.event_code in ["19", "20", "21"] {
-  sysmon::ocsf::events::wmi_events
-} else if ocsf.metadata.event_code == "22" {
-  sysmon::ocsf::events::dns_query
-} else if ocsf.metadata.event_code == "23" {
-  sysmon::ocsf::events::file_delete
-} else if ocsf.metadata.event_code == "24" {
-  sysmon::ocsf::events::clipboard_change
-} else if ocsf.metadata.event_code == "25" {
-  sysmon::ocsf::events::process_tampering
-} else if ocsf.metadata.event_code == "26" {
-  sysmon::ocsf::events::file_delete
-} else if ocsf.metadata.event_code in ["27","28"] {
-  sysmon::ocsf::events::file_block
-} else if ocsf.metadata.event_code == "29" {
-  sysmon::ocsf::events::file_executable_detected
-} else if ocsf.metadata.event_code == "255" {
-  sysmon::ocsf::events::sysmon_error
+if $event.ocsf.metadata.event_code == "1" {
+  sysmon::ocsf::events::process_create event=$event
+} else if $event.ocsf.metadata.event_code == "2" {
+  sysmon::ocsf::events::file_create_time event=$event
+} else if $event.ocsf.metadata.event_code == "3" {
+  sysmon::ocsf::events::network_connect event=$event
+} else if $event.ocsf.metadata.event_code == "4" {
+  sysmon::ocsf::events::service_state_change event=$event
+} else if $event.ocsf.metadata.event_code == "5" {
+  sysmon::ocsf::events::process_terminate event=$event
+} else if $event.ocsf.metadata.event_code == "6" {
+  sysmon::ocsf::events::driver_load event=$event
+} else if $event.ocsf.metadata.event_code == "7" {
+  sysmon::ocsf::events::image_load event=$event
+} else if $event.ocsf.metadata.event_code == "8" {
+  sysmon::ocsf::events::create_remote_thread event=$event
+} else if $event.ocsf.metadata.event_code == "9" {
+  sysmon::ocsf::events::raw_access_read event=$event
+} else if $event.ocsf.metadata.event_code == "10" {
+  sysmon::ocsf::events::process_access event=$event
+} else if $event.ocsf.metadata.event_code == "11" {
+  sysmon::ocsf::events::file_create event=$event
+} else if $event.ocsf.metadata.event_code == "12" {
+  sysmon::ocsf::events::registry_create_delete event=$event
+} else if $event.ocsf.metadata.event_code == "13" {
+  sysmon::ocsf::events::registry_value_set event=$event
+} else if $event.ocsf.metadata.event_code == "14" {
+  sysmon::ocsf::events::registry_rename event=$event
+} else if $event.ocsf.metadata.event_code == "15" {
+  sysmon::ocsf::events::file_create_stream_hash event=$event
+} else if $event.ocsf.metadata.event_code == "16" {
+  sysmon::ocsf::events::sysmon_config_change event=$event
+} else if $event.ocsf.metadata.event_code == "17" {
+  sysmon::ocsf::events::pipe_created event=$event
+} else if $event.ocsf.metadata.event_code == "18" {
+  sysmon::ocsf::events::pipe_connected event=$event
+} else if $event.ocsf.metadata.event_code in ["19", "20", "21"] {
+  sysmon::ocsf::events::wmi_events event=$event
+} else if $event.ocsf.metadata.event_code == "22" {
+  sysmon::ocsf::events::dns_query event=$event
+} else if $event.ocsf.metadata.event_code == "23" {
+  sysmon::ocsf::events::file_delete event=$event
+} else if $event.ocsf.metadata.event_code == "24" {
+  sysmon::ocsf::events::clipboard_change event=$event
+} else if $event.ocsf.metadata.event_code == "25" {
+  sysmon::ocsf::events::process_tampering event=$event
+} else if $event.ocsf.metadata.event_code == "26" {
+  sysmon::ocsf::events::file_delete event=$event
+} else if $event.ocsf.metadata.event_code in ["27","28"] {
+  sysmon::ocsf::events::file_block event=$event
+} else if $event.ocsf.metadata.event_code == "29" {
+  sysmon::ocsf::events::file_executable_detected event=$event
+} else if $event.ocsf.metadata.event_code == "255" {
+  sysmon::ocsf::events::sysmon_error event=$event
 } else {
   // Base Event — unknown/future Sysmon EID
-  ocsf.category_uid = 0
-  ocsf.class_uid = 0
-  ocsf.activity_id = 0
-  ocsf.type_uid = 0
+  $event.ocsf.category_uid = 0
+  $event.ocsf.class_uid = 0
+  $event.ocsf.activity_id = 0
+  $event.ocsf.type_uid = 0
 }
 
-this = {...ocsf, unmapped: sysmon}
+$event = {...$event.ocsf, unmapped: $event.sysmon}

--- a/sysmon/tests/ocsf/01-ProcessCreate.tql
+++ b/sysmon/tests/ocsf/01-ProcessCreate.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/01-ProcessCreate.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/02-FileCreateTime.tql
+++ b/sysmon/tests/ocsf/02-FileCreateTime.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/02-FileCreateTime.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/03-NetworkConnect.tql
+++ b/sysmon/tests/ocsf/03-NetworkConnect.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/03-NetworkConnect.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/04-ServiceStateChange.tql
+++ b/sysmon/tests/ocsf/04-ServiceStateChange.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/04-ServiceStateChange.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/05-ProcessTerminate.tql
+++ b/sysmon/tests/ocsf/05-ProcessTerminate.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/05-ProcessTerminate.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/06-DriverLoad.tql
+++ b/sysmon/tests/ocsf/06-DriverLoad.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/06-DriverLoad.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/07-ImageLoad.tql
+++ b/sysmon/tests/ocsf/07-ImageLoad.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/07-ImageLoad.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/08-CreateRemoteThread.tql
+++ b/sysmon/tests/ocsf/08-CreateRemoteThread.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/08-CreateRemoteThread.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/09-RawAccessRead.tql
+++ b/sysmon/tests/ocsf/09-RawAccessRead.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/09-RawAccessRead.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/10-ProcessAccess.tql
+++ b/sysmon/tests/ocsf/10-ProcessAccess.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/10-ProcessAccess.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/11-FileCreate.tql
+++ b/sysmon/tests/ocsf/11-FileCreate.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/11-FileCreate.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/12-RegistryCreateDelete.tql
+++ b/sysmon/tests/ocsf/12-RegistryCreateDelete.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/12-RegistryCreateDelete.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/13-RegistryValueSet.tql
+++ b/sysmon/tests/ocsf/13-RegistryValueSet.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/13-RegistryValueSet.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/14-RegistryRename.tql
+++ b/sysmon/tests/ocsf/14-RegistryRename.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/14-RegistryRename.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/15-FileCreateStreamHash.tql
+++ b/sysmon/tests/ocsf/15-FileCreateStreamHash.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/15-FileCreateStreamHash.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/16-SysmonConfigChange.tql
+++ b/sysmon/tests/ocsf/16-SysmonConfigChange.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/16-SysmonConfigChange.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/17-PipeCreated.tql
+++ b/sysmon/tests/ocsf/17-PipeCreated.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/17-PipeCreated.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/18-PipeConnected.tql
+++ b/sysmon/tests/ocsf/18-PipeConnected.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/18-PipeConnected.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/19-WmiEventFilter.tql
+++ b/sysmon/tests/ocsf/19-WmiEventFilter.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/19-WmiEventFilter.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/20-WmiEventConsumer.tql
+++ b/sysmon/tests/ocsf/20-WmiEventConsumer.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/20-WmiEventConsumer.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/21-WmiEventConsumerToFilter.tql
+++ b/sysmon/tests/ocsf/21-WmiEventConsumerToFilter.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/21-WmiEventConsumerToFilter.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/22-DnsQuery.tql
+++ b/sysmon/tests/ocsf/22-DnsQuery.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/22-DnsQuery.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/23-FileDelete.tql
+++ b/sysmon/tests/ocsf/23-FileDelete.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/23-FileDelete.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/24-ClipboardChange.tql
+++ b/sysmon/tests/ocsf/24-ClipboardChange.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/24-ClipboardChange.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/25-ProcessTampering.tql
+++ b/sysmon/tests/ocsf/25-ProcessTampering.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/25-ProcessTampering.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/255-Error.tql
+++ b/sysmon/tests/ocsf/255-Error.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/255-Error.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/26-FileDeleteDetected.tql
+++ b/sysmon/tests/ocsf/26-FileDeleteDetected.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/26-FileDeleteDetected.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/27-FileBlockExecutable.tql
+++ b/sysmon/tests/ocsf/27-FileBlockExecutable.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/27-FileBlockExecutable.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/28-FileBlockShredding.tql
+++ b/sysmon/tests/ocsf/28-FileBlockShredding.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/28-FileBlockShredding.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/sysmon/tests/ocsf/29-FileExecutableDetected.tql
+++ b/sysmon/tests/ocsf/29-FileExecutableDetected.tql
@@ -1,7 +1,11 @@
 from_file f"{env("TENZIR_INPUTS")}/29-FileExecutableDetected.xml" {
   read_all
 }
-sysmon::ocsf::map data
+win = data.parse_winlog()
+sysmon::ocsf::map event=win
+win.raw_data = move data
+win.raw_data_size = win.raw_data.length_bytes()
+this = win
 ocsf::derive
 ocsf::cast
 

--- a/zeek/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/zeek/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,22 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:21.799017Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+```

--- a/zeek/operators/ocsf/base.tql
+++ b/zeek/operators/ocsf/base.tql
@@ -1,25 +1,30 @@
 ---
 description: |
   Zeek log → OCSF Base Event.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 0
-ocsf.class_uid = 0
-ocsf.category_uid = 0
-ocsf.severity_id = 1
-ocsf.type_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.category_uid = 0
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = 0
 
 // --- OCSF: context attributes -----------------
 
-if zeek._path? != null {
-  ocsf.metadata.log_name = move zeek._path
+if $event.zeek._path? != null {
+  $event.ocsf.metadata.log_name = move $event.zeek._path
 }
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.status_id = 0
+$event.ocsf.status_id = 0
 
 // --- Finalize ---------------------------------
 

--- a/zeek/operators/ocsf/logs/conn.tql
+++ b/zeek/operators/ocsf/logs/conn.tql
@@ -1,9 +1,14 @@
 ---
 description: |
   Zeek conn.log → OCSF Network Activity.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-zeek::ocsf::map_network
+zeek::ocsf::map_network event=$event
 
 // --- OCSF: classification attributes ----------
 
@@ -32,46 +37,46 @@ let $conn_states = {
   // Connections Zeek couldn't classify.
   OTH: 6,
 }
-ocsf.activity_id = $conn_states[zeek.conn_state]? else 6
-ocsf.class_uid = 4001
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = $conn_states[$event.zeek.conn_state]? else 6
+$event.ocsf.class_uid = 4001
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata.log_name = "conn.log"
-ocsf.app_protocol_name = move zeek.service
+$event.ocsf.metadata.log_name = "conn.log"
+$event.ocsf.app_protocol_name = move $event.zeek.service
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.connection_info.flag_history = move zeek.history
-if zeek.local_orig? != null and zeek.local_resp? != null {
-  if zeek.local_orig and zeek.local_resp {
-    ocsf.connection_info.direction = "Lateral"
-    ocsf.connection_info.direction_id = 3
-  } else if zeek.local_orig {
-    ocsf.connection_info.direction = "Outbound"
-    ocsf.connection_info.direction_id = 2
-  } else if zeek.local_resp {
-    ocsf.connection_info.direction = "Inbound"
-    ocsf.connection_info.direction_id = 1
+$event.ocsf.connection_info.flag_history = move $event.zeek.history
+if $event.zeek.local_orig? != null and $event.zeek.local_resp? != null {
+  if $event.zeek.local_orig and $event.zeek.local_resp {
+    $event.ocsf.connection_info.direction = "Lateral"
+    $event.ocsf.connection_info.direction_id = 3
+  } else if $event.zeek.local_orig {
+    $event.ocsf.connection_info.direction = "Outbound"
+    $event.ocsf.connection_info.direction_id = 2
+  } else if $event.zeek.local_resp {
+    $event.ocsf.connection_info.direction = "Inbound"
+    $event.ocsf.connection_info.direction_id = 1
   } else {
-    ocsf.connection_info.direction = "Unknown"
-    ocsf.connection_info.direction_id = 0
+    $event.ocsf.connection_info.direction = "Unknown"
+    $event.ocsf.connection_info.direction_id = 0
   }
-  drop zeek.local_orig, zeek.local_resp
+  drop $event.zeek.local_orig, $event.zeek.local_resp
 }
-ocsf.status = "Other"
-ocsf.status_code = move zeek.conn_state
-ocsf.status_id = 99
-ocsf.traffic = {
-  bytes_in: move zeek.resp_bytes,
-  bytes_out: move zeek.orig_bytes,
-  bytes_missed: move zeek.missed_bytes,
-  packets_in: move zeek.resp_pkts,
-  packets_out: move zeek.orig_pkts,
+$event.ocsf.status = "Other"
+$event.ocsf.status_code = move $event.zeek.conn_state
+$event.ocsf.status_id = 99
+$event.ocsf.traffic = {
+  bytes_in: move $event.zeek.resp_bytes,
+  bytes_out: move $event.zeek.orig_bytes,
+  bytes_missed: move $event.zeek.missed_bytes,
+  packets_in: move $event.zeek.resp_pkts,
+  packets_out: move $event.zeek.orig_pkts,
 }
-ocsf.traffic.bytes = ocsf.traffic.bytes_in + ocsf.traffic.bytes_out
-ocsf.traffic.packets = ocsf.traffic.packets_in + ocsf.traffic.packets_out
+$event.ocsf.traffic.bytes = $event.ocsf.traffic.bytes_in + $event.ocsf.traffic.bytes_out
+$event.ocsf.traffic.packets = $event.ocsf.traffic.packets_in + $event.ocsf.traffic.packets_out
 
 @name = "ocsf.network_activity"

--- a/zeek/operators/ocsf/logs/dhcp.tql
+++ b/zeek/operators/ocsf/logs/dhcp.tql
@@ -1,6 +1,11 @@
 ---
 description: |
   Zeek dhcp.log → OCSF DHCP Activity.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // --- Preamble ---------------------------------
@@ -9,8 +14,8 @@ description: |
 // DORA "session". See https://docs.zeek.org/en/master/logs/dhcp.html for
 // details. In OCSF, an event represents a single DORA message, which is
 // why we simply unroll the array.
-unroll zeek.msg_types
-zeek::ocsf::map_network
+unroll $event.zeek.msg_types
+zeek::ocsf::map_network event=$event
 
 // --- OCSF: classification attributes ----------
 
@@ -26,30 +31,30 @@ let $msg_types = {
   RELEASE: 7,
   INFORM: 8,
 }
-ocsf.activity_id = $msg_types[zeek.msg_types]? else 99
-ocsf.class_uid = 4004
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = $msg_types[$event.zeek.msg_types]? else 99
+$event.ocsf.class_uid = 4004
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata.log_name = "dhcp.log"
+$event.ocsf.metadata.log_name = "dhcp.log"
 // The `uids` field in the DHCP log is an array of all conn UIDs. To keep at
 // least the uniqueness constraint intact, we sort and join them.
-zeek._uids = sort(move zeek.uids).join(",")
-ocsf.metadata.original_event_uid = zeek._uids
-ocsf.metadata.correlation_uid = move zeek._uids
+$event.zeek._uids = sort(move $event.zeek.uids).join(",")
+$event.ocsf.metadata.original_event_uid = $event.zeek._uids
+$event.ocsf.metadata.correlation_uid = move $event.zeek._uids
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.connection_info.protocol_name = "udp"
-ocsf.connection_info.protocol_num = 17
-ocsf.src_endpoint.hostname = move zeek.host_name?
-ocsf.src_endpoint.ip = move zeek.client_addr? else zeek.assigned_addr?
-ocsf.src_endpoint.domain = move zeek.client_fqdn?
-ocsf.src_endpoint.mac = move zeek.mac?
-ocsf.dst_endpoint.ip = move zeek.server_addr?
-ocsf.dst_endpoint.domain = move zeek.domain?
-ocsf.lease_dur = int(move zeek.lease_time?)
+$event.ocsf.connection_info.protocol_name = "udp"
+$event.ocsf.connection_info.protocol_num = 17
+$event.ocsf.src_endpoint.hostname = move $event.zeek.host_name?
+$event.ocsf.src_endpoint.ip = move $event.zeek.client_addr? else $event.zeek.assigned_addr?
+$event.ocsf.src_endpoint.domain = move $event.zeek.client_fqdn?
+$event.ocsf.src_endpoint.mac = move $event.zeek.mac?
+$event.ocsf.dst_endpoint.ip = move $event.zeek.server_addr?
+$event.ocsf.dst_endpoint.domain = move $event.zeek.domain?
+$event.ocsf.lease_dur = int(move $event.zeek.lease_time?)
 
 @name = "ocsf.dhcp_activity"

--- a/zeek/operators/ocsf/logs/dns.tql
+++ b/zeek/operators/ocsf/logs/dns.tql
@@ -1,20 +1,25 @@
 ---
 description: |
   Zeek dns.log → OCSF DNS Activity.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-zeek::ocsf::map_network
+zeek::ocsf::map_network event=$event
 
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 6
-ocsf.class_uid = 4003
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 6
+$event.ocsf.class_uid = 4003
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata.log_name = "dns.log"
+$event.ocsf.metadata.log_name = "dns.log"
 
 // --- OCSF: primary attributes -----------------
 
@@ -41,28 +46,28 @@ let $rcode_names = {
   BADCOOKIE: "BADCOOKIE",
   BADSIG: "BADSIG_VERS",
 }
-ocsf.answers = zip(move zeek.answers, move zeek.TTLs).map(x => {
+$event.ocsf.answers = zip(move $event.zeek.answers, move $event.zeek.TTLs).map(x => {
   rdata: x.left,
   ttl: int(x.right),
 })
-ocsf.query = {
-  class: move zeek.qclass_name,
-  hostname: move zeek.query,
+$event.ocsf.query = {
+  class: move $event.zeek.qclass_name,
+  hostname: move $event.zeek.query,
   // TODO: go deeper and extract the log semantics.
   //opcode_id: 0,
-  type: move zeek.qtype_name,
+  type: move $event.zeek.qtype_name,
 }
-ocsf.query_time = ocsf.time
-ocsf.response_time = ocsf.time
-ocsf.rcode = $rcode_names[zeek.rcode_name]? else zeek.rcode_name
-drop zeek.rcode_name
-ocsf.rcode_id = move zeek.rcode
+$event.ocsf.query_time = $event.ocsf.time
+$event.ocsf.response_time = $event.ocsf.time
+$event.ocsf.rcode = $rcode_names[$event.zeek.rcode_name]? else $event.zeek.rcode_name
+drop $event.zeek.rcode_name
+$event.ocsf.rcode_id = move $event.zeek.rcode
 
-ocsf.connection_info = {
+$event.ocsf.connection_info = {
   direction: "Other",
   direction_id: 99,
 }
-ocsf.status = "Unknown"
-ocsf.status_id = 0
+$event.ocsf.status = "Unknown"
+$event.ocsf.status_id = 0
 
 @name = "ocsf.dns_activity"

--- a/zeek/operators/ocsf/logs/ftp.tql
+++ b/zeek/operators/ocsf/logs/ftp.tql
@@ -1,9 +1,14 @@
 ---
 description: |
   Zeek ftp.log → OCSF FTP Activity.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-zeek::ocsf::map_network
+zeek::ocsf::map_network event=$event
 
 // --- OCSF: classification attributes ----------
 
@@ -20,32 +25,32 @@ let $commands = {
   RNTO: 5,
   RMD: 4,
 }
-ocsf.activity_id = $commands[zeek.command]? else 0
-ocsf.class_uid = 4008
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = $commands[$event.zeek.command]? else 0
+$event.ocsf.class_uid = 4008
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata.log_name = "ftp.log"
+$event.ocsf.metadata.log_name = "ftp.log"
 
-ocsf.file = {
-  name: move zeek.arg,
-  size: move zeek.file_size,
+$event.ocsf.file = {
+  name: move $event.zeek.arg,
+  size: move $event.zeek.file_size,
   type_id: 0,
 }
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.connection_info.protocol_name = "tcp"
-ocsf.connection_info.protocol_num = 6
+$event.ocsf.connection_info.protocol_name = "tcp"
+$event.ocsf.connection_info.protocol_num = 6
 
-ocsf.command = move zeek.command
-ocsf.codes = [move zeek.reply_code]
-ocsf.status_code = ocsf.codes[0].string()
-ocsf.status_detail = move zeek.reply_msg
-ocsf.type = "passive" if zeek.data_channel.passive else "active"
-ocsf.port = move zeek.data_channel.resp_p
-drop zeek.data_channel
+$event.ocsf.command = move $event.zeek.command
+$event.ocsf.codes = [move $event.zeek.reply_code]
+$event.ocsf.status_code = $event.ocsf.codes[0].string()
+$event.ocsf.status_detail = move $event.zeek.reply_msg
+$event.ocsf.type = "passive" if $event.zeek.data_channel.passive else "active"
+$event.ocsf.port = move $event.zeek.data_channel.resp_p
+drop $event.zeek.data_channel
 
 @name = "ocsf.ftp_activity"

--- a/zeek/operators/ocsf/logs/http.tql
+++ b/zeek/operators/ocsf/logs/http.tql
@@ -1,9 +1,14 @@
 ---
 description: |
   Zeek http.log → OCSF HTTP Activity.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-zeek::ocsf::map_network
+zeek::ocsf::map_network event=$event
 
 // --- OCSF: classification attributes ----------
 
@@ -17,59 +22,59 @@ let $methods = {
   PUT: 7,
   TRACE: 8,
 }
-zeek._method = move zeek.method?
-ocsf.activity_id = $methods[zeek._method]? else 0
-ocsf.class_uid = 4002
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.zeek._method = move $event.zeek.method?
+$event.ocsf.activity_id = $methods[$event.zeek._method]? else 0
+$event.ocsf.class_uid = 4002
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata.log_name = "http.log"
+$event.ocsf.metadata.log_name = "http.log"
 
 // --- OCSF: primary attributes -----------------
 
-if zeek.has("dest_host") {
-  host = zeek.dest_host
+if $event.zeek.has("dest_host") {
+  $event.host = $event.zeek.dest_host
 } else {
-  host = zeek.host
+  $event.host = $event.zeek.host
 }
 
-ocsf.http_request = {
-  http_method: zeek._method.to_title() if zeek._method? != null else null,
-  referrer: move zeek.referrer,
+$event.ocsf.http_request = {
+  http_method: $event.zeek._method.to_title() if $event.zeek._method? != null else null,
+  referrer: move $event.zeek.referrer,
   url: {
-    hostname: move host,
+    hostname: move $event.host,
     // TODO: Take this apart with string or URL functions.
     // Zeek's uri field is actually the path plus all parameters.
-    path: move zeek.uri,
+    path: move $event.zeek.uri,
   },
-  user_agent: move zeek.user_agent,
-  version: move zeek.version,
+  user_agent: move $event.zeek.user_agent,
+  version: move $event.zeek.version,
 }
-drop zeek._method?
-if zeek.has("client_headers") {
-  ocsf.http_request.http_headers = \
-    zeek.client_headers.map(x => x.split(": ", max=1)).map(xs => {name: xs[0], value: xs[1]})
-  drop zeek.client_headers
+drop $event.zeek._method?
+if $event.zeek.has("client_headers") {
+  $event.ocsf.http_request.http_headers = \
+    $event.zeek.client_headers.map(x => x.split(": ", max=1)).map(xs => {name: xs[0], value: xs[1]})
+  drop $event.zeek.client_headers
 }
-if zeek.has("server_headers") {
-  ocsf.http_response.http_headers = \
-    zeek.server_headers.map(x => x.split(": ", max=1)).map(xs => {name: xs[0], value: xs[1]})
-  drop zeek.server_headers
-}
-
-ocsf.http_response = {
-  code: move zeek.status_code,
-  status: move zeek.status_msg,
+if $event.zeek.has("server_headers") {
+  $event.ocsf.http_response.http_headers = \
+    $event.zeek.server_headers.map(x => x.split(": ", max=1)).map(xs => {name: xs[0], value: xs[1]})
+  drop $event.zeek.server_headers
 }
 
-ocsf.connection_info.direction = "Other"
-ocsf.connection_info.direction_id = 99
-ocsf.connection_info.protocol_name = "tcp"
-ocsf.connection_info.protocol_num = 6
+$event.ocsf.http_response = {
+  code: move $event.zeek.status_code,
+  status: move $event.zeek.status_msg,
+}
 
-ocsf.status = "Unknown"
-ocsf.status_id = 0
+$event.ocsf.connection_info.direction = "Other"
+$event.ocsf.connection_info.direction_id = 99
+$event.ocsf.connection_info.protocol_name = "tcp"
+$event.ocsf.connection_info.protocol_num = 6
+
+$event.ocsf.status = "Unknown"
+$event.ocsf.status_id = 0
 
 @name = "ocsf.http_activity"

--- a/zeek/operators/ocsf/logs/rdp.tql
+++ b/zeek/operators/ocsf/logs/rdp.tql
@@ -1,9 +1,14 @@
 ---
 description: |
   Zeek rdp.log → OCSF RDP Activity.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-zeek::ocsf::map_network
+zeek::ocsf::map_network event=$event
 
 // --- OCSF: classification attributes ----------
 
@@ -15,41 +20,41 @@ let $results = {
   "Rejected for symmetry breaking": 2,
   "Locked conference": 2,
 }
-ocsf.activity_id = 6
-ocsf.class_uid = 4005
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 6
+$event.ocsf.class_uid = 4005
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata.log_name = "rdp.log"
+$event.ocsf.metadata.log_name = "rdp.log"
 // --- OCSF: primary attributes -----------------
 
-ocsf.connection_info.protocol_name = "tcp"
-ocsf.connection_info.protocol_num = 6
+$event.ocsf.connection_info.protocol_name = "tcp"
+$event.ocsf.connection_info.protocol_num = 6
 
-ocsf.protocol_ver = move zeek.client_build?
-ocsf.identifier_cookie = move zeek.cookie
-ocsf.keyboard_info = {
-  keyboard_layout: move zeek.keyboard_layout?,
+$event.ocsf.protocol_ver = move $event.zeek.client_build?
+$event.ocsf.identifier_cookie = move $event.zeek.cookie
+$event.ocsf.keyboard_info = {
+  keyboard_layout: move $event.zeek.keyboard_layout?,
 }
-ocsf.remote_display = {
-  physical_height: move zeek.desktop_height?,
-  physical_width: move zeek.desktop_width?,
-  color_depth: int(replace(move zeek.requested_color_depth?, "bit", "")),
+$event.ocsf.remote_display = {
+  physical_height: move $event.zeek.desktop_height?,
+  physical_width: move $event.zeek.desktop_width?,
+  color_depth: int(replace(move $event.zeek.requested_color_depth?, "bit", "")),
 }
-ocsf.tls = {
-  key_length: int(replace(move zeek.encryption_method?, "bit", "")),
+$event.ocsf.tls = {
+  key_length: int(replace(move $event.zeek.encryption_method?, "bit", "")),
   // The version is required, but not present in the data.
   version: null,
 }
-ocsf.status_detail = move zeek.result
-ocsf.status_id = $results[ocsf.status_detail] else 0
+$event.ocsf.status_detail = move $event.zeek.result
+$event.ocsf.status_id = $results[$event.ocsf.status_detail] else 0
 
 // --- OCSF: context attributes -----------------
 
-ocsf.device = {
-  name: move zeek.client_name?,
+$event.ocsf.device = {
+  name: move $event.zeek.client_name?,
   os: {
     name: "Windows",
     cpe_name: "cpe:2.3:o:microsoft:windows",
@@ -57,7 +62,7 @@ ocsf.device = {
     type: "Windows",
   },
   // 64-byte clientDigProductId
-  uid: move zeek.client_dig_product_id?,
+  uid: move $event.zeek.client_dig_product_id?,
   type_id: 2,
   type: "Desktop",
 }

--- a/zeek/operators/ocsf/logs/smb_files.tql
+++ b/zeek/operators/ocsf/logs/smb_files.tql
@@ -1,50 +1,55 @@
 ---
 description: |
   Zeek smb_files.log → OCSF SMB Activity.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-zeek::ocsf::map_network
+zeek::ocsf::map_network event=$event
 
 // --- OCSF: classification attributes ----------
 
 // The Zeek actions don't naturally map to the corresponding OCSF
 // class. Zeek actions have the pattern `SMB::{TYPE}_{ACTION}` where
 // `TYPE` is one of `FILE`, `PIPE`, or `PRINT`.
-if zeek.action.ends_with("_OPEN") {
-  ocsf.activity_id = 2
+if $event.zeek.action.ends_with("_OPEN") {
+  $event.ocsf.activity_id = 2
 } else {
-  ocsf.activity_id = 99
+  $event.ocsf.activity_id = 99
 }
-ocsf.class_uid = 4006
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.class_uid = 4006
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata.log_name = "smb_files.log"
+$event.ocsf.metadata.log_name = "smb_files.log"
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.connection_info.protocol_name = "tcp"
-ocsf.connection_info.protocol_num = 6
+$event.ocsf.connection_info.protocol_name = "tcp"
+$event.ocsf.connection_info.protocol_num = 6
 
-ocsf.file = {
-  path: move zeek.path,
+$event.ocsf.file = {
+  path: move $event.zeek.path,
 }
-ocsf.share = move zeek.name
-if zeek.action.starts_with("SMB::FILE") {
-  ocsf.share_type_id = 1
-  ocsf.share_type = "File"
-} else if zeek.action.starts_with("SMB::PIPE") {
-  ocsf.share_type_id = 2
-  ocsf.share_type = "Pipe"
-} else if zeek.action.starts_with("SMB::PRINT") {
-  ocsf.share_type_id = 3
-  ocsf.share_type = "Print"
+$event.ocsf.share = move $event.zeek.name
+if $event.zeek.action.starts_with("SMB::FILE") {
+  $event.ocsf.share_type_id = 1
+  $event.ocsf.share_type = "File"
+} else if $event.zeek.action.starts_with("SMB::PIPE") {
+  $event.ocsf.share_type_id = 2
+  $event.ocsf.share_type = "Pipe"
+} else if $event.zeek.action.starts_with("SMB::PRINT") {
+  $event.ocsf.share_type_id = 3
+  $event.ocsf.share_type = "Print"
 } else {
-  ocsf.share_type_id = 0
-  ocsf.share_type = "Unknown"
+  $event.ocsf.share_type_id = 0
+  $event.ocsf.share_type = "Unknown"
 }
-drop zeek.action
+drop $event.zeek.action
 
 @name = "ocsf.smb_activity"

--- a/zeek/operators/ocsf/logs/smtp.tql
+++ b/zeek/operators/ocsf/logs/smtp.tql
@@ -1,6 +1,11 @@
 ---
 description: |
   Zeek smtp.log → OCSF Email Activity.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // TODO:
@@ -9,36 +14,36 @@ description: |
 // - Surface Zeek file UIDs (`fuids`) for corresponding Network File Activity
 //   events when possible.
 
-zeek::ocsf::map_network
-drop ocsf.connection_info?
+zeek::ocsf::map_network event=$event
+drop $event.ocsf.connection_info?
 
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 1
-ocsf.class_uid = 4009
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 1
+$event.ocsf.class_uid = 4009
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata.log_name = "smtp.log"
+$event.ocsf.metadata.log_name = "smtp.log"
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.dst_endpoint.intermediate_ips = move zeek.path
+$event.ocsf.dst_endpoint.intermediate_ips = move $event.zeek.path
 
-ocsf.email = {
-  from_mailbox: move zeek.from,
-  from: move zeek.mailfrom,
-  cc: move zeek.cc?,
-  reply_to: move zeek.reply_to?,
-  message_uid: move zeek.msg_id,
-  to: move zeek.rcptto,
-  to_mailboxes: move zeek.to,
-  subject: move zeek.subject,
+$event.ocsf.email = {
+  from_mailbox: move $event.zeek.from,
+  from: move $event.zeek.mailfrom,
+  cc: move $event.zeek.cc?,
+  reply_to: move $event.zeek.reply_to?,
+  message_uid: move $event.zeek.msg_id,
+  to: move $event.zeek.rcptto,
+  to_mailboxes: move $event.zeek.to,
+  subject: move $event.zeek.subject,
 }
-ocsf.command = move zeek.helo
-ocsf.protocol_name = "SMTP"
-ocsf.status_detail = move zeek.last_reply
+$event.ocsf.command = move $event.zeek.helo
+$event.ocsf.protocol_name = "SMTP"
+$event.ocsf.status_detail = move $event.zeek.last_reply
 
 @name = "ocsf.email_activity"

--- a/zeek/operators/ocsf/logs/ssh.tql
+++ b/zeek/operators/ocsf/logs/ssh.tql
@@ -1,9 +1,14 @@
 ---
 description: |
   Zeek ssh.log → OCSF SSH Activity.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-zeek::ocsf::map_network
+zeek::ocsf::map_network event=$event
 
 // --- OCSF: classification attributes ----------
 
@@ -11,34 +16,34 @@ zeek::ocsf::map_network
 // we have a ssh.log entry, it means we already have an established
 // connection and must assume data is being exchanged, even if it's just
 // the SSH handshake.
-ocsf.activity_id = 6
-ocsf.class_uid = 4007
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
-if "ABP" in zeek.inferences or "BFS" in zeek.inferences {
+$event.ocsf.activity_id = 6
+$event.ocsf.class_uid = 4007
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
+if "ABP" in $event.zeek.inferences or "BFS" in $event.zeek.inferences {
   // Client authentication bypass (ABP) or brute force success (BFS) are
   // worthwhile escalating.
-  ocsf.severity_id = 4
-} else if "BF" in zeek.inferences or "SV" in zeek.inferences or "SC" in zeek.inferences or "SP" in zeek.inferences {
+  $event.ocsf.severity_id = 4
+} else if "BF" in $event.zeek.inferences or "SV" in $event.zeek.inferences or "SC" in $event.zeek.inferences or "SP" in $event.zeek.inferences {
   // Noteworthy are brute force attempts (BF), version scanning (SV),
   // capability scanning (SC), or other scanning (SP).
-  ocsf.severity_id = 3
+  $event.ocsf.severity_id = 3
 } else {
   // Everything else is standard.
-  ocsf.severity_id = 1
+  $event.ocsf.severity_id = 1
 }
 
 // --- OCSF: occurence attributes ---------------
 
-ocsf.count = move zeek.auth_attempts
+$event.ocsf.count = move $event.zeek.auth_attempts
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata.log_name = "ssh.log"
+$event.ocsf.metadata.log_name = "ssh.log"
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.connection_info.protocol_name = "tcp"
-ocsf.connection_info.protocol_num = 6
+$event.ocsf.connection_info.protocol_name = "tcp"
+$event.ocsf.connection_info.protocol_num = 6
 
 // The Direction enum in Zeek can be INBOUND, OUTBOUND, BIDIRECTIONAL, or
 // NO_DIRECTION. NB: there is no equivalent to Lateral in Zeek, so we
@@ -68,44 +73,44 @@ let $direction = {
     name: "Unknown"
   },
 }
-ocsf.connection_info.direction = $direction[zeek.direction].name
-ocsf.connection_info.direction_id = $direction[zeek.direction].id
-drop zeek.direction
+$event.ocsf.connection_info.direction = $direction[$event.zeek.direction].name
+$event.ocsf.connection_info.direction_id = $direction[$event.zeek.direction].id
+drop $event.zeek.direction
 
-ocsf.src_endpoint.agent_list = [{
-  name: move zeek.client,
+$event.ocsf.src_endpoint.agent_list = [{
+  name: move $event.zeek.client,
   type: "Remote Access",
   type_id: 9,
 }]
-ocsf.dst_endpoint.agent_list = [{
-  name: move zeek.server,
+$event.ocsf.dst_endpoint.agent_list = [{
+  name: move $event.zeek.server,
   type: "Remote Access",
   type_id: 9,
 }]
 
-ocsf.server_hassh = {
-  algorithm: move zeek.hasshServerAlgorithms,
+$event.ocsf.server_hassh = {
+  algorithm: move $event.zeek.hasshServerAlgorithms,
   fingerprint: {
     algorithm_id: 20,
-    value: move zeek.hasshServer,
+    value: move $event.zeek.hasshServer,
   },
 }
-ocsf.client_hassh = {
-  algorithm: move zeek.hasshAlgorithms,
+$event.ocsf.client_hassh = {
+  algorithm: move $event.zeek.hasshAlgorithms,
   fingerprint: {
     algorithm_id: 20,
-    value: move zeek.hassh,
+    value: move $event.zeek.hassh,
   },
 }
 
 // The Authentication Type can be deduced if we have the `inferences`
 // package.
-if "KS" in zeek.inferences {
-  ocsf.auth_type_id = 4
-  ocsf.auth_type = "Keyboard Interactive"
+if "KS" in $event.zeek.inferences {
+  $event.ocsf.auth_type_id = 4
+  $event.ocsf.auth_type = "Keyboard Interactive"
 } else {
-  ocsf.auth_type_id = 0
-  ocsf.auth_type = "Unknown"
+  $event.ocsf.auth_type_id = 0
+  $event.ocsf.auth_type = "Unknown"
 }
 
 @name = "ocsf.ssh_activity"

--- a/zeek/operators/ocsf/logs/ssl.tql
+++ b/zeek/operators/ocsf/logs/ssl.tql
@@ -1,20 +1,25 @@
 ---
 description: |
   Zeek ssl.log → OCSF Network Activity.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-zeek::ocsf::map_network
+zeek::ocsf::map_network event=$event
 
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 6
-ocsf.class_uid = 4001
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 6
+$event.ocsf.class_uid = 4001
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata.log_name = "ssl.log"
+$event.ocsf.metadata.log_name = "ssl.log"
 
 // Converted from:
 // https://github.com/zeek/zeek/blob/fdf887ce3bd80e0b466a973d5063c5882303d282/scripts/base/protocols/ssl/consts.zeek#L113
@@ -55,51 +60,51 @@ let $alert_codes = {
   ech_required: 121, // draft-ietf-tls-esni-17
 }
 
-ocsf.tls = {
+$event.ocsf.tls = {
   certificate: {
-    issuer: move zeek.issuer,
-    subject: move zeek.subject,
+    issuer: move $event.zeek.issuer,
+    subject: move $event.zeek.subject,
   },
-  cipher: move zeek.cipher,
+  cipher: move $event.zeek.cipher,
   ja3_hash: {
     algorithm_id: 1,
-    value: move zeek.ja3?,
+    value: move $event.zeek.ja3?,
   },
   ja3s_hash: {
     algorithm_id: 1,
-    value: move zeek.ja3s?,
+    value: move $event.zeek.ja3s?,
   },
-  sni: move zeek.server_name,
-  version: move zeek.version,
+  sni: move $event.zeek.server_name,
+  version: move $event.zeek.version,
 }
 // NB: If we have an alert, `ssl_history` also contains [lL].
-if zeek.last_alert != null {
-  ocsf.tls.alert = $alert_codes[zeek.last_alert]
+if $event.zeek.last_alert != null {
+  $event.ocsf.tls.alert = $alert_codes[$event.zeek.last_alert]
 }
 
 // --- OCSF: primary attributes -----------------
 
-ocsf.connection_info.protocol_name = "tcp"
-ocsf.connection_info.protocol_num = 6
+$event.ocsf.connection_info.protocol_name = "tcp"
+$event.ocsf.connection_info.protocol_num = 6
 
-if not zeek.established or zeek.last_alert != null {
-  ocsf.status_id = 2
-  ocsf.status = "Failure"
-  ocsf.status_detail = move zeek.last_alert
-} else if zeek.validation_status? == "ok" {
+if not $event.zeek.established or $event.zeek.last_alert != null {
+  $event.ocsf.status_id = 2
+  $event.ocsf.status = "Failure"
+  $event.ocsf.status_detail = move $event.zeek.last_alert
+} else if $event.zeek.validation_status? == "ok" {
   // There could be more `validation_status` values that mean success,
   // but it's difficult to find them. In Zeek, we'd need to grep through
   // all invocations of `x509_result_record` and trace the arguments.
   //
   // Going with just "ok" here is simply going off empirical data.
-  ocsf.status_id = 1
-  ocsf.status = "Success"
-  ocsf.status_detail = move zeek.validation_status
+  $event.ocsf.status_id = 1
+  $event.ocsf.status = "Success"
+  $event.ocsf.status_detail = move $event.zeek.validation_status
 } else {
-  ocsf.status_id = 0
-  ocsf.status = "Unknown"
-  ocsf.status_detail = move zeek.validation_status
+  $event.ocsf.status_id = 0
+  $event.ocsf.status = "Unknown"
+  $event.ocsf.status_detail = move $event.zeek.validation_status
 }
-drop zeek.established
+drop $event.zeek.established
 
 @name = "ocsf.network_activity"

--- a/zeek/operators/ocsf/logs/x509.tql
+++ b/zeek/operators/ocsf/logs/x509.tql
@@ -1,40 +1,45 @@
 ---
 description: |
   Zeek x509.log → OCSF Network Activity.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
-zeek::ocsf::map_network
+zeek::ocsf::map_network event=$event
 
 // --- OCSF: classification attributes ----------
 
-ocsf.activity_id = 6
-ocsf.class_uid = 4001
-ocsf.severity_id = 1
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.activity_id = 6
+$event.ocsf.class_uid = 4001
+$event.ocsf.severity_id = 1
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata.log_name = "x509.log"
+$event.ocsf.metadata.log_name = "x509.log"
 
-ocsf.tls = {
+$event.ocsf.tls = {
   certificate: {
-    serial_number: move zeek.certificate.serial,
-    created_time: move zeek.certificate.not_valid_before,
-    expiration_time: move zeek.certificate.not_valid_after,
-    issuer: move zeek.certificate.issuer,
-    subject: move zeek.certificate.subject,
-    version: (move zeek.certificate.version).string(),
+    serial_number: move $event.zeek.certificate.serial,
+    created_time: move $event.zeek.certificate.not_valid_before,
+    expiration_time: move $event.zeek.certificate.not_valid_after,
+    issuer: move $event.zeek.certificate.issuer,
+    subject: move $event.zeek.certificate.subject,
+    version: (move $event.zeek.certificate.version).string(),
   },
-  sans: (move zeek.san.dns).map(name => {
+  sans: (move $event.zeek.san.dns).map(name => {
     name: name,
     type: "DNSName",
   }),
   version: null,
 }
-if zeek.fingerprint? != null {
-  ocsf.tls.certificate.fingerprints = [{
+if $event.zeek.fingerprint? != null {
+  $event.ocsf.tls.certificate.fingerprints = [{
     algorithm_id: 3,
-    value: move zeek.fingerprint,
+    value: move $event.zeek.fingerprint,
   }]
 }
 

--- a/zeek/operators/ocsf/map.tql
+++ b/zeek/operators/ocsf/map.tql
@@ -1,29 +1,34 @@
 ---
 description: Zeek log -> OCSF
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {zeek: this}
-ocsf = {}
+$event = {...$event, zeek: $event, ocsf: {}}
 
 // --- OCSF: occurrence attributes --------------
 
-if type_of(zeek.ts).kind == "time" {
-  ocsf.time = move zeek.ts
-} else if type_of(zeek.ts).kind == "double" {
-  ocsf.time = (move zeek.ts).seconds().from_epoch()
+if type_of($event.zeek.ts).kind == "time" {
+  $event.ocsf.time = move $event.zeek.ts
+} else if type_of($event.zeek.ts).kind == "double" {
+  $event.ocsf.time = (move $event.zeek.ts).seconds().from_epoch()
 }
-if zeek.has("duration") {
-  zeek._duration = (move zeek.duration).seconds()
-  ocsf.duration = count_milliseconds(zeek._duration).round()
-  ocsf.start_time = ocsf.time
-  ocsf.end_time = ocsf.time + zeek._duration
-  drop zeek._duration
+if $event.zeek.has("duration") {
+  $event.zeek._duration = (move $event.zeek.duration).seconds()
+  $event.ocsf.duration = count_milliseconds($event.zeek._duration).round()
+  $event.ocsf.start_time = $event.ocsf.time
+  $event.ocsf.end_time = $event.ocsf.time + $event.zeek._duration
+  drop $event.zeek._duration
 }
 
 // --- OCSF: context attributes -----------------
 
-ocsf.metadata = {
-  logged_time: move zeek._write_ts?,
+$event.ocsf.metadata = {
+  logged_time: move $event.zeek._write_ts?,
   product: {
     name: "Zeek",
     vendor_name: "Zeek",
@@ -31,48 +36,48 @@ ocsf.metadata = {
   },
   version: "1.8.0",
 }
-if zeek.uid? != null {
-  ocsf.metadata.original_event_uid = zeek.uid
-  ocsf.metadata.correlation_uid = move zeek.uid
+if $event.zeek.uid? != null {
+  $event.ocsf.metadata.original_event_uid = $event.zeek.uid
+  $event.ocsf.metadata.correlation_uid = move $event.zeek.uid
 }
 
-match zeek._path? else @name {
+match $event.zeek._path? else @name {
   "conn" | "zeek.conn" => {
-    zeek::ocsf::logs::conn
+    zeek::ocsf::logs::conn event=$event
   }
   "dhcp" | "zeek.dhcp" => {
-    zeek::ocsf::logs::dhcp
+    zeek::ocsf::logs::dhcp event=$event
   }
   "dns" | "zeek.dns" => {
-    zeek::ocsf::logs::dns
+    zeek::ocsf::logs::dns event=$event
   }
   "ftp" | "zeek.ftp" => {
-    zeek::ocsf::logs::ftp
+    zeek::ocsf::logs::ftp event=$event
   }
   "http" | "zeek.http" => {
-    zeek::ocsf::logs::http
+    zeek::ocsf::logs::http event=$event
   }
   "rdp" | "zeek.rdp" => {
-    zeek::ocsf::logs::rdp
+    zeek::ocsf::logs::rdp event=$event
   }
   "smb_files" | "zeek.smb_files" => {
-    zeek::ocsf::logs::smb_files
+    zeek::ocsf::logs::smb_files event=$event
   }
   "smtp" | "zeek.smtp" => {
-    zeek::ocsf::logs::smtp
+    zeek::ocsf::logs::smtp event=$event
   }
   "ssh" | "zeek.ssh" => {
-    zeek::ocsf::logs::ssh
+    zeek::ocsf::logs::ssh event=$event
   }
   "ssl" | "zeek.ssl" => {
-    zeek::ocsf::logs::ssl
+    zeek::ocsf::logs::ssl event=$event
   }
   "x509" | "zeek.x509" => {
-    zeek::ocsf::logs::x509
+    zeek::ocsf::logs::x509 event=$event
   }
   _ => {
-    zeek::ocsf::base
+    zeek::ocsf::base event=$event
   }
 }
 
-this = {...ocsf, unmapped: zeek}
+$event = {...$event.ocsf, unmapped: $event.zeek}

--- a/zeek/operators/ocsf/map_network.tql
+++ b/zeek/operators/ocsf/map_network.tql
@@ -1,62 +1,67 @@
 ---
 description: |
   Zeek events → OCSF Network Activity.
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 // --- OCSF: classification attributes ----------
 
-ocsf.category_uid = 4
+$event.ocsf.category_uid = 4
 
 // --- OCSF: occurence & context attributes------
 
-if ocsf.metadata.original_event_uid? != null {
-  ocsf.connection_info.uid = ocsf.metadata.original_event_uid
+if $event.ocsf.metadata.original_event_uid? != null {
+  $event.ocsf.connection_info.uid = $event.ocsf.metadata.original_event_uid
 }
 
 // Implied in metadata.log_name.
-drop zeek._path?
+drop $event.zeek._path?
 
 // --- OCSF: primary attributes -----------------
 
 // Map source/destination endpoints.
-if zeek.has("id") {
-  ocsf.src_endpoint = {
-    ip: zeek.id.orig_h,
-    port: zeek.id.orig_p,
+if $event.zeek.has("id") {
+  $event.ocsf.src_endpoint = {
+    ip: $event.zeek.id.orig_h,
+    port: $event.zeek.id.orig_p,
   }
-  ocsf.dst_endpoint = {
-    ip: zeek.id.resp_h,
-    port: zeek.id.resp_p,
+  $event.ocsf.dst_endpoint = {
+    ip: $event.zeek.id.resp_h,
+    port: $event.zeek.id.resp_p,
   }
-  drop zeek.id
+  drop $event.zeek.id
   // Fill protocol version based on endpoints.
   // This could at some point go into `ocsf::derive`.
-  if ocsf.src_endpoint.ip.is_v6() or ocsf.dst_endpoint.ip.is_v6() {
-    ocsf.connection_info.protocol_ver_id = 6
+  if $event.ocsf.src_endpoint.ip.is_v6() or $event.ocsf.dst_endpoint.ip.is_v6() {
+    $event.ocsf.connection_info.protocol_ver_id = 6
   } else {
-    ocsf.connection_info.protocol_ver_id = 4
+    $event.ocsf.connection_info.protocol_ver_id = 4
   }
 }
-if zeek.has("orig_l2_addr") {
-  ocsf.src_endpoint.mac = move zeek.orig_l2_addr
+if $event.zeek.has("orig_l2_addr") {
+  $event.ocsf.src_endpoint.mac = move $event.zeek.orig_l2_addr
 }
-if zeek.has("resp_l2_addr") {
-  ocsf.dst_endpoint.mac = move zeek.resp_l2_addr
+if $event.zeek.has("resp_l2_addr") {
+  $event.ocsf.dst_endpoint.mac = move $event.zeek.resp_l2_addr
 }
-if zeek.has("orig_cc") {
-  ocsf.src_endpoint.location = {
-    country: move zeek.orig_cc,
+if $event.zeek.has("orig_cc") {
+  $event.ocsf.src_endpoint.location = {
+    country: move $event.zeek.orig_cc,
   }
 }
-if zeek.has("resp_cc") {
-  ocsf.dst_endpoint.location = {
-    country: move zeek.resp_cc,
+if $event.zeek.has("resp_cc") {
+  $event.ocsf.dst_endpoint.location = {
+    country: move $event.zeek.resp_cc,
   }
 }
 
 // Map Community ID.
-if zeek.has("community_id") {
-  ocsf.connection_info.community_uid = move zeek.community_id
+if $event.zeek.has("community_id") {
+  $event.ocsf.connection_info.community_uid = move $event.zeek.community_id
 }
 
 // Map transport-layer protocol details.
@@ -67,7 +72,7 @@ let $proto_nums = {
   icmpv6: 58,
   ipv6: 41,
 }
-if zeek.has("proto") {
-  ocsf.connection_info.protocol_num = $proto_nums[zeek.proto]? else -1
-  ocsf.connection_info.protocol_name = move zeek.proto
+if $event.zeek.has("proto") {
+  $event.ocsf.connection_info.protocol_num = $proto_nums[$event.zeek.proto]? else -1
+  $event.ocsf.connection_info.protocol_name = move $event.zeek.proto
 }

--- a/zscaler/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
+++ b/zscaler/changelog/unreleased/event-scoped-ocsf-mapping-operators.md
@@ -1,0 +1,22 @@
+---
+title: Event-scoped OCSF mapping operators
+type: breaking
+authors:
+  - mavam
+  - codex
+created: 2026-06-13T07:58:22.47847Z
+---
+
+OCSF mapping operators now take a named `event` field argument that defaults to `this` and perform all mapping work inside that explicit event scope.
+
+Before:
+
+```tql
+pkg::ocsf::map source
+```
+
+After:
+
+```tql
+pkg::ocsf::map event=source
+```

--- a/zscaler/operators/ocsf/base.tql
+++ b/zscaler/operators/ocsf/base.tql
@@ -1,9 +1,14 @@
 ---
 description: Zscaler → OCSF Base Event (0)
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.base_event"
-ocsf.activity_id = 0
-ocsf.category_uid = 0
-ocsf.class_uid = 0
-ocsf.type_uid = 0
+$event.ocsf.activity_id = 0
+$event.ocsf.category_uid = 0
+$event.ocsf.class_uid = 0
+$event.ocsf.type_uid = 0

--- a/zscaler/operators/ocsf/map.tql
+++ b/zscaler/operators/ocsf/map.tql
@@ -1,24 +1,29 @@
 ---
 description: Zscaler → OCSF
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
+      default: this
 ---
 
-this = {zia: this}
-ocsf = {}
+$event = {...$event, zia: $event, ocsf: {}}
 
 // Clean up the original data.
-replace zia.bwthrottle, what="NO", with=false
-replace zia.bwthrottle, what="YES", with=true
-replace what="None", with=null
-replace what="N/A", with=null
-replace what="NA", with=null
-if zia.refererURL? != null {
-  zia.refererURL = zia.refererURL.trim("\"")
+replace $event.zia.bwthrottle, what="NO", with=false
+replace $event.zia.bwthrottle, what="YES", with=true
+replace $event.zia, what="None", with=null
+replace $event.zia, what="N/A", with=null
+replace $event.zia, what="NA", with=null
+if $event.zia.refererURL? != null {
+  $event.zia.refererURL = $event.zia.refererURL.trim("\"")
 }
-if zia.filetype? != null {
-  zia.filetype = zia.filetype.trim("\"")
+if $event.zia.filetype? != null {
+  $event.zia.filetype = $event.zia.filetype.trim("\"")
 }
 
-ocsf.metadata = {
+$event.ocsf.metadata = {
   log_name: "NSS",
   product: {
     name: "Unknown",
@@ -26,24 +31,24 @@ ocsf.metadata = {
   },
   version: "1.8.0",
 }
-if zia.product? != null {
-  ocsf.metadata.product.name = move zia.product
+if $event.zia.product? != null {
+  $event.ocsf.metadata.product.name = move $event.zia.product
 }
-if zia.vendor? != null {
-  ocsf.metadata.product.vendor_name = move zia.vendor
+if $event.zia.vendor? != null {
+  $event.ocsf.metadata.product.vendor_name = move $event.zia.vendor
 }
-if zia.event_id? != null {
-  ocsf.metadata.original_event_uid = string(move zia.event_id)
+if $event.zia.event_id? != null {
+  $event.ocsf.metadata.original_event_uid = string(move $event.zia.event_id)
 }
 
-ocsf.severity_id = 0
-ocsf.time = now()
+$event.ocsf.severity_id = 0
+$event.ocsf.time = now()
 
 // Poor man's proxy log detection.
-if zia.has("requestmethod") {
-  zscaler::ocsf::zia::proxy
+if $event.zia.has("requestmethod") {
+  zscaler::ocsf::zia::proxy event=$event
 } else {
-  zscaler::ocsf::base
+  zscaler::ocsf::base event=$event
 }
 
-this = {...ocsf, unmapped: zia}
+$event = {...$event.ocsf, unmapped: $event.zia}

--- a/zscaler/operators/ocsf/zia/proxy.tql
+++ b/zscaler/operators/ocsf/zia/proxy.tql
@@ -1,5 +1,10 @@
 ---
 description: "ZIA NSS: Proxy → OCSF HTTP Activity"
+args:
+  named:
+    - name: event
+      description: The field that holds the event to map.
+      type: field
 ---
 
 @name = "ocsf.http_activity"
@@ -17,11 +22,11 @@ let $activity_map = {
   TRACE: 8,
   PATCH: 9,
 }
-ocsf.activity_id = $activity_map[zia.requestmethod]? else 0
+$event.ocsf.activity_id = $activity_map[$event.zia.requestmethod]? else 0
 
-ocsf.category_uid = 4
-ocsf.class_uid = 4002
-ocsf.type_uid = ocsf.class_uid * 100 + ocsf.activity_id
+$event.ocsf.category_uid = 4
+$event.ocsf.class_uid = 4002
+$event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
 let $severities = {
   None: 0,
@@ -30,92 +35,92 @@ let $severities = {
   high: 4,
   critical: 5,
 }
-ocsf.severity_id = $severities[move zia.threatseverity]? else 0
+$event.ocsf.severity_id = $severities[move $event.zia.threatseverity]? else 0
 
 // --- OCSF: context attributes -----------------
 
-ocsf.app_name = move zia.appname
+$event.ocsf.app_name = move $event.zia.appname
 
-ocsf.metadata.profiles = ["host", "network_proxy", "security_control"]
+$event.ocsf.metadata.profiles = ["host", "network_proxy", "security_control"]
 
-ocsf.time = parse_time(move zia.datetime, "%a %b %d %H:%M:%S %Y")
+$event.ocsf.time = parse_time(move $event.zia.datetime, "%a %b %d %H:%M:%S %Y")
 
 // --- OCSF: primary attributes -----------------
 
-if zia.status != null {
+if $event.zia.status != null {
   // Only when raw=true
-  zia.status = zia.status.int()
-  if zia.status >= 200 and zia.status < 400 {
-    ocsf.status_id = 1
-  } else if zia.status >= 400 {
-    ocsf.status_id = 2
+  $event.zia.status = $event.zia.status.int()
+  if $event.zia.status >= 200 and $event.zia.status < 400 {
+    $event.ocsf.status_id = 1
+  } else if $event.zia.status >= 400 {
+    $event.ocsf.status_id = 2
   } else {
-    ocsf.status_id = 0
+    $event.ocsf.status_id = 0
   }
-  ocsf.status_code = zia.status.string()
+  $event.ocsf.status_code = $event.zia.status.string()
 }
 
-ocsf.status_detail = move zia.reason
+$event.ocsf.status_detail = move $event.zia.reason
 
 // Source Endpoint (The client machine)
-ocsf.src_endpoint = {
-  ip: ip(move zia.ClientIP)
+$event.ocsf.src_endpoint = {
+  ip: ip(move $event.zia.ClientIP)
 }
 
 // Destination Endpoint (The web server)
-ocsf.dst_endpoint = {
-  ip: ip(move zia.serverip),
-  domain: move zia.hostname,
+$event.ocsf.dst_endpoint = {
+  ip: ip(move $event.zia.serverip),
+  domain: move $event.zia.hostname,
 }
 
-ocsf.traffic = {
-  bytes_in: int(move zia.responsesize),
-  bytes_out: int(move zia.requestsize),
-  bytes: int(move zia.transactionsize)
+$event.ocsf.traffic = {
+  bytes_in: int(move $event.zia.responsesize),
+  bytes_out: int(move $event.zia.requestsize),
+  bytes: int(move $event.zia.transactionsize)
 }
 
-ocsf.http_request = {
-  http_method: move zia.requestmethod,
-  referrer: move zia.refererURL,
-  user_agent: move zia.useragent,
+$event.ocsf.http_request = {
+  http_method: move $event.zia.requestmethod,
+  referrer: move $event.zia.refererURL,
+  user_agent: move $event.zia.useragent,
   url: {
-    url_string: move zia.url,
-    scheme: to_lower(move zia.protocol),
+    url_string: move $event.zia.url,
+    scheme: to_lower(move $event.zia.protocol),
     category_ids: [99, 99, 99, 99],
-    categories: [move zia.urlcategory, move zia.urlsupercategory, move zia.appclass, move zia.urlclass]
+    categories: [move $event.zia.urlcategory, move $event.zia.urlsupercategory, move $event.zia.appclass, move $event.zia.urlclass]
   }
 }
 
-ocsf.http_response = {
-  code: move zia.status,
-  content_type: move zia.contenttype
+$event.ocsf.http_response = {
+  code: move $event.zia.status,
+  content_type: move $event.zia.contenttype
 }
 
 // --- OCSF: Host profile -----------
 
-ocsf.actor = {
+$event.ocsf.actor = {
   user: {
-    name: move zia.user,
+    name: move $event.zia.user,
     org: {
       // ou: org unit
-      ou_name: move zia.department?,
+      ou_name: move $event.zia.department?,
     },
   },
 }
 
-ocsf.device = {
-  hostname: move zia.devicehostname?,
+$event.ocsf.device = {
+  hostname: move $event.zia.devicehostname?,
   owner: {
-    name: move zia.deviceowner?,
+    name: move $event.zia.deviceowner?,
   },
 }
 
 // --- OCSF: Network Proxy profile -----------
 
 // The ZIA node
-ocsf.proxy_endpoint = {
-  ip: ip(move zia.clientpublicIP),
-  name: move zia.location
+$event.ocsf.proxy_endpoint = {
+  ip: ip(move $event.zia.clientpublicIP),
+  name: move $event.zia.location
 }
 
 // --- OCSF: Security Control profile -----------
@@ -126,13 +131,13 @@ let $actions = {
   "Quarantined": 3,
   "Isolated": 5
 }
-ocsf.action_id = $actions[zia.action]? else 0
-drop zia.action
+$event.ocsf.action_id = $actions[$event.zia.action]? else 0
+drop $event.zia.action
 
-if zia.threatname != null {
-  ocsf.malware = [{
+if $event.zia.threatname != null {
+  $event.ocsf.malware = [{
     classification_ids: [0],
-    name: move zia.threatname,
+    name: move $event.zia.threatname,
   }]
 }
 
@@ -140,6 +145,6 @@ if zia.threatname != null {
 // - zia.threatclass
 // - zia.threatcategory
 
-ocsf.risk_score = int(move zia.pagerisk)
+$event.ocsf.risk_score = int(move $event.zia.pagerisk)
 
 // --- Finalize ---------------------------------


### PR DESCRIPTION
## 🔍 Problem

- Package mappers outside Microsoft still used global mapping state.
- Callers that add fields such as `raw_data` need an explicit mapping scope until proper UDFs exist.

## 🛠️ Solution

- Move package mapping UDOs to named `event` field arguments and `$event` scoped source/target namespaces.
- Keep public mapper defaults so `pkg::ocsf::map` continues to work on the current event.
- Update Splunk CIM/OCSF mappings to the target-first namespace pattern and explicit scoped dispatch.
- Add package changelog entries through `tenzir-ship`.

## 💬 Review

- Focus on mapper dispatchers and call sites that parse into temporary fields.
- The diff is mostly mechanical `$event` scoping; behavior should be unchanged.

<sub>
📚 Docs PR: tenzir/docs#401
</sub>
