### PR TITLE
Update documentation links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Tenzir Library
 
 This repository hosts the Tenzir Library, a collection of
-[packages](https://docs.tenzir.com/explanations/packages.md) that
+[packages](https://tenzir.com/docs/explanations/packages.md) that
 contain user-defined operators, pipelines, examples, and context definitions.
 
 Every top-level directory that does not start with `.` is a package.
@@ -12,7 +12,7 @@ Integration packages typically have the name of the primary vendor, like
 ## Workflows
 
 All key workflows are well-supported by agents. See
-<https://docs.tenzir.com/guides/ai-workbench/use-agent-skills.md> for a list
+<https://tenzir.com/docs/guides/ai-workbench/use-agent-skills.md> for a list
 of relevant agent skills during package development.
 
 Always load the `tenzir-docs` skill when working with TQL content.
@@ -34,7 +34,7 @@ Use the `tenzir-manage-packages` skill to manage the lifecycle of a package.
 
 ### Test packages
 
-Use [tenzir-test](https://docs.tenzir.com/reference/test-framework.md) for
+Use [tenzir-test](https://tenzir.com/docs/reference/test-framework.md) for
 testing packages.
 
 Primary operations:

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # 📚 Tenzir Library
 
 This repository hosts the official collection of content
-[packages](https://docs.tenzir.com/explanations/packages/) for Tenzir.
+[packages](https://tenzir.com/docs/explanations/packages/) for Tenzir.
 
 ## 🚀 Install packages
 
 Pick the workflow that fits your environment. For details, see our [installation
-guide](https://docs.tenzir.com/guides/package-management/install-a-package/):
+guide](https://tenzir.com/docs/guides/package-management/install-a-package/):
 
 1. **Web UI**: browse to
    [app.tenzir.com/library](https://app.tenzir.com/library) and click _Install_.
 2. **Interactive**: run
-   [`package::add`](https://docs.tenzir.com/reference/operators/package/add)
+   [`package::add`](https://tenzir.com/docs/reference/operators/package/add)
    against a local directory, and remove it later with
-   [`package::remove`](https://docs.tenzir.com/reference/operators/package/remove).
+   [`package::remove`](https://tenzir.com/docs/reference/operators/package/remove).
 3. **As code**: place packages under `packages/` inside your
    configuration directory (or another path listed in `tenzir.package-dirs`) and
    include an optional `config.yaml` for inputs.
@@ -25,7 +25,7 @@ A package lives in a directory with these building blocks:
 - `operators/`: user-defined operators (UDOs) you can reuse across pipelines.
 - `examples/`: runnable TQL snippets that demonstrate package UDOs.
 - `tests/`: deterministic [integration
-  tests](https://docs.tenzir.com/reference/test-framework) that verify UDOs.
+  tests](https://tenzir.com/docs/reference/test-framework) that verify UDOs.
 - `package.yaml`: the package manifest with metadata and optional
   enrichment contexts.
 
@@ -34,10 +34,10 @@ A package lives in a directory with these building blocks:
 Join us on our mission to democratize the world of security data integrations.
 
 Follow the [write-a-package
-tutorial](https://docs.tenzir.com/tutorials/write-a-package/) to scaffold, test,
+tutorial](https://tenzir.com/docs/tutorials/write-a-package/) to scaffold, test,
 and document a new idea, then:
 
-- Share it on the [Community Discord](https://docs.tenzir.com/discord) to gather
+- Share it on the [Community Discord](https://discord.tenzir.com) to gather
   feedback.
 - Open a pull request in
   [github.com/tenzir/library](https://github.com/tenzir/library) so the package


### PR DESCRIPTION
## 🔍 Problem

- Root documentation still points at the legacy `docs.tenzir.com` host.
- The Community Discord link should use the direct Discord subdomain.

## 🛠️ Solution

- Point Tenzir documentation links at `tenzir.com/docs`.
- Point the Community Discord link at `discord.tenzir.com`.

## 💬 Review

- Verify the replacements are link-only changes and preserve the existing docs paths.