### PR TITLE
Update ASIM warning baseline

### DIFF
--- a/microsoft/tests/asim/ocsf/map.txt
+++ b/microsoft/tests/asim/ocsf/map.txt
@@ -1,1 +1,11 @@
 warning: assertion failed: {reason:"unsupported OCSF to ASIM mapping",class_uid:1009,class_name:"Script Activity",type_uid:100901,type_name:"Script Activity: Execute",name:"ocsf.script_activity"}
+  --> microsoft/operators/asim/ocsf/map.tql:61:12
+   |
+61 |     assert false, message={
+   |            ~~~~~ 
+   |
+  --> microsoft/tests/asim/ocsf/map.tql:24:1
+   |
+24 | microsoft::asim::ocsf::map
+   | ~~~~~~~~~~~~~~~~~~~~~~~~~~ called from here
+   |


### PR DESCRIPTION
## 🔍 Problem

- The package tests on `main` fail because released Tenzir now emits diagnostic source locations for the existing unsupported OCSF-to-ASIM mapping warning.
- The warning itself is not new; only the rendered diagnostic context changed.

## 🛠️ Solution

- Regenerate the ASIM OCSF warning baseline using the same root-project invocation shape as CI.

## 💬 Review

- Verify that the expected diagnostic paths are repository-relative.
- Local check: `uvx tenzir-test .`
