### PR TITLE
Update ASIM warning baseline

### DIFF
--- a/microsoft/tests/asim/ocsf/map.txt
+++ b/microsoft/tests/asim/ocsf/map.txt
@@ -1,1 +1,11 @@
 warning: assertion failed: {reason:"unsupported OCSF to ASIM mapping",class_uid:1009,class_name:"Script Activity",type_uid:100901,type_name:"Script Activity: Execute",name:"ocsf.script_activity"}
+  --> operators/asim/ocsf/map.tql:61:12
+   |
+61 |     assert false, message={
+   |            ~~~~~ 
+   |
+  --> tests/asim/ocsf/map.tql:24:1
+   |
+24 | microsoft::asim::ocsf::map
+   | ~~~~~~~~~~~~~~~~~~~~~~~~~~ called from here
+   |


### PR DESCRIPTION
Regenerate the Microsoft ASIM OCSF warning fixture with tenzir-test so it matches the diagnostic locations emitted by the released Tenzir CLI.

Assisted-by: GPT-5 (Codex)