### PR TITLE
Fix ASIM warning baseline paths

### DIFF
--- a/.github/workflows/tenzir-test.yml
+++ b/.github/workflows/tenzir-test.yml
@@ -59,4 +59,15 @@ jobs:
         env:
           TENZIR_BINARY: ${{ matrix.tenzir.binary }}
           TENZIR_NODE_BINARY: ${{ matrix.tenzir.node_binary }}
-        run: uvx tenzir-test ${{ steps.touched.outputs.packages }}
+        shell: bash
+        run: |
+          packages="${{ steps.touched.outputs.packages }}"
+          if [[ "$packages" == "." ]]; then
+            uvx tenzir-test .
+          else
+            args=()
+            for package in $packages; do
+              args+=(--match "$package/*")
+            done
+            uvx tenzir-test . "${args[@]}"
+          fi

--- a/microsoft/tests/asim/ocsf/map.txt
+++ b/microsoft/tests/asim/ocsf/map.txt
@@ -1,10 +1,10 @@
 warning: assertion failed: {reason:"unsupported OCSF to ASIM mapping",class_uid:1009,class_name:"Script Activity",type_uid:100901,type_name:"Script Activity: Execute",name:"ocsf.script_activity"}
-  --> operators/asim/ocsf/map.tql:61:12
+  --> microsoft/operators/asim/ocsf/map.tql:61:12
    |
 61 |     assert false, message={
    |            ~~~~~ 
    |
-  --> tests/asim/ocsf/map.tql:24:1
+  --> microsoft/tests/asim/ocsf/map.tql:24:1
    |
 24 | microsoft::asim::ocsf::map
    | ~~~~~~~~~~~~~~~~~~~~~~~~~~ called from here


### PR DESCRIPTION
## 🔍 Problem

- The ASIM warning baseline merged in #166 was generated from the Microsoft package root.
- The post-merge `main` build runs `uvx tenzir-test .` from the repository root, so diagnostics include `microsoft/` path prefixes.
- Pull-request CI selected touched packages directly, which rooted `tenzir-test` at the package and produced different diagnostic paths.

## 🛠️ Solution

- Regenerate the affected baseline from the repository root.
- Keep pull-request package selection rooted at `.` and pass touched packages as `--match <package>/*` selectors.

## 💬 Review

- Baseline change is only the two diagnostic path prefixes.
- Workflow change keeps PR and post-merge test invocations on the same root-path convention.
- Local checks: `uvx tenzir-test . --match 'microsoft/*'` and `uvx tenzir-test .`
