### PR TITLE
Extract shared constants into package `constants.tql`

### DIFF
--- a/fortinet/changelog/unreleased/fortigate-cifs-ssh-monitored-disposition.md
+++ b/fortinet/changelog/unreleased/fortigate-cifs-ssh-monitored-disposition.md
@@ -1,0 +1,13 @@
+---
+title: FortiGate CIFS and SSH monitored disposition
+type: change
+authors:
+  - jachris
+prs:
+  - 163
+created: 2026-06-24T12:09:04.000000Z
+---
+
+FortiGate CIFS and SSH UTM logs with `action="monitored"` now map to OCSF
+`disposition_id` 17 (Monitored) instead of 0 (Unknown), matching the other UTM
+content-inspection mappers (webfilter, emailfilter, virus).

--- a/fortinet/constants.tql
+++ b/fortinet/constants.tql
@@ -1,0 +1,10 @@
+// Package-wide constants shared across the FortiGate OCSF log mappers.
+
+// OCSF `status_id` for the FortiGate `status` field on event/* logs.
+let $statuses = {success: 1, failed: 2}
+
+// OCSF `disposition_id` for the UTM content-inspection logs (webfilter,
+// emailfilter, virus, cifs, ssh), whose `action` is one of allowed/blocked/
+// monitored. Other log types (IPS, traffic, ...) use different action
+// vocabularies and keep their own local maps.
+let $utm_dispositions = {blocked: 2, allowed: 1, monitored: 17}

--- a/fortinet/operators/fortigate/ocsf/logs/authentication.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/authentication.tql
@@ -53,11 +53,7 @@ $event.ocsf.is_remote = true
 
 // `status` is the authentication outcome.
 if $event.fortinet.status? != null {
-  let $statuses = {
-    success: 1,
-    failed: 2,
-  }
-  $event.ocsf.status_id = $statuses[move $event.fortinet.status]? else 0
+  $event.ocsf.status_id = fortinet::$statuses[move $event.fortinet.status]? else 0
 }
 
 // event/system: `method` is the access method (e.g. "ssh", "https").

--- a/fortinet/operators/fortigate/ocsf/logs/cifs.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/cifs.tql
@@ -31,9 +31,5 @@ $event.ocsf.file = {
 fortinet::fortigate::ocsf::security_control event=$event
 
 if $event.fortinet.action? != null {
-  let $dispositions = {
-    blocked: 2,
-    allowed: 1,
-  }
-  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
+  $event.ocsf.disposition_id = fortinet::$utm_dispositions[move $event.fortinet.action]? else 0
 }

--- a/fortinet/operators/fortigate/ocsf/logs/emailfilter.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/emailfilter.tql
@@ -45,10 +45,5 @@ fortinet::fortigate::ocsf::network_endpoints event=$event
 fortinet::fortigate::ocsf::security_control event=$event
 
 if $event.fortinet.action? != null {
-  let $dispositions = {
-    blocked: 2,
-    allowed: 1,
-    monitored: 17,
-  }
-  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
+  $event.ocsf.disposition_id = fortinet::$utm_dispositions[move $event.fortinet.action]? else 0
 }

--- a/fortinet/operators/fortigate/ocsf/logs/endpoint.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/endpoint.tql
@@ -44,9 +44,5 @@ if $event.fortinet.fctuid? != null {
 }
 
 if $event.fortinet.status? != null {
-  let $statuses = {
-    success: 1,
-    failed: 2,
-  }
-  $event.ocsf.status_id = $statuses[move $event.fortinet.status]? else 0
+  $event.ocsf.status_id = fortinet::$statuses[move $event.fortinet.status]? else 0
 }

--- a/fortinet/operators/fortigate/ocsf/logs/ssh.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/ssh.tql
@@ -34,9 +34,5 @@ fortinet::fortigate::ocsf::connection_info event=$event
 fortinet::fortigate::ocsf::security_control event=$event
 
 if $event.fortinet.action? != null {
-  let $dispositions = {
-    blocked: 2,
-    allowed: 1,
-  }
-  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
+  $event.ocsf.disposition_id = fortinet::$utm_dispositions[move $event.fortinet.action]? else 0
 }

--- a/fortinet/operators/fortigate/ocsf/logs/virus.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/virus.tql
@@ -44,12 +44,7 @@ fortinet::fortigate::ocsf::network_evidence event=$event
 fortinet::fortigate::ocsf::security_control event=$event
 
 if $event.fortinet.action? != null {
-  let $dispositions = {
-    blocked: 2,
-    allowed: 1,
-    monitored: 17,
-  }
-  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
+  $event.ocsf.disposition_id = fortinet::$utm_dispositions[move $event.fortinet.action]? else 0
 }
 
 // `crscore`/`crlevel` are the composite UTM risk score and level.

--- a/fortinet/operators/fortigate/ocsf/logs/vpn.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/vpn.tql
@@ -56,11 +56,7 @@ drop $event.fortinet.dir?
 
 // `status`/`result` reflect negotiation outcome.
 if $event.fortinet.status? != null {
-  let $statuses = {
-    success: 1,
-    failed: 2,
-  }
-  $event.ocsf.status_id = $statuses[move $event.fortinet.status]? else 0
+  $event.ocsf.status_id = fortinet::$statuses[move $event.fortinet.status]? else 0
 }
 drop $event.fortinet.result?
 

--- a/fortinet/operators/fortigate/ocsf/logs/webfilter.tql
+++ b/fortinet/operators/fortigate/ocsf/logs/webfilter.tql
@@ -40,12 +40,7 @@ $event.ocsf.traffic = {
 fortinet::fortigate::ocsf::security_control event=$event
 
 if $event.fortinet.action? != null {
-  let $dispositions = {
-    blocked: 2,
-    allowed: 1,
-    monitored: 17,
-  }
-  $event.ocsf.disposition_id = $dispositions[move $event.fortinet.action]? else 0
+  $event.ocsf.disposition_id = fortinet::$utm_dispositions[move $event.fortinet.action]? else 0
 }
 
 // `crscore`/`crlevel` are the composite UTM risk score and level.

--- a/microsoft/constants.tql
+++ b/microsoft/constants.tql
@@ -1,0 +1,28 @@
+// Package-wide constants shared across the Microsoft Graph OCSF event mappers.
+
+// Entra ID Protection `riskLevel` → OCSF `severity_id` / `risk_level_id`.
+let $risk_levels = {none: 1, low: 2, medium: 3, high: 4}
+let $risk_level_ids = {none: 0, low: 1, medium: 2, high: 3}
+
+// Entra ID Protection `riskState` → OCSF `status_id`. Distinct from the Defender
+// alert status vocabulary, which its mapper keeps locally.
+let $statuses = {
+  atRisk: 1,
+  confirmedCompromised: 1,
+  none: 4,
+  confirmedSafe: 3,
+  remediated: 4,
+  dismissed: 3,
+}
+
+// Microsoft Graph security `severity` → OCSF `severity_id`, shared by the
+// Defender alert and incident mappers.
+let $severities = {informational: 1, low: 2, medium: 3, high: 4}
+
+// Microsoft Graph security `classification` → OCSF `verdict_id`.
+let $verdicts = {
+  unknown: 0,
+  falsePositive: 1,
+  truePositive: 2,
+  informationalExpectedActivity: 5,
+}

--- a/microsoft/operators/graph/ocsf/events/defender_alert.tql
+++ b/microsoft/operators/graph/ocsf/events/defender_alert.tql
@@ -20,13 +20,7 @@ $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 $event.ocsf.time = time(move $event.graph.createdDateTime)
 $event.ocsf.end_time = time(move $event.graph.lastUpdateDateTime?)
 
-let $severities = {
-  informational: 1,
-  low: 2,
-  medium: 3,
-  high: 4,
-}
-$event.ocsf.severity_id = $severities[$event.graph.severity]? else 0
+$event.ocsf.severity_id = microsoft::$severities[$event.graph.severity]? else 0
 drop $event.graph.severity?
 
 let $statuses = {
@@ -39,13 +33,7 @@ if $event.ocsf.status_id != null {
   drop $event.graph.status?
 }
 
-let $verdicts = {
-  unknown: 0,
-  falsePositive: 1,
-  truePositive: 2,
-  informationalExpectedActivity: 5,
-}
-$event.ocsf.verdict_id = $verdicts[$event.graph.classification?]?
+$event.ocsf.verdict_id = microsoft::$verdicts[$event.graph.classification?]?
 if $event.ocsf.verdict_id != null {
   drop $event.graph.classification?
 }

--- a/microsoft/operators/graph/ocsf/events/defender_incident.tql
+++ b/microsoft/operators/graph/ocsf/events/defender_incident.tql
@@ -50,13 +50,7 @@ match $event.ocsf.status_id {
 }
 $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-let $severities = {
-  informational: 1,
-  low: 2,
-  medium: 3,
-  high: 4,
-}
-$event.ocsf.severity_id = $severities[$event.graph.severity]? else 0
+$event.ocsf.severity_id = microsoft::$severities[$event.graph.severity]? else 0
 drop $event.graph.severity?
 
 if $event.graph.priorityScore? != null {
@@ -127,13 +121,7 @@ if $event.graph.assignedTo? != null {
   }
 }
 
-let $verdicts = {
-  unknown: 0,
-  falsePositive: 1,
-  truePositive: 2,
-  informationalExpectedActivity: 5,
-}
-$event.ocsf.verdict_id = $verdicts[$event.graph.classification?]?
+$event.ocsf.verdict_id = microsoft::$verdicts[$event.graph.classification?]?
 if $event.ocsf.verdict_id != null {
   drop $event.graph.classification?
 }

--- a/microsoft/operators/graph/ocsf/events/risk_detection.tql
+++ b/microsoft/operators/graph/ocsf/events/risk_detection.tql
@@ -20,33 +20,13 @@ $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 $event.ocsf.time = time(move $event.graph.detectedDateTime)
 $event.ocsf.end_time = time(move $event.graph.lastUpdatedDateTime?)
 
-let $risk_levels = {
-  none: 1,
-  low: 2,
-  medium: 3,
-  high: 4,
-}
-let $risk_level_ids = {
-  none: 0,
-  low: 1,
-  medium: 2,
-  high: 3,
-}
-$event.ocsf.severity_id = $risk_levels[$event.graph.riskLevel]? else 0
-$event.ocsf.risk_level_id = $risk_level_ids[$event.graph.riskLevel]?
+$event.ocsf.severity_id = microsoft::$risk_levels[$event.graph.riskLevel]? else 0
+$event.ocsf.risk_level_id = microsoft::$risk_level_ids[$event.graph.riskLevel]?
 if $event.ocsf.risk_level_id != null {
   drop $event.graph.riskLevel?
 }
 
-let $statuses = {
-  atRisk: 1,
-  confirmedCompromised: 1,
-  none: 4,
-  confirmedSafe: 3,
-  remediated: 4,
-  dismissed: 3,
-}
-$event.ocsf.status_id = $statuses[$event.graph.riskState]?
+$event.ocsf.status_id = microsoft::$statuses[$event.graph.riskState]?
 if $event.ocsf.status_id != null {
   drop $event.graph.riskState?
 }

--- a/microsoft/operators/graph/ocsf/events/risky_user.tql
+++ b/microsoft/operators/graph/ocsf/events/risky_user.tql
@@ -19,33 +19,13 @@ $event.ocsf.activity_id = 1  // Create
 $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 $event.ocsf.time = time(move $event.graph.riskLastUpdatedDateTime)
 
-let $risk_levels = {
-  none: 1,
-  low: 2,
-  medium: 3,
-  high: 4,
-}
-let $risk_level_ids = {
-  none: 0,
-  low: 1,
-  medium: 2,
-  high: 3,
-}
-$event.ocsf.severity_id = $risk_levels[$event.graph.riskLevel]? else 0
-$event.ocsf.risk_level_id = $risk_level_ids[$event.graph.riskLevel]?
+$event.ocsf.severity_id = microsoft::$risk_levels[$event.graph.riskLevel]? else 0
+$event.ocsf.risk_level_id = microsoft::$risk_level_ids[$event.graph.riskLevel]?
 if $event.ocsf.risk_level_id != null {
   drop $event.graph.riskLevel?
 }
 
-let $statuses = {
-  atRisk: 1,
-  confirmedCompromised: 1,
-  none: 4,
-  confirmedSafe: 3,
-  remediated: 4,
-  dismissed: 3,
-}
-$event.ocsf.status_id = $statuses[$event.graph.riskState]?
+$event.ocsf.status_id = microsoft::$statuses[$event.graph.riskState]?
 if $event.ocsf.status_id != null {
   drop $event.graph.riskState?
 }

--- a/okta/constants.tql
+++ b/okta/constants.tql
@@ -1,0 +1,6 @@
+// Package-wide constants shared across the Okta OCSF event mappers.
+
+// OCSF `status_id` for the Okta `outcome.result` values that only ever signal
+// success or failure. Mappers that also see ALLOW/DENY/CHALLENGE keep their own
+// extended map.
+let $status_map = {SUCCESS: 1, FAILURE: 2}

--- a/okta/operators/ocsf/event/account_change.tql
+++ b/okta/operators/ocsf/event/account_change.tql
@@ -43,11 +43,7 @@ $event.ocsf.category_uid = 3
 $event.ocsf.class_uid = 3001
 $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-let $status_map = {
-  SUCCESS: 1,
-  FAILURE: 2,
-}
-$event.ocsf.status_id = $status_map[$event.okta.outcome.result?]? else 0
+$event.ocsf.status_id = okta::$status_map[$event.okta.outcome.result?]? else 0
 $event.ocsf.status_detail = move $event.okta.outcome.reason?
 drop $event.okta.outcome?
 

--- a/okta/operators/ocsf/event/api_activity.tql
+++ b/okta/operators/ocsf/event/api_activity.tql
@@ -34,11 +34,7 @@ $event.ocsf.category_uid = 6
 $event.ocsf.class_uid = 6003
 $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-let $status_map = {
-  SUCCESS: 1,
-  FAILURE: 2,
-}
-$event.ocsf.status_id = $status_map[$event.okta.outcome.result?]? else 0
+$event.ocsf.status_id = okta::$status_map[$event.okta.outcome.result?]? else 0
 $event.ocsf.status_detail = move $event.okta.outcome.reason?
 drop $event.okta.outcome?
 

--- a/okta/operators/ocsf/event/entity_management.tql
+++ b/okta/operators/ocsf/event/entity_management.tql
@@ -65,11 +65,7 @@ $event.ocsf.category_uid = 3
 $event.ocsf.class_uid = 3004
 $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-let $status_map = {
-  SUCCESS: 1,
-  FAILURE: 2,
-}
-$event.ocsf.status_id = $status_map[$event.okta.outcome.result?]? else 0
+$event.ocsf.status_id = okta::$status_map[$event.okta.outcome.result?]? else 0
 $event.ocsf.status_detail = move $event.okta.outcome.reason?
 drop $event.okta.outcome?
 

--- a/okta/operators/ocsf/event/group_management.tql
+++ b/okta/operators/ocsf/event/group_management.tql
@@ -25,11 +25,7 @@ $event.ocsf.category_uid = 3
 $event.ocsf.class_uid = 3006
 $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-let $status_map = {
-  SUCCESS: 1,
-  FAILURE: 2,
-}
-$event.ocsf.status_id = $status_map[$event.okta.outcome.result?]? else 0
+$event.ocsf.status_id = okta::$status_map[$event.okta.outcome.result?]? else 0
 $event.ocsf.status_detail = move $event.okta.outcome.reason?
 drop $event.okta.outcome?
 

--- a/sophos/constants.tql
+++ b/sophos/constants.tql
@@ -1,0 +1,4 @@
+// Package-wide constants shared across the Sophos OCSF event mappers.
+
+// OCSF `status_id` for the Sophos alert `status` field.
+let $statuses = {open: 1, inProgress: 2, suppressed: 3, resolved: 4, closed: 4}

--- a/sophos/operators/ocsf/events/alert.tql
+++ b/sophos/operators/ocsf/events/alert.tql
@@ -26,14 +26,7 @@ if $event.sophos.raisedAt? != null {
   $event.ocsf.time = time(move $event.sophos.created_at)
 }
 
-let $statuses = {
-  open: 1,
-  inProgress: 2,
-  suppressed: 3,
-  resolved: 4,
-  closed: 4,
-}
-$event.ocsf.status_id = $statuses[move $event.sophos.status?]? else 1
+$event.ocsf.status_id = sophos::$statuses[move $event.sophos.status?]? else 1
 
 $event.ocsf.finding_info = {
   uid: $event.ocsf.metadata.original_event_uid,

--- a/sophos/operators/ocsf/events/common_alert.tql
+++ b/sophos/operators/ocsf/events/common_alert.tql
@@ -24,14 +24,7 @@ if $event.sophos.raisedAt? != null {
   $event.ocsf.time = time(move $event.sophos.updatedAt)
 }
 
-let $statuses = {
-  open: 1,
-  inProgress: 2,
-  suppressed: 3,
-  resolved: 4,
-  closed: 4,
-}
-$event.ocsf.status_id = $statuses[move $event.sophos.status?]? else 1
+$event.ocsf.status_id = sophos::$statuses[move $event.sophos.status?]? else 1
 
 $event.ocsf.finding_info = {
   uid: $event.ocsf.metadata.original_event_uid,

--- a/sysmon/constants.tql
+++ b/sysmon/constants.tql
@@ -1,0 +1,8 @@
+// Package-wide constants shared across the Sysmon OCSF event mappers.
+
+// OCSF `fingerprint.algorithm_id` values for the hash algorithms Sysmon reports
+// in its comma-separated `Hashes` field (e.g. "SHA1=...,MD5=...").
+let $algorithms = {MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4}
+
+// OCSF `digital_signature.state_id` values for Sysmon `SignatureStatus`.
+let $sig_states = {Valid: 1, Expired: 2, Revoked: 3, Untrusted: 6}

--- a/sysmon/operators/ocsf/events/driver_load.tql
+++ b/sysmon/operators/ocsf/events/driver_load.tql
@@ -14,9 +14,6 @@ $event.ocsf.class_uid = 1002
 $event.ocsf.activity_id = 1  // Load
 $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-let $algorithms = { MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4 }
-let $sig_states  = { Valid: 1, Expired: 2, Revoked: 3, Untrusted: 6 }
-
 // Sysmon reports driver loads from the kernel (PID 4 / System), so there is no
 // meaningful user-space actor. The required actor object is left empty.
 $event.ocsf.actor = {}
@@ -33,7 +30,7 @@ $event.ocsf.driver = {
                .split(",")
                .map(h => h.split("=", max=1))
                .map(kv => {
-                 algorithm_id: $algorithms[kv[0]?]? else 99,
+                 algorithm_id: sysmon::$algorithms[kv[0]?]? else 99,
                  value: kv[1]?,
                })),
   },
@@ -44,7 +41,7 @@ $event.ocsf.driver.file.name = $event.ocsf.driver.file.path.split("\\")[-1]
 if $event.sysmon.EventData.Signed {
   $event.ocsf.driver.file.signature = {
     algorithm_id: 0,  // Unknown — Sysmon does not report the algorithm
-    state_id: $sig_states[$event.sysmon.EventData.SignatureStatus]?,
+    state_id: sysmon::$sig_states[$event.sysmon.EventData.SignatureStatus]?,
   }
   if $event.sysmon.EventData.Signature != null {
     $event.ocsf.driver.file.signature.certificate = {

--- a/sysmon/operators/ocsf/events/file_block.tql
+++ b/sysmon/operators/ocsf/events/file_block.tql
@@ -22,9 +22,6 @@ $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 // Both events are blocking events — the operation was prevented.
 $event.ocsf.status_id = 2  // Failure
 
-let $algorithms = { MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4 }
-
-
 // IsExecutable is present on EID 28; absent on EID 27 (implicitly true).
 // If explicitly false, downgrade type_id to Regular File.
 $event.ocsf.file = {
@@ -38,7 +35,7 @@ $event.ocsf.file.hashes = ((move $event.sysmon.EventData.Hashes)
   .split(",")
   .map(h => h.split("=", max=1))
   .map(kv => {
-    algorithm_id: $algorithms[kv[0]?]? else 99,
+    algorithm_id: sysmon::$algorithms[kv[0]?]? else 99,
     value: kv[1]?,
   }))
 

--- a/sysmon/operators/ocsf/events/file_create_stream_hash.tql
+++ b/sysmon/operators/ocsf/events/file_create_stream_hash.tql
@@ -14,8 +14,6 @@ $event.ocsf.class_uid = 1001
 $event.ocsf.activity_id = 1  // Create
 $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-let $algorithms = { MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4 }
-
 // TargetFilename format: "C:\path\file.exe:Zone.Identifier"
 // Split on all colons, then rejoin all-but-last to reconstruct the full file path
 // (which itself contains a colon after the drive letter).
@@ -38,7 +36,7 @@ $event.ocsf.file.hashes = ((move $event.sysmon.EventData.Hash)
   .split(",")
   .map(h => h.split("=", max=1))
   .map(kv => {
-    algorithm_id: $algorithms[kv[0]?]? else 99,
+    algorithm_id: sysmon::$algorithms[kv[0]?]? else 99,
     value: kv[1]?,
   }))
 

--- a/sysmon/operators/ocsf/events/file_delete.tql
+++ b/sysmon/operators/ocsf/events/file_delete.tql
@@ -18,9 +18,6 @@ $event.ocsf.class_uid = 1001
 $event.ocsf.activity_id = 4  // Delete
 $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-let $algorithms = { MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4 }
-
-
 $event.ocsf.file = {
   path: move $event.sysmon.EventData.TargetFilename,
   type_id: 8 if (move $event.sysmon.EventData.IsExecutable) else 1,
@@ -32,7 +29,7 @@ $event.ocsf.file.hashes = ((move $event.sysmon.EventData.Hashes)
   .split(",")
   .map(h => h.split("=", max=1))
   .map(kv => {
-    algorithm_id: $algorithms[kv[0]?]? else 99,
+    algorithm_id: sysmon::$algorithms[kv[0]?]? else 99,
     value: kv[1]?,
   }))
 

--- a/sysmon/operators/ocsf/events/file_executable_detected.tql
+++ b/sysmon/operators/ocsf/events/file_executable_detected.tql
@@ -17,9 +17,6 @@ $event.ocsf.class_uid = 1001
 $event.ocsf.activity_id = 1  // Create
 $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-let $algorithms = { MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4 }
-
-
 $event.ocsf.file = {
   path: move $event.sysmon.EventData.TargetFilename,
   type_id: 8,  // Executable File — EID 29 is PE-specific by definition
@@ -30,7 +27,7 @@ $event.ocsf.file.hashes = ((move $event.sysmon.EventData.Hashes)
   .split(",")
   .map(h => h.split("=", max=1))
   .map(kv => {
-    algorithm_id: $algorithms[kv[0]?]? else 99,
+    algorithm_id: sysmon::$algorithms[kv[0]?]? else 99,
     value: kv[1]?,
   }))
 

--- a/sysmon/operators/ocsf/events/image_load.tql
+++ b/sysmon/operators/ocsf/events/image_load.tql
@@ -14,9 +14,6 @@ $event.ocsf.class_uid = 1005
 $event.ocsf.activity_id = 1  // Load
 $event.ocsf.type_uid = $event.ocsf.class_uid * 100 + $event.ocsf.activity_id
 
-let $algorithms = { MD5: 1, SHA1: 2, SHA256: 3, SHA512: 4 }
-let $sig_states  = { Valid: 1, Expired: 2, Revoked: 3, Untrusted: 6 }
-
 // Replace "-" sentinels so optional file-metadata fields can be moved unconditionally.
 replace $event.sysmon.EventData.FileVersion, what="-", with=null
 replace $event.sysmon.EventData.Description, what="-", with=null
@@ -38,7 +35,7 @@ $event.ocsf.module = {
                .split(",")
                .map(h => h.split("=", max=1))
                .map(kv => {
-                 algorithm_id: $algorithms[kv[0]?]? else 99,
+                 algorithm_id: sysmon::$algorithms[kv[0]?]? else 99,
                  value: kv[1]?,
                })),
   },
@@ -55,7 +52,7 @@ drop $event.sysmon.EventData.Product
 if $event.sysmon.EventData.Signed {
   $event.ocsf.module.file.signature = {
     algorithm_id: 0,  // Unknown — Sysmon does not report the algorithm
-    state_id: $sig_states[$event.sysmon.EventData.SignatureStatus]?,
+    state_id: sysmon::$sig_states[$event.sysmon.EventData.SignatureStatus]?,
   }
   if $event.sysmon.EventData.Signature != null {
     $event.ocsf.module.file.signature.certificate = {

--- a/sysmon/operators/ocsf/events/process_create.tql
+++ b/sysmon/operators/ocsf/events/process_create.tql
@@ -72,19 +72,12 @@ $event.ocsf.process.file.path = $event.ocsf.process.path
 $event.ocsf.process.parent_process.file.name = $event.ocsf.process.parent_process.path.split("\\")[-1]
 $event.ocsf.process.parent_process.file.path = $event.ocsf.process.parent_process.path
 
-let $algorithms = {
-  MD5: 1,
-  SHA1: 2,
-  SHA256: 3,
-  SHA512: 4,
-}
-
 // Parse "SHA1=abc,MD5=def,..." into fingerprint objects.
 $event.ocsf.process.file.hashes = ((move $event.sysmon.EventData.Hashes)
   .split(",")
   .map(h => h.split("=", max=1))
   .map(kv => {
-    algorithm_id: $algorithms[kv[0]?]? else 99,
+    algorithm_id: sysmon::$algorithms[kv[0]?]? else 99,
     value: kv[1]?,
   }))
 


### PR DESCRIPTION
## 🔍 Problem

OCSF mappers across several library packages copy-paste the same constant
lookup tables (hash-algorithm IDs, severity/status/verdict enums, FortiGate
dispositions). The copies drift: FortiGate CIFS/SSH omit the `monitored`
disposition their sibling mappers have, so a `monitored` action silently maps
to `0` (Unknown) instead of `17`.

## 🛠️ Solution

Hoist the genuinely duplicated constant maps into a per-package `constants.tql`
and reference them as `pkg::$name` (the new package `let` bindings).

- `constants.tql` added to sysmon, microsoft, okta, fortinet, and sophos.
- Mappers using a differently-shaped map of the same name keep their local `let`.
- Routing FortiGate CIFS/SSH through the shared `fortinet::$utm_dispositions`
  also fixes the missing `monitored` mapping (separate commit + changelog).

## 💬 Review

- No behavior change apart from the FortiGate CIFS/SSH `monitored` fix.
- `tenzir-test` against a local build: sysmon 30/30, fortinet 1/1, okta 7/7,
  sophos 7/7, microsoft 74/75 — the one failure is a pre-existing, unrelated
  ASIM test (reproduces on a clean tree).
- Depends on the engine PR shipping `constants.tql`; library CI runs against
  released Tenzir via `uvx`, so it stays red until that release.

<sub>
📚 Docs PR: tenzir/docs#413<br>
📎 Related: tenzir/tenzir#6363
</sub>
