### PR TITLE
Add alphaMountain read API operators

### DIFF
--- a/alphamountain/changelog/unreleased/expanded-alphamountain-read-api-coverage.md
+++ b/alphamountain/changelog/unreleased/expanded-alphamountain-read-api-coverage.md
@@ -9,3 +9,7 @@ created: 2026-06-15T00:00:00Z
 
 The alphaMountain package now includes read operators for multi-URI category
 and threat lookups, plus license and service quota information.
+
+Lookup and feed operators now expose single-service API statuses as plain
+`status` strings, while the OCSF mapper moves shaped API status and error
+details into OCSF status fields.

--- a/alphamountain/changelog/unreleased/expanded-alphamountain-read-api-coverage.md
+++ b/alphamountain/changelog/unreleased/expanded-alphamountain-read-api-coverage.md
@@ -1,0 +1,11 @@
+---
+title: Expanded alphaMountain read API coverage
+type: feature
+authors:
+  - mavam
+  - codex
+created: 2026-06-15T00:00:00Z
+---
+
+The alphaMountain package now includes read operators for multi-URI category
+and threat lookups, plus license and service quota information.

--- a/alphamountain/operators/category/feed.tql
+++ b/alphamountain/operators/category/feed.tql
@@ -39,7 +39,7 @@ alphamountain::api::post url="https://batch.alphamountain.ai/category/feed/json"
 unroll feed
 this = {
   ...move feed,
-  status: move status,
+  status: status["category/feed"],
   version: move version,
 }
 @name = "alphamountain.category"

--- a/alphamountain/operators/category/uri.tql
+++ b/alphamountain/operators/category/uri.tql
@@ -41,7 +41,7 @@ if category? != null {
   this = {
     ...move category,
     uri: move uri,
-    status: move status,
+    status: status.category,
     ttl: move ttl,
     version: move version,
   }

--- a/alphamountain/operators/category/uris.tql
+++ b/alphamountain/operators/category/uris.tql
@@ -1,0 +1,45 @@
+---
+description: Gets categories for multiple URIs.
+args:
+  named:
+    - name: license
+      type: secret
+      description: alphaMountain API license key.
+    - name: uris
+      description: URI or URL list to categorize.
+    - name: request_type
+      type: string
+      default: "partner.info"
+      description: API request type.
+    - name: mapping
+      type: int
+      default: null
+      description: Optional category mapping version.
+---
+
+let $body = {
+  license: $license,
+  version: 1,
+  type: $request_type,
+  uris: $uris,
+  mapping: $mapping,
+}
+
+alphamountain::api::post url="https://api.alphamountain.ai/category/uris", body=$body
+_events = [
+  ...categories.keys().map(uri => {
+    ...categories[uri],
+    uri: uri,
+    status: status,
+    version: version,
+  }),
+  ...errors.keys().map(uri => {
+    uri: uri,
+    error: errors[uri],
+    status: status,
+    version: version,
+  }),
+]
+unroll _events
+this = _events.drop_null_fields()
+@name = "alphamountain.category"

--- a/alphamountain/operators/category/uris.tql
+++ b/alphamountain/operators/category/uris.tql
@@ -30,13 +30,13 @@ _events = [
   ...categories.keys().map(uri => {
     ...categories[uri],
     uri: uri,
-    status: status,
+    status: status["category/uris"],
     version: version,
   }),
   ...errors.keys().map(uri => {
     uri: uri,
     error: errors[uri],
-    status: status,
+    status: status["category/uris"],
     version: version,
   }),
 ]

--- a/alphamountain/operators/license/info.tql
+++ b/alphamountain/operators/license/info.tql
@@ -1,0 +1,27 @@
+---
+description: Gets license and service quota information.
+args:
+  named:
+    - name: license
+      type: secret
+      description: alphaMountain API license key.
+    - name: flags
+      default: null
+      description: Optional license info flags.
+---
+
+let $body = {
+  license: $license,
+  flags: $flags,
+}
+
+alphamountain::api::post url="https://api.alphamountain.ai/license/info", body=$body
+_response = this
+_services = _response.keys().map(service_key => {
+  ..._response[service_key],
+  service_key: service_key,
+  service: _response[service_key].service? else service_key,
+})
+unroll _services
+this = _services.drop_null_fields()
+@name = "alphamountain.license_info"

--- a/alphamountain/operators/license/info.tql
+++ b/alphamountain/operators/license/info.tql
@@ -16,12 +16,12 @@ let $body = {
 }
 
 alphamountain::api::post url="https://api.alphamountain.ai/license/info", body=$body
-_response = this
-_services = _response.keys().map(service_key => {
-  ..._response[service_key],
+unroll this
+service_key = this.keys()[0]
+this = {
+  ...this[service_key],
   service_key: service_key,
-  service: _response[service_key].service? else service_key,
-})
-unroll _services
-this = _services.drop_null_fields()
+  service: this[service_key].service? else service_key,
+}
+drop_null_fields
 @name = "alphamountain.license_info"

--- a/alphamountain/operators/license/info.tql
+++ b/alphamountain/operators/license/info.tql
@@ -21,7 +21,6 @@ service_key = this.keys()[0]
 this = {
   ...this[service_key],
   service_key: service_key,
-  service: this[service_key].service? else service_key,
 }
 drop_null_fields
 @name = "alphamountain.license_info"

--- a/alphamountain/operators/ocsf/map.tql
+++ b/alphamountain/operators/ocsf/map.tql
@@ -222,6 +222,21 @@ $event.ocsf.metadata = {
 }
 $event.ocsf.osint = [move $event.osint]
 $event.ocsf.severity_id = 1
+if $event.am.status? != null and type_of($event.am.status).kind == "string" {
+  $event.ocsf.status = move $event.am.status
+  match $event.ocsf.status {
+    "Success" => {
+      $event.ocsf.status_id = 1
+    }
+    _ => {
+      $event.ocsf.status_id = 2
+    }
+  }
+}
+if $event.am.error? != null {
+  $event.ocsf.status_id = 2
+  $event.ocsf.status_detail = move $event.am.error
+}
 if ($event.am.has("score") and $event.am.score == null) or
    ($event.am.has("categories") and $event.am.categories == null) {
   $event.ocsf.status_id = 99

--- a/alphamountain/operators/threat/feed.tql
+++ b/alphamountain/operators/threat/feed.tql
@@ -40,7 +40,7 @@ alphamountain::api::post url="https://batch.alphamountain.ai/threat/feed/json", 
 unroll feed
 this = {
   ...move feed,
-  status: move status,
+  status: status["threat/feed"],
   version: move version,
 }
 @name = "alphamountain.threat"

--- a/alphamountain/operators/threat/uri.tql
+++ b/alphamountain/operators/threat/uri.tql
@@ -41,7 +41,7 @@ if threat? != null {
   this = {
     ...move threat,
     uri: move uri,
-    status: move status,
+    status: status.threat,
     ttl: move ttl,
     version: move version,
   }

--- a/alphamountain/operators/threat/uris.tql
+++ b/alphamountain/operators/threat/uris.tql
@@ -25,13 +25,13 @@ _events = [
   ...scores.keys().map(uri => {
     ...scores[uri],
     uri: uri,
-    status: status,
+    status: status["threat/uris"],
     version: version,
   }),
   ...errors.keys().map(uri => {
     uri: uri,
     error: errors[uri],
-    status: status,
+    status: status["threat/uris"],
     version: version,
   }),
 ]

--- a/alphamountain/operators/threat/uris.tql
+++ b/alphamountain/operators/threat/uris.tql
@@ -1,0 +1,40 @@
+---
+description: Gets threat scores for multiple URIs.
+args:
+  named:
+    - name: license
+      type: secret
+      description: alphaMountain API license key.
+    - name: uris
+      description: URI or URL list to assess.
+    - name: request_type
+      type: string
+      default: "partner.info"
+      description: API request type.
+---
+
+let $body = {
+  license: $license,
+  version: 1,
+  type: $request_type,
+  uris: $uris,
+}
+
+alphamountain::api::post url="https://api.alphamountain.ai/threat/uris", body=$body
+_events = [
+  ...scores.keys().map(uri => {
+    ...scores[uri],
+    uri: uri,
+    status: status,
+    version: version,
+  }),
+  ...errors.keys().map(uri => {
+    uri: uri,
+    error: errors[uri],
+    status: status,
+    version: version,
+  }),
+]
+unroll _events
+this = _events.drop_null_fields()
+@name = "alphamountain.threat"

--- a/alphamountain/package.yaml
+++ b/alphamountain/package.yaml
@@ -10,7 +10,8 @@ description: |
   intelligence for cybersecurity investigational and protection platforms.
 
   This package provides reusable operators for alphaMountain URI lookups,
-  intelligence feeds, and OCSF OSINT Inventory Info mapping.
+  multi-URI lookups, intelligence feeds, license information, and OCSF OSINT
+  Inventory Info mapping.
 categories:
 - sources
 - mappings


### PR DESCRIPTION
## 🔍 Problem

- The alphaMountain package only wrapped a subset of the read APIs.
- Multi-URI lookups and license entitlement inspection were missing from the reusable UDO surface.

## 🛠️ Solution

- Add multi-URI category and threat lookup operators.
- Add a license information operator for service quota and entitlement inspection.
- Keep the wrappers thin and hard-code the documented alphaMountain endpoints.
- Update the package description and changelog for the expanded read coverage.

## 💬 Review

- Focus on the URI-keyed response flattening in the multi-URI operators.
- Existing package tests pass; live smoke tests passed locally with the provided test key.
