### PR TITLE
Restore ASIM warning baseline paths

### DIFF
--- a/microsoft/tests/asim/ocsf/map.txt
+++ b/microsoft/tests/asim/ocsf/map.txt
@@ -1,10 +1,10 @@
 warning: assertion failed: {reason:"unsupported OCSF to ASIM mapping",class_uid:1009,class_name:"Script Activity",type_uid:100901,type_name:"Script Activity: Execute",name:"ocsf.script_activity"}
-  --> operators/asim/ocsf/map.tql:61:12
+  --> microsoft/operators/asim/ocsf/map.tql:61:12
    |
 61 |     assert false, message={
    |            ~~~~~
    |
-  --> tests/asim/ocsf/map.tql:24:1
+  --> microsoft/tests/asim/ocsf/map.tql:24:1
    |
 24 | microsoft::asim::ocsf::map
    | ~~~~~~~~~~~~~~~~~~~~~~~~~~ called from here


### PR DESCRIPTION
## 🔍 Problem

- The ASIM assertion baseline was regenerated from the Microsoft package root in #170.
- CI runs the library suite from the repository root, so the diagnostic paths retain the `microsoft/` prefix and fail comparison.

## 🛠️ Solution

Restore the repository-root path prefixes in the assertion baseline while preserving the updated diagnostic formatting.

## 💬 Review

The baseline-only change matches the CI invocation fixed in #168. Both release and prerelease suites pass locally (231 passed, 1 skipped).

<sub>
📎 Related: tenzir/library#168, tenzir/library#170
</sub>
